### PR TITLE
GridSearch Properties and Protection

### DIFF
--- a/fairlearn/__init__.py
+++ b/fairlearn/__init__.py
@@ -2,3 +2,5 @@ __name__ = "fairlearn"
 __version__ = "0.3.0-alpha"
 
 _KW_SENSITIVE_FEATURES = "sensitive_features"
+
+_NO_PREDICT_BEFORE_FIT = "Must call fit before attempting to make predictions"

--- a/fairlearn/reductions/grid_search/grid_search.py
+++ b/fairlearn/reductions/grid_search/grid_search.py
@@ -120,6 +120,25 @@ class GridSearch(Reduction):
         self.grid_limit = float(grid_limit)
         self.grid = grid
 
+        self._all_results = []
+        self._best_result = None
+
+    @property
+    def all_results(self):
+        """A list of :class:`GridSearchResult` from each
+        point in the grid
+        """
+        return self._all_results
+
+    @property
+    def best_result(self):
+        """The best result found from the grid search.
+        The predictor contained in this instance of
+        :class:`GridSearchResult` is used in calls to
+        ``predict`` and ``predict_proba``.
+        """
+        return self._best_result
+
     def fit(self, X, y, **kwargs):
         """Runs the grid search. This will result in multiple copies of the
         estimator being made, and the `fit` method of each one called.
@@ -191,7 +210,7 @@ class GridSearch(Reduction):
             grid = self.grid
 
         # Fit the estimates
-        self.all_results = []
+        self._all_results = []
         for i in grid.columns:
             lambda_vec = grid[i]
             weights = self.constraints.signed_weights(lambda_vec)
@@ -211,12 +230,12 @@ class GridSearch(Reduction):
                                    lambda_vec,
                                    objective.gamma(predict_fct)[0],
                                    self.constraints.gamma(predict_fct))
-            self.all_results.append(nxt)
+            self._all_results.append(nxt)
 
         if self.selection_rule == TRADEOFF_OPTIMIZATION:
             def loss_fct(x):
                 return self.objective_weight * x.objective + self.constraint_weight * x.gamma.max()
-            self.best_result = min(self.all_results, key=loss_fct)
+            self._best_result = min(self._all_results, key=loss_fct)
         else:
             raise RuntimeError("Unsupported selection rule")
 

--- a/fairlearn/reductions/grid_search/grid_search.py
+++ b/fairlearn/reductions/grid_search/grid_search.py
@@ -258,14 +258,16 @@ class GridSearch(Reduction):
         return self.best_result.predictor.predict(X)
 
     def predict_proba(self, X):
-        """Provides the result of predict_proba from the
+        """Provides the result of ``predict_proba`` from the
         best model found by the grid search. The underlying
-        estimator must support predict_proba for this
+        estimator must support ``predict_proba`` for this
         to work.
 
         :param X: The data for which predictions are required
         :type X: Array
         """
+        if self.best_result is None:
+            raise NotFittedException(_NO_PREDICT_BEFORE_FIT)
         return self.best_result.predictor.predict_proba(X)
 
     def _make_vector(self, formless, formless_name):

--- a/fairlearn/reductions/grid_search/grid_search.py
+++ b/fairlearn/reductions/grid_search/grid_search.py
@@ -5,10 +5,11 @@ import copy
 import numpy as np
 import pandas as pd
 
+from fairlearn.exceptions import NotFittedException
 from fairlearn.reductions import Reduction
 from fairlearn.reductions.grid_search import GridSearchResult
 from fairlearn.reductions.moments.moment import Moment, ClassificationMoment
-from fairlearn import _KW_SENSITIVE_FEATURES
+from fairlearn import _KW_SENSITIVE_FEATURES, _NO_PREDICT_BEFORE_FIT
 
 TRADEOFF_OPTIMIZATION = "tradeoff_optimization"
 
@@ -252,6 +253,8 @@ class GridSearch(Reduction):
             the result will be a scalar. Otherwise the result will be an
         :rtype: Scalar or array
         """
+        if self.best_result is None:
+            raise NotFittedException(_NO_PREDICT_BEFORE_FIT)
         return self.best_result.predictor.predict(X)
 
     def predict_proba(self, X):

--- a/fairlearn/reductions/grid_search/grid_search_result.py
+++ b/fairlearn/reductions/grid_search/grid_search_result.py
@@ -39,4 +39,3 @@ class GridSearchResult:
         """Description goes here
         """
         return self._gamma
-

--- a/fairlearn/reductions/grid_search/grid_search_result.py
+++ b/fairlearn/reductions/grid_search/grid_search_result.py
@@ -3,8 +3,40 @@
 
 
 class GridSearchResult:
+    """Class to hold a single result from the :class:`GridSearch` class.
+    """
+
     def __init__(self, predictor, lambda_vec, objective, gamma):
-        self.predictor = predictor
-        self.lambda_vec = lambda_vec
-        self.objective = objective
-        self.gamma = gamma
+        self._predictor = predictor
+        self._lambda_vec = lambda_vec
+        self._objective = objective
+        self._gamma = gamma
+
+    @property
+    def predictor(self):
+        """The predictor trained for this particular result
+        from :class:`GridSearch`
+        """
+        return self._predictor
+
+    @property
+    def lambda_vec(self):
+        """The Lagrange multiplier corresponding to this
+        result. The exact contents of this are defined
+        by the `constraints` argument passed to
+        :class:`GridSearch`
+        """
+        return self._lambda_vec
+
+    @property
+    def objective(self):
+        """Description goes here
+        """
+        return self._objective
+
+    @property
+    def gamma(self):
+        """Description goes here
+        """
+        return self._gamma
+

--- a/test/unit/reductions/grid_search/test_grid_search_arguments.py
+++ b/test/unit/reductions/grid_search/test_grid_search_arguments.py
@@ -239,6 +239,16 @@ class ArgumentTests:
 
         assert message == execInfo.value.args[0]
 
+    def test_no_predict_proba_before_fit(self):
+        gs = GridSearch(self.estimator, self.disparity_criterion)
+        X, _, _ = self._quick_data()
+
+        message = str("Must call fit before attempting to make predictions")
+        with pytest.raises(NotFittedException) as execInfo:
+            gs.predict_proba(X)
+
+        assert message == execInfo.value.args[0]
+
 
 # Tests specific to Classification
 class ConditionalOpportunityTests(ArgumentTests):

--- a/test/unit/reductions/grid_search/test_grid_search_arguments.py
+++ b/test/unit/reductions/grid_search/test_grid_search_arguments.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 from sklearn.linear_model import LogisticRegression, LinearRegression
 
+from fairlearn.exceptions import NotFittedException
 from fairlearn.reductions import GridSearch
 import fairlearn.reductions.moments as moments
 
@@ -225,6 +226,16 @@ class ArgumentTests:
             gs.fit(transformX(X),
                    transformY(Y),
                    sensitive_features=A_two_col_ndarray)
+
+        assert message == execInfo.value.args[0]
+
+    def test_no_predict_before_fit(self):
+        gs = GridSearch(self.estimator, self.disparity_criterion)
+        X, _, _ = self._quick_data()
+
+        message = str("Must call fit before attempting to make predictions")
+        with pytest.raises(NotFittedException) as execInfo:
+            gs.predict(X)
 
         assert message == execInfo.value.args[0]
 


### PR DESCRIPTION
Minor improvements for `GridSearch`:
- `GridSearchResult` now uses properties for everything
- `GridSearch` now uses properties for `all_results` and `best_result`, allowing them to be documented
- Add a check on the `predict` and `predict_proba` methods of `GridSearch` to make sure that `fit` has been called previously