### PR TITLE
Restrict code coverage build to unit tests

### DIFF
--- a/devops/code-coverage-job-template.yml
+++ b/devops/code-coverage-job-template.yml
@@ -18,7 +18,7 @@ jobs:
   - script: pip install -r requirements.txt
     displayName: 'Install required packages'
 
-  - script: python -m pytest test/ --junitxml=./TEST-TEST.xml --cov=fairlearn --cov-report=xml --cov-report=html -o unit_suite_name="${{ parameters.name }}"
+  - script: python -m pytest test/unit --junitxml=./TEST-TEST.xml --cov=fairlearn --cov-report=xml --cov-report=html -o unit_suite_name="${{ parameters.name }}"
     displayName: 'Run tests'
 
   # Publish code coverage results


### PR DESCRIPTION
Including the performance tests makes the code coverage build time out