### PR TITLE
Consistency for Requirements

### DIFF
--- a/devops/all-tests-job-template.yml
+++ b/devops/all-tests-job-template.yml
@@ -25,7 +25,7 @@ jobs:
   - script: pip install -r ${{ parameters.requirementsFile }}
     displayName: 'Install required packages specified in ${{ parameters.requirementsFile }}'
     
-  - script: python $(Build.SourcesDirectory)/scripts/requirementscheck.py $(Build.SourcesDirectory)
+  - script: python ./scripts/requirementscheck.py --fixed requirements-fixed.txt --lowerbound requirements.txt
     displayName: "Run check on requirements files"
 
   - script: flake8 .

--- a/devops/all-tests-job-template.yml
+++ b/devops/all-tests-job-template.yml
@@ -22,6 +22,9 @@ jobs:
       versionSpec: '$(PyVer)' 
       addToPath: true
 
+  - script: python $(Build.SourcesDirectory)/scripts/requirementscheck.py $(Build.SourcesDirectory)
+    displayName: "Run check on requirements files"
+
   - script: pip install -r ${{ parameters.requirementsFile }}
     displayName: 'Install required packages specified in ${{ parameters.requirementsFile }}'
 

--- a/devops/all-tests-job-template.yml
+++ b/devops/all-tests-job-template.yml
@@ -22,11 +22,11 @@ jobs:
       versionSpec: '$(PyVer)' 
       addToPath: true
 
-  - script: python $(Build.SourcesDirectory)/scripts/requirementscheck.py $(Build.SourcesDirectory)
-    displayName: "Run check on requirements files"
-
   - script: pip install -r ${{ parameters.requirementsFile }}
     displayName: 'Install required packages specified in ${{ parameters.requirementsFile }}'
+    
+  - script: python $(Build.SourcesDirectory)/scripts/requirementscheck.py $(Build.SourcesDirectory)
+    displayName: "Run check on requirements files"
 
   - script: flake8 .
     displayName: "Run flake8"

--- a/requirements-fixed.txt
+++ b/requirements-fixed.txt
@@ -8,6 +8,7 @@ scipy==1.3.0
 # Required for environment
 autopep8
 flake8
+requirements
 
 # Required for test
 # Pin pytest due to VS Code issue

--- a/requirements-fixed.txt
+++ b/requirements-fixed.txt
@@ -3,12 +3,12 @@ matplotlib==3.0.3
 numpy==1.17.2
 pandas==0.25.1
 scikit-learn==0.21.3
-scipy==1.3.0
+scipy==1.3.1
 
 # Required for environment
 autopep8
 flake8
-requirements
+requirements-parser
 
 # Required for test
 # Pin pytest due to VS Code issue

--- a/requirements-fixed.txt
+++ b/requirements-fixed.txt
@@ -3,7 +3,7 @@ matplotlib==3.0.3
 numpy==1.17.2
 pandas==0.25.1
 scikit-learn==0.21.3
-scipy==1.3.1
+scipy==1.3.0
 
 # Required for environment
 autopep8

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ scipy>=1.3.1
 # Required for environment
 autopep8
 flake8
+requirements
 
 # Required for test
 # Pin pytest due to VS Code issue

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,12 +3,12 @@ matplotlib>=3.0.3
 numpy>=1.17.2
 pandas>=0.25.1
 scikit-learn>=0.21.3
-scipy>=1.3.1
+scipy>=1.3.0
 
 # Required for environment
 autopep8
 flake8
-requirements
+requirements-parser
 
 # Required for test
 # Pin pytest due to VS Code issue

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ matplotlib>=3.0.3
 numpy>=1.17.2
 pandas>=0.25.1
 scikit-learn>=0.21.3
-scipy>=1.3.0
+scipy>=1.3.1
 
 # Required for environment
 autopep8

--- a/scripts/requirementscheck.py
+++ b/scripts/requirementscheck.py
@@ -54,14 +54,14 @@ for f, d in dependencies.items():
         continue
     print("Examining {0}".format(f))
     if sorted(d.keys()) != sorted(truth_deps.keys()):
-        print(" Dependency list does not match!", file=sys.stderr)
+        print(" Dependency list does not match!")
         found_mismatch = True
     else:
         for dep, ver in truth_deps.items():
             if ver != d[dep]:
-                print("  Mismatched versions for {0}".format(dep), file=sys.stderr)
+                print("  Mismatched versions for {0}".format(dep))
                 found_mismatch = True
-    print("Examination completed")
+    print("Examination of {0} completed".format(f))
     print()
 
 # spec = importlib.util.spec_from_file_location("setup", os.path.join(target_dir, "setup.py"))
@@ -70,7 +70,7 @@ for f, d in dependencies.items():
 # print(module)
 
 if found_mismatch:
-    print("FOUND MISMATCHES", file=sys.stderr)
+    print("##[error]Found mismatches", file=sys.stderr)
     sys.exit(1)
 else:
     sys.exit(0)

--- a/scripts/requirementscheck.py
+++ b/scripts/requirementscheck.py
@@ -1,0 +1,22 @@
+import argparse
+import os
+import re
+import requirements
+
+
+desc = "Checks setup.py and pip requirements files for consistency"
+
+parser = argparse.ArgumentParser(description=desc)
+parser.add_argument('directory')
+
+args = parser.parse_args()
+
+target_dir = os.path.abspath(args.directory)
+
+print("Examining {0}".format(target_dir))
+
+file_pattern = r"requirements.*\.txt"
+
+files = [f for f in os.listdir(target_dir) if re.match(file_pattern, f)]
+
+print(files)

--- a/scripts/requirementscheck.py
+++ b/scripts/requirementscheck.py
@@ -25,6 +25,7 @@ print("Found requirements files: {0}".format(files))
 
 dependencies = {}
 for f in files:
+    print("Parsing file: {0}".format(f))
     target_file = os.path.join(target_dir, f)
     dep_dict = {}
     with open(f, 'r') as fd:
@@ -35,10 +36,12 @@ for f in files:
                 dep_dict[req_name] = req.specs[0][1]
 
     dependencies[f] = dep_dict
+print("All requirements files parsed")
 
 truth_file = list(dependencies.keys())[0]
 print("Taking {0} as ground truth".format(truth_file))
 truth_deps = dependencies[truth_file]
+print()
 
 found_mismatch = False
 for f, d in dependencies.items():
@@ -53,6 +56,8 @@ for f, d in dependencies.items():
             if ver != d[dep]:
                 print("  Mismatched versions for {0}".format(dep), file=sys.stderr)
                 found_mismatch = True
+    print("Examination completed")
+    print()
 
 # spec = importlib.util.spec_from_file_location("setup", os.path.join(target_dir, "setup.py"))
 # module = importlib.util.module_from_spec(spec)
@@ -60,6 +65,7 @@ for f, d in dependencies.items():
 # print(module)
 
 if found_mismatch:
+    print("FOUND MISMATCHES", file=sys.stderr)
     sys.exit(1)
 else:
     sys.exit(0)

--- a/scripts/requirementscheck.py
+++ b/scripts/requirementscheck.py
@@ -1,3 +1,26 @@
+"""Simple script for comparing two requirements files.
+
+Given two requirements files, this script:
+- Checks that they both contain the same list of packages
+- Checks that the package versions match according to the following
+  rules:
+    - If no version is specified for one, it must not be specified
+      for the other
+    - If a version is specified, then the only valid comparators are
+      '==' and '>='
+    - If a version is specified in one file, then the same version
+      must be specified in the other
+The purposes of these comparisons is to ensure that our
+`requirements.txt` and `requirements-fixed.txt` files are kept in
+sync.
+
+If any of the checks fail, then the script will write out information
+about the failures (preprended for highlighting as an error in Azure
+Dev Ops) and return 1 instead of 0.
+
+At present there is no support for parsing `setup.py` and checking
+the packages listed there.
+"""
 # Simple script which finds all files matching requirements*.txt in a given directory
 # and makes sure that they match up to '>=' vs '=='
 

--- a/scripts/requirementscheck.py
+++ b/scripts/requirementscheck.py
@@ -1,4 +1,5 @@
 import argparse
+import importlib.util
 import os
 import re
 import requirements
@@ -19,4 +20,24 @@ file_pattern = r"requirements.*\.txt"
 
 files = [f for f in os.listdir(target_dir) if re.match(file_pattern, f)]
 
-print(files)
+print("Found requirements files: {0}".format(files))
+
+dependencies = {}
+for f in files:
+    target_file = os.path.join(target_dir, f)
+    dep_dict = {}
+    with open(f, 'r') as fd:
+        for req in requirements.parse(fd):
+            req_name = req.name
+            assert len(req.specs) <= 1
+            if len(req.specs) == 1:
+                dep_dict[req_name] = req.specs[0][1]
+
+    dependencies[f] = dep_dict
+
+
+spec = importlib.util.spec_from_file_location("setup", os.path.join(target_dir, "setup.py"))
+module = importlib.util.module_from_spec(spec)
+#spec.loader.exec_module(module)
+
+print(module)

--- a/scripts/requirementscheck.py
+++ b/scripts/requirementscheck.py
@@ -1,3 +1,6 @@
+# Simple script which finds all files matching requirements*.txt in a given directory
+# and makes sure that they match up to '>=' vs '=='
+
 import argparse
 # import importlib.util
 import os

--- a/scripts/requirementscheck.py
+++ b/scripts/requirementscheck.py
@@ -63,18 +63,16 @@ def compare_specs(spec1, spec2):
     have2 = len(spec2.specs) > 0
 
     if have1 != have2:
-        print("{0}Only one spec on {1}",
-              error_prefix,
-              spec1.name)
+        msg = "Only one spec on {0}".format(spec1.name)
+        print_ado_error(msg)
         specs_match = False
     elif not have1:
         # We have two empty lists
         pass
     else:
         if spec1.specs[0][1] != spec2.specs[0][1]:
-            print("{0}Version mismatch on {1}",
-                  error_prefix,
-                  spec1.name)
+            msg = "Version mismatch on {0}".format(spec1.name)
+            print_ado_error(msg)
             specs_match = False
 
     return specs_match
@@ -96,11 +94,13 @@ def compare_requirements(req1, req2):
         return False
     else:
         all_match = True
+        matches = []
         for i in range(len(names1)):
             # No need to check the spec again
             spec1 = req1[i]
             spec2 = req2[i]
-            all_match = all_match and compare_specs(spec1, spec2)
+            matches.append(compare_specs(spec1, spec2))
+        all_match = all_match and any(matches)
 
     return all_match
 

--- a/scripts/requirementscheck.py
+++ b/scripts/requirementscheck.py
@@ -31,9 +31,14 @@ for f in files:
     with open(f, 'r') as fd:
         for req in requirements.parse(fd):
             req_name = req.name
-            assert len(req.specs) <= 1
+            if len(req.specs) > 1:
+                print("Spec too complicated", file=sys.stderr)
+                sys.exit(2)
             if len(req.specs) == 1:
                 dep_dict[req_name] = req.specs[0][1]
+            else:
+                # Nothing specified so add a fake version
+                dep_dict[req_name] = -1
 
     dependencies[f] = dep_dict
 print("All requirements files parsed")

--- a/scripts/requirementscheck.py
+++ b/scripts/requirementscheck.py
@@ -2,78 +2,136 @@
 # and makes sure that they match up to '>=' vs '=='
 
 import argparse
-# import importlib.util
-import os
-import re
 import requirements
 import sys
 
+error_prefix = "##[error]"
 
-desc = "Checks setup.py and pip requirements files for consistency"
+
+def print_ado_error(msg):
+    print("{0}{1}".format(error_prefix, msg))
+
+
+def check_requirement_specs(requirement):
+    """Ensures that the requirement is '=='
+    or '>=' since we're interested in pinning
+    lower bounds
+    """
+    specs_good = True
+
+    if len(requirement.specs) > 1:
+        msg = "Too many specs for {0}".format(requirement.name)
+        print_ado_error(msg)
+        specs_good = False
+    elif len(requirement.specs) == 1:
+        allowed = {">=", "=="}
+        cmp = requirement.specs[0][0]
+        if requirement.specs[0][0] not in allowed:
+            msg = "Comparator {0} not allowed for {1}".format(cmp, requirement.name)
+            print_ado_error(msg)
+            specs_good = False
+
+    return specs_good
+
+
+def load_requirements_file(filename):
+    """Loads the specified requirements file
+    and checks that the specs are OK by themselves
+    """
+
+    print("Loading {0}".format(filename))
+
+    good_requirements = True
+    with open(filename, 'r') as fd:
+        reqs = sorted(list(requirements.parse(fd)), key=lambda x: x.name)
+        for r in reqs:
+            good_requirements = good_requirements and check_requirement_specs(r)
+
+    return good_requirements, reqs
+
+
+def compare_specs(spec1, spec2):
+    """Compare two specifications assuming that there
+    is a maximum of one comparator. If present this is
+    assumed to be == or >=
+    """
+    specs_match = True
+    # Quick sanity check
+    assert spec1.name == spec2.name
+
+    have1 = len(spec1.specs) > 0
+    have2 = len(spec2.specs) > 0
+
+    if have1 != have2:
+        print("{0}Only one spec on {1}",
+              error_prefix,
+              spec1.name)
+        specs_match = False
+    elif not have1:
+        # We have two empty lists
+        pass
+    else:
+        if spec1.specs[0][1] != spec2.specs[0][1]:
+            print("{0}Version mismatch on {1}",
+                  error_prefix,
+                  spec1.name)
+            specs_match = False
+
+    return specs_match
+
+
+def compare_requirements(req1, req2):
+    """Compare the two requirements, assuming that
+    check_requirement_specs has already been run and
+    hence that we don't need to worry about the
+    comparator
+    """
+    names1 = [x.name for x in req1]
+    names2 = [x.name for x in req1]
+
+    all_match = True
+    if names1 != names2:
+        msg = "List of requirement names does not match"
+        print_ado_error(msg)
+        return False
+    else:
+        all_match = True
+        for i in range(len(names1)):
+            # No need to check the spec again
+            spec1 = req1[i]
+            spec2 = req2[i]
+            all_match = all_match and compare_specs(spec1, spec2)
+
+    return all_match
+
+
+desc = "Checks two requirements files for consistency"
 
 parser = argparse.ArgumentParser(description=desc)
-parser.add_argument('directory')
+parser.add_argument('--fixed')
+parser.add_argument('--lowerbound')
 
 args = parser.parse_args()
 
-target_dir = os.path.abspath(args.directory)
+fixed_filename = args.fixed
+lowerbound_filename = args.lowerbound
 
-print("Examining {0}".format(target_dir))
+requirement_match_good = True
 
-file_pattern = r"requirements.*\.txt"
+good_fixed, fixed_specs = load_requirements_file(fixed_filename)
+good_lb, lb_specs = load_requirements_file(lowerbound_filename)
 
-files = [f for f in os.listdir(target_dir) if re.match(file_pattern, f)]
-
-print("Found requirements files: {0}".format(files))
-
-dependencies = {}
-for f in files:
-    print("Parsing file: {0}".format(f))
-    target_file = os.path.join(target_dir, f)
-    dep_dict = {}
-    with open(f, 'r') as fd:
-        for req in requirements.parse(fd):
-            req_name = req.name
-            if len(req.specs) > 1:
-                print("Spec too complicated", file=sys.stderr)
-                sys.exit(2)
-            if len(req.specs) == 1:
-                dep_dict[req_name] = req.specs[0][1]
-            else:
-                # Nothing specified so add a fake version
-                dep_dict[req_name] = -1
-
-    dependencies[f] = dep_dict
-print("All requirements files parsed")
-
-truth_file = list(dependencies.keys())[0]
-print("Taking {0} as ground truth".format(truth_file))
-truth_deps = dependencies[truth_file]
+print()
+print("Files loaded")
 print()
 
-found_mismatch = False
-for f, d in dependencies.items():
-    if f == truth_file:
-        continue
-    print("Examining {0}".format(f))
-    if sorted(d.keys()) != sorted(truth_deps.keys()):
-        print(" Dependency list does not match!")
-        found_mismatch = True
-    else:
-        for dep, ver in truth_deps.items():
-            if ver != d[dep]:
-                print("  Mismatched versions for {0}".format(dep))
-                found_mismatch = True
-    print("Examination of {0} completed".format(f))
-    print()
+requirement_match_good = good_fixed and good_lb
 
-# spec = importlib.util.spec_from_file_location("setup", os.path.join(target_dir, "setup.py"))
-# module = importlib.util.module_from_spec(spec)
-# spec.loader.exec_module(module)
-# print(module)
+requirement_match_good = requirement_match_good and compare_requirements(fixed_specs, lb_specs)
 
-if found_mismatch:
-    print("##[error]Found mismatches", file=sys.stderr)
+if not requirement_match_good:
+    print_ado_error("Found mismatches")
     sys.exit(1)
 else:
+    print("No mismatches found")
     sys.exit(0)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     python_requires='>=3.5',
     install_requires=[
-        "matplotlib>=>=3.0.3",
+        "matplotlib>=3.0.3",
         "numpy>=1.17.2",
         "pandas>=0.25.1",
         "scikit-learn>=0.21.3",


### PR DESCRIPTION
Script to check that two requirements files for pip are consistent. Use in the builds to compare `requirements.txt` and `requirements-fixed.txt`

There is no support for `setup.py` at the present time.