### PR TITLE
Fix for mean_underunderprediction

### DIFF
--- a/fairlearn/metrics/_mean_predictions.py
+++ b/fairlearn/metrics/_mean_predictions.py
@@ -69,4 +69,5 @@ def mean_underprediction(y_true, y_pred, sample_weight=None):
     err = y_p - y_t
     err[err > 0] = 0
 
-    return np.dot(err, s_w) / s_w.sum()
+    # Error metrics should decrease to 0 so have to flip sign
+    return -np.dot(err, s_w) / s_w.sum()

--- a/test/unit/metrics/test_mean_predictions.py
+++ b/test/unit/metrics/test_mean_predictions.py
@@ -48,14 +48,14 @@ def test_mean_underprediction_unweighted():
 
     result = metrics.mean_underprediction(y_true, y_pred)
 
-    assert result == -1
+    assert result == 1
 
 
 def test_mean_underprediction_weighted():
-    y_pred = [0, 1, 2, 3, 4]
-    y_true = [1, 1, 5, 0, 2]
-    weight = [3, 1, 2, 1, 2]
+    y_pred = [0, 1, 5, 3, 1]
+    y_true = [1, 1, 2, 0, 2]
+    weight = [4, 1, 2, 2, 1]
 
     result = metrics.mean_underprediction(y_true, y_pred, weight)
 
-    assert result == -1
+    assert result == 0.5


### PR DESCRIPTION
By convention, error metrics decrease towards zero
Update the sign of `mean_underprediction` to reflect this