### PR TITLE
Turn off Python 3.5 for Notebooks

### DIFF
--- a/devops/notebook-job-template.yml
+++ b/devops/notebook-job-template.yml
@@ -1,7 +1,7 @@
 parameters:
   name: 'Notebooks'
   vmImage: 'ubuntu-latest'
-  pyVersions: [3.5, 3.6, 3.7]
+  pyVersions: [3.6, 3.7] # Trouble with 3.5 right now
   requirementsFile: 'requirements.txt'
 
 jobs:


### PR DESCRIPTION
Having trouble with Python 3.5 in the Notebooks build
Since this was a recent addition, turn it back off pending debug and fix