### PR TITLE
tempeh upgrade to v0.1.7 to fix notebooks in python 3.5

### DIFF
--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -30,7 +30,7 @@ jobs:
   parameters:
     name: MacOS
     vmImage:  'macOS-10.13'
-    pyVersions: [3.6, 3.7] 
+    pyVersions: [3.5, 3.6, 3.7] 
 
 - template: notebook-job-template.yml
   parameters:

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -30,7 +30,7 @@ jobs:
   parameters:
     name: MacOS
     vmImage:  'macOS-10.13'
-    pyVersions: [3.5, 3.6, 3.7] 
+    pyVersions: [3.6, 3.7] 
 
 - template: notebook-job-template.yml
   parameters:

--- a/devops/notebook-job-template.yml
+++ b/devops/notebook-job-template.yml
@@ -1,7 +1,7 @@
 parameters:
   name: 'Notebooks'
   vmImage: 'ubuntu-latest'
-  pyVersions: [3.6, 3.7] # Trouble with 3.5 right now
+  pyVersions: [3.5, 3.6, 3.7]
   requirementsFile: 'requirements.txt'
 
 jobs:

--- a/requirements-fixed.txt
+++ b/requirements-fixed.txt
@@ -14,7 +14,7 @@ requirements-parser
 # Pin pytest due to VS Code issue
 pytest==5.0.1
 pytest-cov
-tempeh==0.1.6
+tempeh==0.1.7
 
 # Required for notebooks
 jupyter

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ requirements-parser
 # Pin pytest due to VS Code issue
 pytest==5.0.1
 pytest-cov
-tempeh==0.1.6
+tempeh==0.1.7
 
 # Required for notebooks
 jupyter


### PR DESCRIPTION
The issue before was that we were catching a ModuleNotFoundError for not having tensorflow/pytorch installed, but ModuleNotfoundError itself doesn't exist in py3.5, so that was generalized in tempeh release v0.1.7 to catch ImportError. Adding notebook test for py3.5 back.