### PR TITLE
Single element fix for group metrics

### DIFF
--- a/fairlearn/metrics/_balanced_root_mean_squared_error.py
+++ b/fairlearn/metrics/_balanced_root_mean_squared_error.py
@@ -5,6 +5,8 @@ import math
 import numpy as np
 import sklearn.metrics as skm
 
+from ._input_manipulations import _ensure_1d_ndarray
+
 _Y_TRUE_NOT_0_1 = "Only 0 and 1 are allowed in y_true and both must be present"
 
 
@@ -20,11 +22,11 @@ def balanced_root_mean_squared_error(y_true, y_pred, sample_weight=None):
     :any:`sklearn.metrics.mean_squared_error` routine.
     """
 
-    y_ta = np.squeeze(np.asarray(y_true))
-    y_pa = np.squeeze(np.asarray(y_pred))
+    y_ta = _ensure_1d_ndarray(y_true, "y_true")
+    y_pa = _ensure_1d_ndarray(y_pred, "y_pred")
     s_w = np.ones(len(y_ta))
     if sample_weight is not None:
-        s_w = np.squeeze(np.asarray(sample_weight))
+        s_w = _ensure_1d_ndarray(sample_weight, "sample_weight")
 
     y_ta_values = np.unique(y_ta)
     if not np.array_equal(y_ta_values, [0, 1]):

--- a/fairlearn/metrics/_balanced_root_mean_squared_error.py
+++ b/fairlearn/metrics/_balanced_root_mean_squared_error.py
@@ -5,7 +5,7 @@ import math
 import numpy as np
 import sklearn.metrics as skm
 
-from ._input_manipulations import _ensure_1d_ndarray
+from ._input_manipulations import _convert_to_ndarray_and_squeeze
 
 _Y_TRUE_NOT_0_1 = "Only 0 and 1 are allowed in y_true and both must be present"
 
@@ -22,11 +22,11 @@ def balanced_root_mean_squared_error(y_true, y_pred, sample_weight=None):
     :any:`sklearn.metrics.mean_squared_error` routine.
     """
 
-    y_ta = _ensure_1d_ndarray(y_true, "y_true")
-    y_pa = _ensure_1d_ndarray(y_pred, "y_pred")
+    y_ta = _convert_to_ndarray_and_squeeze(y_true, "y_true")
+    y_pa = _convert_to_ndarray_and_squeeze(y_pred, "y_pred")
     s_w = np.ones(len(y_ta))
     if sample_weight is not None:
-        s_w = _ensure_1d_ndarray(sample_weight, "sample_weight")
+        s_w = _convert_to_ndarray_and_squeeze(sample_weight, "sample_weight")
 
     y_ta_values = np.unique(y_ta)
     if not np.array_equal(y_ta_values, [0, 1]):

--- a/fairlearn/metrics/_balanced_root_mean_squared_error.py
+++ b/fairlearn/metrics/_balanced_root_mean_squared_error.py
@@ -22,11 +22,11 @@ def balanced_root_mean_squared_error(y_true, y_pred, sample_weight=None):
     :any:`sklearn.metrics.mean_squared_error` routine.
     """
 
-    y_ta = _convert_to_ndarray_and_squeeze(y_true, "y_true")
-    y_pa = _convert_to_ndarray_and_squeeze(y_pred, "y_pred")
+    y_ta = _convert_to_ndarray_and_squeeze(y_true)
+    y_pa = _convert_to_ndarray_and_squeeze(y_pred)
     s_w = np.ones(len(y_ta))
     if sample_weight is not None:
-        s_w = _convert_to_ndarray_and_squeeze(sample_weight, "sample_weight")
+        s_w = _convert_to_ndarray_and_squeeze(sample_weight)
 
     y_ta_values = np.unique(y_ta)
     if not np.array_equal(y_ta_values, [0, 1]):

--- a/fairlearn/metrics/_input_manipulations.py
+++ b/fairlearn/metrics/_input_manipulations.py
@@ -22,12 +22,9 @@ def _ensure_1d_ndarray(input, input_name):
     """
     result = np.asarray(input)
 
-    if np.count_nonzero(np.asarray(result.shape) > 1) > 1:
+    old_shape = np.asarray(result.shape)
+
+    if np.count_nonzero(old_shape > 1) > 1:
         raise ValueError(_ARRAY_NOT_REALLY_1D.format(input_name))
 
-    if result.size > 1:
-        result = np.squeeze(result)
-    else:
-        result = result.reshape(1)
-
-    return result
+    return result.reshape(old_shape.max())

--- a/fairlearn/metrics/_input_manipulations.py
+++ b/fairlearn/metrics/_input_manipulations.py
@@ -4,7 +4,7 @@
 import numpy as np
 
 
-def _convert_to_ndarray_and_squeeze(input, input_name):
+def _convert_to_ndarray_and_squeeze(input):
     """Converts to a numpy.ndarray and calls squeeze (to dispose of unit length dimensions),
     with a special case to stop single element arrays being converted to scalars.
     """

--- a/fairlearn/metrics/_input_manipulations.py
+++ b/fairlearn/metrics/_input_manipulations.py
@@ -4,19 +4,9 @@
 import numpy as np
 
 
-def _ensure_1d_ndarray(input, input_name):
-    """Ensures that the input is represented as a 1d numpy.ndarray.
-
-    The goal of this routine is to ensure that input arrays of shape
-    (1,n) and (n,1), not to mention (1,1,n,1,1) can all be treated as
-    an array of shape (n). However, an array of shape (2,2) will be
-    rejected.
-
-    This routine relies on the behaviour of numpy.asarray, and is not
-    comprehensive as a result. For example
-    numpy.asarray([[1,2], [2]])
-    will result in a 1D ndarray, with two elements, each of which is a
-    list. This method is not built to detect that issue
+def _convert_to_ndarray_and_squeeze(input, input_name):
+    """Converts to a numpy.ndarray and calls squeeze (to dispose of unit length dimensions),
+    with a special case to stop single element arrays being converted to scalars.
     """
     result = np.asarray(input)
 

--- a/fairlearn/metrics/_input_manipulations.py
+++ b/fairlearn/metrics/_input_manipulations.py
@@ -3,11 +3,29 @@
 
 import numpy as np
 
+_ARRAY_NOT_REALLY_1D = "'{0}' has more than one dimension longer than 1"
 
-def _convert_to_1d_array(input):
+
+def _ensure_1d_ndarray(input, input_name):
+    """Ensures that the input is represented as a 1d numpy.ndarray.
+
+    The goal of this routine is to ensure that input arrays of shape
+    (1,n) and (n,1), not to mention (1,1,n,1,1) can all be treated as
+    an array of shape (n). However, an array of shape (2,2) will be
+    rejected.
+
+    This routine relies on the behaviour of numpy.asarray, and is not
+    comprehensive as a result. For example
+    numpy.asarray([[1,2], [2]])
+    will result in a 1D ndarray, with two elements, each of which is a
+    list. This method is not built to detect that issue
+    """
     result = np.asarray(input)
 
-    if len(result) > 1:
+    if np.count_nonzero(np.asarray(result.shape) > 1) > 1:
+        raise ValueError(_ARRAY_NOT_REALLY_1D.format(input_name))
+
+    if result.size > 1:
         result = np.squeeze(result)
     else:
         result = result.reshape(1)

--- a/fairlearn/metrics/_input_manipulations.py
+++ b/fairlearn/metrics/_input_manipulations.py
@@ -1,0 +1,15 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import numpy as np
+
+
+def _convert_to_1d_array(input):
+    result = np.asarray(input)
+
+    if len(result) > 1:
+        result = np.squeeze(result)
+    else:
+        result = result.reshape(1)
+
+    return result

--- a/fairlearn/metrics/_input_manipulations.py
+++ b/fairlearn/metrics/_input_manipulations.py
@@ -3,8 +3,6 @@
 
 import numpy as np
 
-_ARRAY_NOT_REALLY_1D = "'{0}' has more than one dimension longer than 1"
-
 
 def _ensure_1d_ndarray(input, input_name):
     """Ensures that the input is represented as a 1d numpy.ndarray.
@@ -22,9 +20,9 @@ def _ensure_1d_ndarray(input, input_name):
     """
     result = np.asarray(input)
 
-    old_shape = np.asarray(result.shape)
+    if result.size > 1:
+        result = np.squeeze(result)
+    else:
+        result = result.reshape(1)
 
-    if np.count_nonzero(old_shape > 1) > 1:
-        raise ValueError(_ARRAY_NOT_REALLY_1D.format(input_name))
-
-    return result.reshape(old_shape.max())
+    return result

--- a/fairlearn/metrics/_mean_predictions.py
+++ b/fairlearn/metrics/_mean_predictions.py
@@ -43,11 +43,11 @@ def mean_underprediction(y_true, y_pred, sample_weight=None):
     the (weighted) mean of the error where any positive errors
     (i.e. overpredictions) are set to zero
     """
-    y_t = np.squeeze(np.asarray(y_true))
-    y_p = np.squeeze(np.asarray(y_pred))
+    y_t = _ensure_1d_ndarray(y_true, "y_true")
+    y_p = _ensure_1d_ndarray(y_pred, "y_pred")
     s_w = np.ones(len(y_p))
     if sample_weight is not None:
-        s_w = np.squeeze(np.asarray(sample_weight))
+        s_w = _ensure_1d_ndarray(sample_weight, "sample_weight")
 
     err = y_p - y_t
     err[err > 0] = 0

--- a/fairlearn/metrics/_mean_predictions.py
+++ b/fairlearn/metrics/_mean_predictions.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 
-from ._input_manipulations import _ensure_1d_ndarray
+from ._input_manipulations import _convert_to_ndarray_and_squeeze
 
 
 def mean_prediction(y_true, y_pred, sample_weight=None):
@@ -12,10 +12,10 @@ def mean_prediction(y_true, y_pred, sample_weight=None):
     to maintain a consistent interface
     """
 
-    y_p = _ensure_1d_ndarray(y_pred, "y_pred")
+    y_p = _convert_to_ndarray_and_squeeze(y_pred, "y_pred")
     s_w = np.ones(len(y_p))
     if sample_weight is not None:
-        s_w = _ensure_1d_ndarray(sample_weight, "sample_weight")
+        s_w = _convert_to_ndarray_and_squeeze(sample_weight, "sample_weight")
 
     return np.dot(y_p, s_w) / s_w.sum()
 
@@ -26,11 +26,11 @@ def mean_overprediction(y_true, y_pred, sample_weight=None):
     (i.e. underpredictions) are set to zero
     """
 
-    y_t = _ensure_1d_ndarray(y_true, "y_true")
-    y_p = _ensure_1d_ndarray(y_pred, "y_pred")
+    y_t = _convert_to_ndarray_and_squeeze(y_true, "y_true")
+    y_p = _convert_to_ndarray_and_squeeze(y_pred, "y_pred")
     s_w = np.ones(len(y_p))
     if sample_weight is not None:
-        s_w = _ensure_1d_ndarray(sample_weight, "sample_weight")
+        s_w = _convert_to_ndarray_and_squeeze(sample_weight, "sample_weight")
 
     err = y_p - y_t
     err[err < 0] = 0
@@ -43,11 +43,11 @@ def mean_underprediction(y_true, y_pred, sample_weight=None):
     the (weighted) mean of the error where any positive errors
     (i.e. overpredictions) are set to zero
     """
-    y_t = _ensure_1d_ndarray(y_true, "y_true")
-    y_p = _ensure_1d_ndarray(y_pred, "y_pred")
+    y_t = _convert_to_ndarray_and_squeeze(y_true, "y_true")
+    y_p = _convert_to_ndarray_and_squeeze(y_pred, "y_pred")
     s_w = np.ones(len(y_p))
     if sample_weight is not None:
-        s_w = _ensure_1d_ndarray(sample_weight, "sample_weight")
+        s_w = _convert_to_ndarray_and_squeeze(sample_weight, "sample_weight")
 
     err = y_p - y_t
     err[err > 0] = 0

--- a/fairlearn/metrics/_mean_predictions.py
+++ b/fairlearn/metrics/_mean_predictions.py
@@ -12,10 +12,10 @@ def mean_prediction(y_true, y_pred, sample_weight=None):
     to maintain a consistent interface
     """
 
-    y_p = _convert_to_ndarray_and_squeeze(y_pred, "y_pred")
+    y_p = _convert_to_ndarray_and_squeeze(y_pred)
     s_w = np.ones(len(y_p))
     if sample_weight is not None:
-        s_w = _convert_to_ndarray_and_squeeze(sample_weight, "sample_weight")
+        s_w = _convert_to_ndarray_and_squeeze(sample_weight)
 
     return np.dot(y_p, s_w) / s_w.sum()
 
@@ -26,11 +26,11 @@ def mean_overprediction(y_true, y_pred, sample_weight=None):
     (i.e. underpredictions) are set to zero
     """
 
-    y_t = _convert_to_ndarray_and_squeeze(y_true, "y_true")
-    y_p = _convert_to_ndarray_and_squeeze(y_pred, "y_pred")
+    y_t = _convert_to_ndarray_and_squeeze(y_true)
+    y_p = _convert_to_ndarray_and_squeeze(y_pred)
     s_w = np.ones(len(y_p))
     if sample_weight is not None:
-        s_w = _convert_to_ndarray_and_squeeze(sample_weight, "sample_weight")
+        s_w = _convert_to_ndarray_and_squeeze(sample_weight)
 
     err = y_p - y_t
     err[err < 0] = 0
@@ -43,11 +43,11 @@ def mean_underprediction(y_true, y_pred, sample_weight=None):
     the (weighted) mean of the error where any positive errors
     (i.e. overpredictions) are set to zero
     """
-    y_t = _convert_to_ndarray_and_squeeze(y_true, "y_true")
-    y_p = _convert_to_ndarray_and_squeeze(y_pred, "y_pred")
+    y_t = _convert_to_ndarray_and_squeeze(y_true)
+    y_p = _convert_to_ndarray_and_squeeze(y_pred)
     s_w = np.ones(len(y_p))
     if sample_weight is not None:
-        s_w = _convert_to_ndarray_and_squeeze(sample_weight, "sample_weight")
+        s_w = _convert_to_ndarray_and_squeeze(sample_weight)
 
     err = y_p - y_t
     err[err > 0] = 0

--- a/fairlearn/metrics/_mean_predictions.py
+++ b/fairlearn/metrics/_mean_predictions.py
@@ -3,36 +3,19 @@
 
 import numpy as np
 
+from ._input_manipulations import _ensure_1d_ndarray
+
 
 def mean_prediction(y_true, y_pred, sample_weight=None):
     """Returns the (weighted) mean prediction. The true
     values are ignored, but required as an argument in order
     to maintain a consistent interface
-
-    :Example:
-
-    Without weights
-
-    .. literalinclude:: /../test/unit/metrics/test_mean_predictions.py
-        :linenos:
-        :language: python
-        :lines: 8-13
-        :dedent: 4
-
-    With weights
-
-    .. literalinclude:: /../test/unit/metrics/test_mean_predictions.py
-        :linenos:
-        :language: python
-        :lines: 17-23
-        :dedent: 4
-
     """
 
-    y_p = np.squeeze(np.asarray(y_pred))
+    y_p = _ensure_1d_ndarray(y_pred, "y_pred")
     s_w = np.ones(len(y_p))
     if sample_weight is not None:
-        s_w = np.squeeze(np.asarray(sample_weight))
+        s_w = _ensure_1d_ndarray(sample_weight, "sample_weight")
 
     return np.dot(y_p, s_w) / s_w.sum()
 
@@ -43,11 +26,11 @@ def mean_overprediction(y_true, y_pred, sample_weight=None):
     (i.e. underpredictions) are set to zero
     """
 
-    y_t = np.squeeze(np.asarray(y_true))
-    y_p = np.squeeze(np.asarray(y_pred))
+    y_t = _ensure_1d_ndarray(y_true, "y_true")
+    y_p = _ensure_1d_ndarray(y_pred, "y_pred")
     s_w = np.ones(len(y_p))
     if sample_weight is not None:
-        s_w = np.squeeze(np.asarray(sample_weight))
+        s_w = _ensure_1d_ndarray(sample_weight, "sample_weight")
 
     err = y_p - y_t
     err[err < 0] = 0

--- a/fairlearn/metrics/_metrics_engine.py
+++ b/fairlearn/metrics/_metrics_engine.py
@@ -4,6 +4,7 @@
 import numpy as np
 
 from ._group_metric_result import GroupMetricResult
+from ._input_manipulations import _convert_to_1d_array
 
 _MESSAGE_SIZE_MISMATCH = "Array {0} is not the same size as {1}"
 
@@ -39,9 +40,14 @@ def metric_by_group(metric_function, y_true, y_pred, group_membership, sample_we
     y_a = _convert_to_1d_array(y_true)
     y_p = _convert_to_1d_array(y_pred)
     g_d = _convert_to_1d_array(group_membership)
+
+    _check_array_sizes(y_a, y_p, 'y_true', 'y_pred')
+    _check_array_sizes(y_a, g_d, 'y_true', 'group_membership')
+
     s_w = None
     if sample_weight is not None:
         s_w = _convert_to_1d_array(sample_weight)
+        _check_array_sizes(y_a, s_w, 'y_true', 'sample_weight')
 
     # Evaluate the overall metric with the numpy arrays
     # This ensures consistency in how metric_function is called
@@ -111,16 +117,6 @@ def make_group_metric(metric_function):
 
     return wrapper
 
-
-def _convert_to_1d_array(input):
-    result = np.asarray(input)
-
-    if len(result) > 1:
-        result = np.squeeze(result)
-    else:
-        result = result.reshape(1)
-
-    return result
 
 def _check_array_sizes(a, b, a_name, b_name):
     if len(a) != len(b):

--- a/fairlearn/metrics/_metrics_engine.py
+++ b/fairlearn/metrics/_metrics_engine.py
@@ -4,7 +4,7 @@
 import numpy as np
 
 from ._group_metric_result import GroupMetricResult
-from ._input_manipulations import _ensure_1d_ndarray
+from ._input_manipulations import _convert_to_ndarray_and_squeeze
 
 _MESSAGE_SIZE_MISMATCH = "Array {0} is not the same size as {1}"
 
@@ -37,16 +37,16 @@ def metric_by_group(metric_function, y_true, y_pred, group_membership, sample_we
 
     # Make everything a numpy array
     # This allows for fast slicing of the groups
-    y_a = _ensure_1d_ndarray(y_true, "y_true")
-    y_p = _ensure_1d_ndarray(y_pred, "y_pred")
-    g_d = _ensure_1d_ndarray(group_membership, "group_membership")
+    y_a = _convert_to_ndarray_and_squeeze(y_true, "y_true")
+    y_p = _convert_to_ndarray_and_squeeze(y_pred, "y_pred")
+    g_d = _convert_to_ndarray_and_squeeze(group_membership, "group_membership")
 
     _check_array_sizes(y_a, y_p, 'y_true', 'y_pred')
     _check_array_sizes(y_a, g_d, 'y_true', 'group_membership')
 
     s_w = None
     if sample_weight is not None:
-        s_w = _ensure_1d_ndarray(sample_weight, "sample_weight")
+        s_w = _convert_to_ndarray_and_squeeze(sample_weight, "sample_weight")
         _check_array_sizes(y_a, s_w, 'y_true', 'sample_weight')
 
     # Evaluate the overall metric with the numpy arrays

--- a/fairlearn/metrics/_metrics_engine.py
+++ b/fairlearn/metrics/_metrics_engine.py
@@ -37,16 +37,16 @@ def metric_by_group(metric_function, y_true, y_pred, group_membership, sample_we
 
     # Make everything a numpy array
     # This allows for fast slicing of the groups
-    y_a = _ensure_1d_ndarray(y_true)
-    y_p = _ensure_1d_ndarray(y_pred)
-    g_d = _ensure_1d_ndarray(group_membership)
+    y_a = _ensure_1d_ndarray(y_true, "y_true")
+    y_p = _ensure_1d_ndarray(y_pred, "y_pred")
+    g_d = _ensure_1d_ndarray(group_membership, "group_membership")
 
     _check_array_sizes(y_a, y_p, 'y_true', 'y_pred')
     _check_array_sizes(y_a, g_d, 'y_true', 'group_membership')
 
     s_w = None
     if sample_weight is not None:
-        s_w = _ensure_1d_ndarray(sample_weight)
+        s_w = _ensure_1d_ndarray(sample_weight, "sample_weight")
         _check_array_sizes(y_a, s_w, 'y_true', 'sample_weight')
 
     # Evaluate the overall metric with the numpy arrays

--- a/fairlearn/metrics/_metrics_engine.py
+++ b/fairlearn/metrics/_metrics_engine.py
@@ -43,6 +43,12 @@ def metric_by_group(metric_function, y_true, y_pred, group_membership, sample_we
     if sample_weight is not None:
         s_w = np.squeeze(np.asarray(sample_weight))
 
+    print()
+    print("y_a", y_a, "y_true", y_true)
+    print("y_p", y_p)
+    print("g_d", g_d)
+    print("s_w", s_w)
+
     # Evaluate the overall metric with the numpy arrays
     # This ensures consistency in how metric_function is called
     if s_w is not None:

--- a/fairlearn/metrics/_metrics_engine.py
+++ b/fairlearn/metrics/_metrics_engine.py
@@ -4,7 +4,7 @@
 import numpy as np
 
 from ._group_metric_result import GroupMetricResult
-from ._input_manipulations import _convert_to_1d_array
+from ._input_manipulations import _ensure_1d_ndarray
 
 _MESSAGE_SIZE_MISMATCH = "Array {0} is not the same size as {1}"
 
@@ -37,16 +37,16 @@ def metric_by_group(metric_function, y_true, y_pred, group_membership, sample_we
 
     # Make everything a numpy array
     # This allows for fast slicing of the groups
-    y_a = _convert_to_1d_array(y_true)
-    y_p = _convert_to_1d_array(y_pred)
-    g_d = _convert_to_1d_array(group_membership)
+    y_a = _ensure_1d_ndarray(y_true)
+    y_p = _ensure_1d_ndarray(y_pred)
+    g_d = _ensure_1d_ndarray(group_membership)
 
     _check_array_sizes(y_a, y_p, 'y_true', 'y_pred')
     _check_array_sizes(y_a, g_d, 'y_true', 'group_membership')
 
     s_w = None
     if sample_weight is not None:
-        s_w = _convert_to_1d_array(sample_weight)
+        s_w = _ensure_1d_ndarray(sample_weight)
         _check_array_sizes(y_a, s_w, 'y_true', 'sample_weight')
 
     # Evaluate the overall metric with the numpy arrays

--- a/fairlearn/metrics/_metrics_engine.py
+++ b/fairlearn/metrics/_metrics_engine.py
@@ -37,17 +37,13 @@ def metric_by_group(metric_function, y_true, y_pred, group_membership, sample_we
 
     # Make everything a numpy array
     # This allows for fast slicing of the groups
-    y_a = _convert_to_ndarray_and_squeeze(y_true, "y_true")
-    y_p = _convert_to_ndarray_and_squeeze(y_pred, "y_pred")
-    g_d = _convert_to_ndarray_and_squeeze(group_membership, "group_membership")
-
-    _check_array_sizes(y_a, y_p, 'y_true', 'y_pred')
-    _check_array_sizes(y_a, g_d, 'y_true', 'group_membership')
+    y_a = _convert_to_ndarray_and_squeeze(y_true)
+    y_p = _convert_to_ndarray_and_squeeze(y_pred)
+    g_d = _convert_to_ndarray_and_squeeze(group_membership)
 
     s_w = None
     if sample_weight is not None:
-        s_w = _convert_to_ndarray_and_squeeze(sample_weight, "sample_weight")
-        _check_array_sizes(y_a, s_w, 'y_true', 'sample_weight')
+        s_w = _convert_to_ndarray_and_squeeze(sample_weight)
 
     # Evaluate the overall metric with the numpy arrays
     # This ensures consistency in how metric_function is called

--- a/fairlearn/metrics/_metrics_engine.py
+++ b/fairlearn/metrics/_metrics_engine.py
@@ -36,18 +36,12 @@ def metric_by_group(metric_function, y_true, y_pred, group_membership, sample_we
 
     # Make everything a numpy array
     # This allows for fast slicing of the groups
-    y_a = np.squeeze(np.asarray(y_true))
-    y_p = np.squeeze(np.asarray(y_pred))
-    g_d = np.squeeze(np.asarray(group_membership))
+    y_a = _convert_to_1d_array(y_true)
+    y_p = _convert_to_1d_array(y_pred)
+    g_d = _convert_to_1d_array(group_membership)
     s_w = None
     if sample_weight is not None:
-        s_w = np.squeeze(np.asarray(sample_weight))
-
-    print()
-    print("y_a", y_a, "y_true", y_true)
-    print("y_p", y_p)
-    print("g_d", g_d)
-    print("s_w", s_w)
+        s_w = _convert_to_1d_array(sample_weight)
 
     # Evaluate the overall metric with the numpy arrays
     # This ensures consistency in how metric_function is called
@@ -117,6 +111,16 @@ def make_group_metric(metric_function):
 
     return wrapper
 
+
+def _convert_to_1d_array(input):
+    result = np.asarray(input)
+
+    if len(result) > 1:
+        result = np.squeeze(result)
+    else:
+        result = result.reshape(1)
+
+    return result
 
 def _check_array_sizes(a, b, a_name, b_name):
     if len(a) != len(b):

--- a/test/unit/metrics/test_group_sklearn_wrappers.py
+++ b/test/unit/metrics/test_group_sklearn_wrappers.py
@@ -178,7 +178,7 @@ def test_group_zero_one_loss_unnormalized():
 
 # =============================================================================================
 
-def test_group_mean_squared_error_multioutput():
+def test_group_mean_squared_error_multioutput_single_ndarray():
     y_t = np.random.rand(len(groups), 2)
     y_p = np.random.rand(len(groups), 2)
     result = metrics.group_mean_squared_error(y_t, y_p, groups, multioutput='raw_values')
@@ -186,3 +186,28 @@ def test_group_mean_squared_error_multioutput():
     expected_overall = skm.mean_squared_error(y_t, y_p, multioutput='raw_values')
 
     assert np.array_equal(result.overall, expected_overall)
+
+    for target_group in np.unique(groups):
+        mask = np.asarray(groups) == target_group
+        expected = skm.mean_squared_error(y_t[mask], y_p[mask], multioutput='raw_values')
+        assert np.array_equal(result.by_group[target_group], expected)
+
+
+def test_group_mean_squared_error_multioutput_list_ndarray():
+    y_t = [np.random.rand(2) for x in groups]
+    y_p = [np.random.rand(2) for x in groups]
+    result = metrics.group_mean_squared_error(y_t, y_p, groups, multioutput='raw_values')
+
+    expected_overall = skm.mean_squared_error(y_t, y_p, multioutput='raw_values')
+
+    assert np.array_equal(result.overall, expected_overall)
+
+    for target_group in np.unique(groups):
+        y_true = []
+        y_pred = []
+        for i in range(len(groups)):
+            if groups[i] == target_group:
+                y_true.append(y_t[i])
+                y_pred.append(y_p[i])
+        expected = skm.mean_squared_error(y_true, y_pred, multioutput='raw_values')
+        assert np.array_equal(result.by_group[target_group], expected)

--- a/test/unit/metrics/test_input_manipulations.py
+++ b/test/unit/metrics/test_input_manipulations.py
@@ -48,21 +48,3 @@ class TestEnsure1DNDArray:
         assert result.shape == (1,)
         assert result[0] == 1
 
-    def test_multid_rejected_simple(self):
-        X = [[0, 1], [2, 3]]
-
-        with pytest.raises(ValueError) as exception_context:
-            _ = fmim._ensure_1d_ndarray(X, "X")
-
-        expected = "'X' has more than one dimension longer than 1"
-        assert exception_context.value.args[0] == expected
-
-    def test_multid_rejected_complex(self):
-        X = [[[[0], [1]], [[2], [3]]]]
-        assert np.asarray(X).shape == (1, 2, 2, 1)
-
-        with pytest.raises(ValueError) as exception_context:
-            _ = fmim._ensure_1d_ndarray(X, "X")
-
-        expected = "'X' has more than one dimension longer than 1"
-        assert exception_context.value.args[0] == expected

--- a/test/unit/metrics/test_input_manipulations.py
+++ b/test/unit/metrics/test_input_manipulations.py
@@ -1,0 +1,68 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import numpy as np
+import pytest
+
+import fairlearn.metrics._input_manipulations as fmim
+
+
+class TestEnsure1DNDArray:
+    def test_simple_list(self):
+        X = [0, 1, 2]
+
+        result = fmim._ensure_1d_ndarray(X, "X")
+
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (3,)
+        assert result[0] == 0
+        assert result[1] == 1
+        assert result[2] == 2
+
+    def test_multi_rows(self):
+        X = [[0], [1]]
+
+        result = fmim._ensure_1d_ndarray(X, "X")
+
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (2,)
+        assert result[0] == 0
+        assert result[1] == 1
+
+    def test_multi_columns(self):
+        X = [[0, 1]]
+
+        result = fmim._ensure_1d_ndarray(X, "X")
+
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (2,)
+        assert result[0] == 0
+        assert result[1] == 1
+
+    def test_single_element(self):
+        X = [[[1]]]
+
+        result = fmim._ensure_1d_ndarray(X, "X")
+
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (1,)
+        assert result[0] == 1
+
+    def test_multid_rejected_simple(self):
+        X = [[0, 1], [2, 3]]
+
+        with pytest.raises(ValueError) as exception_context:
+            _ = fmim._ensure_1d_ndarray(X, "X")
+
+        expected = "'X' has more than one dimension longer than 1"
+        assert exception_context.value.args[0] == expected
+
+    def test_multid_rejected_complex(self):
+        X = [[[[0], [1]], [[2], [3]]]]
+        assert np.asarray(X).shape == (1, 2, 2, 1)
+
+        with pytest.raises(ValueError) as exception_context:
+            _ = fmim._ensure_1d_ndarray(X, "X")
+
+        expected = "'X' has more than one dimension longer than 1"
+        assert exception_context.value.args[0] == expected

--- a/test/unit/metrics/test_input_manipulations.py
+++ b/test/unit/metrics/test_input_manipulations.py
@@ -2,16 +2,15 @@
 # Licensed under the MIT License.
 
 import numpy as np
-import pytest
 
 import fairlearn.metrics._input_manipulations as fmim
 
 
-class TestEnsure1DNDArray:
+class TestConvertToNDArrayAndSqueeze:
     def test_simple_list(self):
         X = [0, 1, 2]
 
-        result = fmim._ensure_1d_ndarray(X, "X")
+        result = fmim._convert_to_ndarray_and_squeeze(X, "X")
 
         assert isinstance(result, np.ndarray)
         assert result.shape == (3,)
@@ -22,7 +21,7 @@ class TestEnsure1DNDArray:
     def test_multi_rows(self):
         X = [[0], [1]]
 
-        result = fmim._ensure_1d_ndarray(X, "X")
+        result = fmim._convert_to_ndarray_and_squeeze(X, "X")
 
         assert isinstance(result, np.ndarray)
         assert result.shape == (2,)
@@ -32,7 +31,7 @@ class TestEnsure1DNDArray:
     def test_multi_columns(self):
         X = [[0, 1]]
 
-        result = fmim._ensure_1d_ndarray(X, "X")
+        result = fmim._convert_to_ndarray_and_squeeze(X, "X")
 
         assert isinstance(result, np.ndarray)
         assert result.shape == (2,)
@@ -42,9 +41,8 @@ class TestEnsure1DNDArray:
     def test_single_element(self):
         X = [[[1]]]
 
-        result = fmim._ensure_1d_ndarray(X, "X")
+        result = fmim._convert_to_ndarray_and_squeeze(X, "X")
 
         assert isinstance(result, np.ndarray)
         assert result.shape == (1,)
         assert result[0] == 1
-

--- a/test/unit/metrics/test_input_manipulations.py
+++ b/test/unit/metrics/test_input_manipulations.py
@@ -10,7 +10,7 @@ class TestConvertToNDArrayAndSqueeze:
     def test_simple_list(self):
         X = [0, 1, 2]
 
-        result = fmim._convert_to_ndarray_and_squeeze(X, "X")
+        result = fmim._convert_to_ndarray_and_squeeze(X)
 
         assert isinstance(result, np.ndarray)
         assert result.shape == (3,)
@@ -21,7 +21,7 @@ class TestConvertToNDArrayAndSqueeze:
     def test_multi_rows(self):
         X = [[0], [1]]
 
-        result = fmim._convert_to_ndarray_and_squeeze(X, "X")
+        result = fmim._convert_to_ndarray_and_squeeze(X)
 
         assert isinstance(result, np.ndarray)
         assert result.shape == (2,)
@@ -31,7 +31,7 @@ class TestConvertToNDArrayAndSqueeze:
     def test_multi_columns(self):
         X = [[0, 1]]
 
-        result = fmim._convert_to_ndarray_and_squeeze(X, "X")
+        result = fmim._convert_to_ndarray_and_squeeze(X)
 
         assert isinstance(result, np.ndarray)
         assert result.shape == (2,)
@@ -41,7 +41,7 @@ class TestConvertToNDArrayAndSqueeze:
     def test_single_element(self):
         X = [[[1]]]
 
-        result = fmim._convert_to_ndarray_and_squeeze(X, "X")
+        result = fmim._convert_to_ndarray_and_squeeze(X)
 
         assert isinstance(result, np.ndarray)
         assert result.shape == (1,)

--- a/test/unit/metrics/test_mean_predictions.py
+++ b/test/unit/metrics/test_mean_predictions.py
@@ -13,6 +13,15 @@ def test_mean_prediction_unweighted():
     assert result == 2
 
 
+def test_mean_prediction_single():
+    y_pred = [42]
+    y_true = None
+
+    result = metrics.mean_prediction(y_true, y_pred)
+
+    assert result == 42
+
+
 def test_mean_prediction_weighted():
     y_pred = [0, 1, 2, 3, 4]
     y_true = None
@@ -23,9 +32,28 @@ def test_mean_prediction_weighted():
     assert result == 1
 
 
+def test_mean_prediction_weighted_single():
+    y_pred = [42]
+    y_true = None
+    weight = [2]
+
+    result = metrics.mean_prediction(y_true, y_pred, weight)
+
+    assert result == 42
+
+
 def test_mean_overprediction_unweighted():
     y_pred = [0, 1, 2, 3, 4]
     y_true = [1, 1, 5, 0, 2]
+
+    result = metrics.mean_overprediction(y_true, y_pred)
+
+    assert result == 1
+
+
+def test_mean_overprediction_unweighted_single():
+    y_pred = [1]
+    y_true = [0]
 
     result = metrics.mean_overprediction(y_true, y_pred)
 
@@ -40,6 +68,16 @@ def test_mean_overprediction_weighted():
     result = metrics.mean_overprediction(y_true, y_pred, weight)
 
     assert result == 0.5
+
+
+def test_mean_overprediction_weighted_single():
+    y_pred = [1]
+    y_true = [0]
+    weight = [1]
+
+    result = metrics.mean_overprediction(y_true, y_pred, weight)
+
+    assert result == 1
 
 
 def test_mean_underprediction_unweighted():

--- a/test/unit/metrics/test_mean_predictions.py
+++ b/test/unit/metrics/test_mean_predictions.py
@@ -89,6 +89,15 @@ def test_mean_underprediction_unweighted():
     assert result == 1
 
 
+def test_mean_underprediction_unweighted_single():
+    y_pred = [0]
+    y_true = [1]
+
+    result = metrics.mean_underprediction(y_true, y_pred)
+
+    assert result == 1
+
+
 def test_mean_underprediction_weighted():
     y_pred = [0, 1, 5, 3, 1]
     y_true = [1, 1, 2, 0, 2]
@@ -97,3 +106,13 @@ def test_mean_underprediction_weighted():
     result = metrics.mean_underprediction(y_true, y_pred, weight)
 
     assert result == 0.5
+
+
+def test_mean_underprediction_weighted_single():
+    y_pred = [0]
+    y_true = [42]
+    weight = [2]
+
+    result = metrics.mean_underprediction(y_true, y_pred, weight)
+
+    assert result == 42

--- a/test/unit/metrics/test_metrics_engine.py
+++ b/test/unit/metrics/test_metrics_engine.py
@@ -228,6 +228,23 @@ class TestMetricByGroup:
         # Following is special case
         assert result.range_ratio == 1
 
+    def test_single_element_input(self):
+        y_t = [0]
+        y_p = [0]
+        gid = [0]
+        s_w = [0]
+
+        def sum_lengths(y_true, y_pred, sample_weight):
+            return len(y_true) + len(y_pred) + len(sample_weight)
+
+        result = metrics.metric_by_group(sum_lengths, y_t, y_p, gid, sample_weight=s_w)
+        assert result.overall == 3
+        assert result.by_group[0] == 3
+        assert result.minimum == 3
+        assert result.maximum == 3
+        assert result.range == 3
+        assert result.range_ration == 1
+
 
 class TestMakeGroupMetric:
     def test_smoke(self):

--- a/test/unit/metrics/test_metrics_engine.py
+++ b/test/unit/metrics/test_metrics_engine.py
@@ -254,10 +254,10 @@ class TestMetricByGroup:
             return len(y_true) + len(y_pred)
 
         result = metrics.metric_by_group(sum_lengths, y_t, y_p, gid)
-        assert result.overall == 3
+        assert result.overall == 4
         assert result.by_group[0] == 2
         assert result.by_group[1] == 2
-        assert result.miniumm == 2
+        assert result.minimum == 2
         assert result.maximum == 2
         assert result.range == 0
         assert result.range_ratio == 1

--- a/test/unit/metrics/test_metrics_engine.py
+++ b/test/unit/metrics/test_metrics_engine.py
@@ -242,8 +242,25 @@ class TestMetricByGroup:
         assert result.by_group[0] == 3
         assert result.minimum == 3
         assert result.maximum == 3
-        assert result.range == 3
-        assert result.range_ration == 1
+        assert result.range == 0
+        assert result.range_ratio == 1
+
+    def test_groups_only_one_element(self):
+        y_t = [1, 2]
+        y_p = [1, 2]
+        gid = [0, 1]
+
+        def sum_lengths(y_true, y_pred):
+            return len(y_true) + len(y_pred)
+
+        result = metrics.metric_by_group(sum_lengths, y_t, y_p, gid)
+        assert result.overall == 3
+        assert result.by_group[0] == 2
+        assert result.by_group[1] == 2
+        assert result.miniumm == 2
+        assert result.maximum == 2
+        assert result.range == 0
+        assert result.range_ratio == 1
 
 
 class TestMakeGroupMetric:


### PR DESCRIPTION
It turns out that `numpy.squeeze([1])` results in a scalar and not a single element array
This was causing trouble with the group metrics when only a single prediction was passed
Issues also showed up in the mean prediction metrics, which made a similar call

Solution is to add a helper function (with tests) to check for this case, and ensure that a `numpy.ndarray` is always returned