### PR TITLE
Allow RC specification from environment

### DIFF
--- a/fairlearn/__init__.py
+++ b/fairlearn/__init__.py
@@ -5,8 +5,27 @@
 Machine Learning models.
 """
 
+import os
+import sys
+
+_FAIRLEARN_RC_KEY = "FAIRLEARN_RC"
+
+
+_base_version = "0.3.0"
+_rc_version = ""
+
+if _FAIRLEARN_RC_KEY in os.environ.keys():
+    rc_string = os.environ[_FAIRLEARN_RC_KEY]
+    try:
+        rc_value = int(rc_string)
+        _rc_version = "rc{0}".format(rc_value)
+    except ValueError:
+        msg = "Value of {0} in {1} did not parse to integer. Ignoring"
+        print(msg.format(rc_string, _FAIRLEARN_RC_KEY), file=sys.stderr)
+
+
 __name__ = "fairlearn"
-__version__ = "0.3.0-alpha"
+__version__ = "{0}{1}".format(_base_version, _rc_version)
 
 
 _NO_PREDICT_BEFORE_FIT = "Must call fit before attempting to make predictions"
@@ -14,7 +33,6 @@ _NO_PREDICT_BEFORE_FIT = "Must call fit before attempting to make predictions"
 
 # Setup logging infrastructure
 import logging  # noqa: E402
-import os  # noqa: E402
 # Only log to disk if environment variable specified
 fairlearn_logs = os.environ.get('FAIRLEARN_LOGS')
 if fairlearn_logs is not None:


### PR DESCRIPTION
Add logic to `__init__.py` to allow a release candidate number to be specified via an environment variable
The goal of this is to allow us to push different versions to PyPI-Test without affecting the version which is ultimately pushed to PyPI itself

Signed-off-by: Richard Edgar <riedgar@microsoft.com>