### PR TITLE
Standardise input convertors for test

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.

--- a/test/unit/__init__.py
+++ b/test/unit/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.

--- a/test/unit/input_convertors.py
+++ b/test/unit/input_convertors.py
@@ -1,0 +1,74 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import numpy as np
+import pandas as pd
+
+
+def ensure_list(X):
+    assert X is not None
+    if isinstance(X, list):
+        return X
+    elif isinstance(X, np.ndarray):
+        return X.tolist()
+    elif isinstance(X, pd.Series):
+        return X.tolist()
+    elif isinstance(X, pd.DataFrame):
+        return X.tolist()
+    raise ValueError("Failed to convert to list")
+
+
+def ensure_ndarray(X):
+    assert X is not None
+    if isinstance(X, list):
+        return np.asarray(X)
+    elif isinstance(X, np.ndarray):
+        return X
+    elif isinstance(X, pd.Series):
+        return np.asarray(X)
+    elif isinstance(X, pd.DataFrame):
+        return np.asarray(X)
+    raise ValueError("Failed to convert to ndarray")
+
+
+def ensure_ndarray_2d(X):
+    assert X is not None
+    tmp = ensure_ndarray(X)
+    if len(tmp.shape) != 1:
+        raise ValueError("Requires 1d array")
+    result = np.expand_dims(tmp, 1)
+    assert len(result.shape) == 2
+    return result
+
+
+def ensure_series(X):
+    assert X is not None
+    if isinstance(X, list):
+        return pd.Series(X)
+    elif isinstance(X, np.ndarray):
+        return pd.Series(X)
+    elif isinstance(X, pd.Series):
+        return X
+    elif isinstance(X, pd.DataFrame):
+        return pd.Series(X)
+    raise ValueError("Failed to convert to Series")
+
+
+def ensure_dataframe(X):
+    assert X is not None
+    if isinstance(X, list):
+        return pd.DataFrame(X)
+    elif isinstance(X, np.ndarray):
+        return pd.DataFrame(X)
+    elif isinstance(X, pd.Series):
+        return pd.DataFrame(X)
+    elif isinstance(X, pd.DataFrame):
+        return X
+    raise ValueError("Failed to convert to Series")
+
+
+conversions_for_1d = [ensure_list,
+                      ensure_ndarray,
+                      ensure_ndarray_2d,
+                      ensure_series,
+                      ensure_dataframe]

--- a/test/unit/metrics/__init__.py
+++ b/test/unit/metrics/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.

--- a/test/unit/metrics/test_metrics_engine.py
+++ b/test/unit/metrics/test_metrics_engine.py
@@ -2,41 +2,11 @@
 # Licensed under the MIT License.
 
 import numpy as np
-import pandas as pd
 import pytest
 
 import fairlearn.metrics as metrics
+from test.unit.input_convertors import conversions_for_1d
 
-# ===========================================================
-
-# Conversions from Python lists to our supported datatypes
-
-
-def identity(X):
-    return X
-
-
-def tondarray(X):
-    return np.asarray(X)
-
-
-def tondarray2d(X):
-    # ndarray where second dimension is of length 1
-    arr = np.asarray(X)
-    arr = np.expand_dims(arr, 1)
-    assert len(arr.shape) == 2
-    return arr
-
-
-def topandasseries(X):
-    return pd.Series(X)
-
-
-def topandasdf(X):
-    return pd.DataFrame(X)
-
-
-supported_conversions = [identity, tondarray, tondarray2d, topandasseries, topandasdf]
 
 # ===========================================================
 
@@ -54,9 +24,9 @@ def mock_func_matrix_return(y_true, y_pred):
 
 
 class TestMetricByGroup:
-    @pytest.mark.parametrize("transform_gid", supported_conversions)
-    @pytest.mark.parametrize("transform_y_p", supported_conversions)
-    @pytest.mark.parametrize("transform_y_a", supported_conversions)
+    @pytest.mark.parametrize("transform_gid", conversions_for_1d)
+    @pytest.mark.parametrize("transform_y_p", conversions_for_1d)
+    @pytest.mark.parametrize("transform_y_a", conversions_for_1d)
     def test_smoke(self, transform_y_a, transform_y_p, transform_gid):
         y_a = transform_y_a([0, 0, 1, 1, 0, 1, 1, 1])
         y_p = transform_y_p([0, 1, 1, 1, 1, 0, 0, 1])
@@ -75,9 +45,9 @@ class TestMetricByGroup:
         assert result.range == 1
         assert result.range_ratio == pytest.approx(0.6666666667)
 
-    @pytest.mark.parametrize("transform_gid", supported_conversions)
-    @pytest.mark.parametrize("transform_y_p", supported_conversions)
-    @pytest.mark.parametrize("transform_y_a", supported_conversions)
+    @pytest.mark.parametrize("transform_gid", conversions_for_1d)
+    @pytest.mark.parametrize("transform_y_p", conversions_for_1d)
+    @pytest.mark.parametrize("transform_y_a", conversions_for_1d)
     def test_string_groups(self, transform_y_a, transform_y_p, transform_gid):
         a = "ABC"
         b = "DEF"
@@ -100,9 +70,9 @@ class TestMetricByGroup:
         assert result.range == 2
         assert result.range_ratio == pytest.approx(0.33333333333333)
 
-    @pytest.mark.parametrize("transform_gid", supported_conversions)
-    @pytest.mark.parametrize("transform_y_p", supported_conversions)
-    @pytest.mark.parametrize("transform_y_a", supported_conversions)
+    @pytest.mark.parametrize("transform_gid", conversions_for_1d)
+    @pytest.mark.parametrize("transform_y_p", conversions_for_1d)
+    @pytest.mark.parametrize("transform_y_a", conversions_for_1d)
     def test_matrix_metric(self, transform_y_a, transform_y_p, transform_gid):
         a = "ABC"
         b = "DEF"
@@ -124,10 +94,10 @@ class TestMetricByGroup:
         assert result.range is None
         assert result.range_ratio is None
 
-    @pytest.mark.parametrize("transform_s_w", supported_conversions)
-    @pytest.mark.parametrize("transform_gid", supported_conversions)
-    @pytest.mark.parametrize("transform_y_p", supported_conversions)
-    @pytest.mark.parametrize("transform_y_a", supported_conversions)
+    @pytest.mark.parametrize("transform_s_w", conversions_for_1d)
+    @pytest.mark.parametrize("transform_gid", conversions_for_1d)
+    @pytest.mark.parametrize("transform_y_p", conversions_for_1d)
+    @pytest.mark.parametrize("transform_y_a", conversions_for_1d)
     def test_with_weights(self, transform_y_a, transform_y_p, transform_gid, transform_s_w):
         y_a = transform_y_a([0, 0, 1, 1, 0, 1, 1, 1])
         y_p = transform_y_p([0, 1, 1, 1, 1, 0, 0, 1])
@@ -148,8 +118,8 @@ class TestMetricByGroup:
         assert result.range == 4
         assert result.range_ratio == pytest.approx(0.33333333333333)
 
-    @pytest.mark.parametrize("transform_y_p", supported_conversions)
-    @pytest.mark.parametrize("transform_y_a", supported_conversions)
+    @pytest.mark.parametrize("transform_y_p", conversions_for_1d)
+    @pytest.mark.parametrize("transform_y_a", conversions_for_1d)
     def test_true_predict_length_mismatch(self, transform_y_a, transform_y_p):
         y_a = transform_y_a([0, 0, 1, 1, 0, 1, 1, 1])
         y_p = transform_y_p([0, 1, 1, 1, 1, 0, 0])
@@ -162,8 +132,8 @@ class TestMetricByGroup:
         expected = "Array y_pred is not the same size as y_true"
         assert exception_context.value.args[0] == expected
 
-    @pytest.mark.parametrize("transform_gid", supported_conversions)
-    @pytest.mark.parametrize("transform_y_a", supported_conversions)
+    @pytest.mark.parametrize("transform_gid", conversions_for_1d)
+    @pytest.mark.parametrize("transform_y_a", conversions_for_1d)
     def test_true_group_length_mismatch(self, transform_y_a, transform_gid):
         y_a = transform_y_a([0, 0, 1, 1, 0, 1, 1, 1])
         y_p = [0, 1, 1, 1, 1, 0, 0, 0]
@@ -176,8 +146,8 @@ class TestMetricByGroup:
         expected = "Array group_membership is not the same size as y_true"
         assert exception_context.value.args[0] == expected
 
-    @pytest.mark.parametrize("transform_s_w", supported_conversions)
-    @pytest.mark.parametrize("transform_y_a", supported_conversions)
+    @pytest.mark.parametrize("transform_s_w", conversions_for_1d)
+    @pytest.mark.parametrize("transform_y_a", conversions_for_1d)
     def test_true_weight_length_mismatch(self, transform_y_a, transform_s_w):
         y_a = transform_y_a([0, 0, 1, 1, 0, 1, 1, 1])
         y_p = [0, 1, 1, 1, 1, 0, 0, 0]
@@ -282,10 +252,10 @@ class TestMakeGroupMetric:
         assert result.range == 1
         assert result.range_ratio == pytest.approx(0.66666666667)
 
-    @pytest.mark.parametrize("transform_s_w", supported_conversions)
-    @pytest.mark.parametrize("transform_gid", supported_conversions)
-    @pytest.mark.parametrize("transform_y_p", supported_conversions)
-    @pytest.mark.parametrize("transform_y_a", supported_conversions)
+    @pytest.mark.parametrize("transform_s_w", conversions_for_1d)
+    @pytest.mark.parametrize("transform_gid", conversions_for_1d)
+    @pytest.mark.parametrize("transform_y_p", conversions_for_1d)
+    @pytest.mark.parametrize("transform_y_a", conversions_for_1d)
     def test_keys_and_weights(self, transform_y_a, transform_y_p, transform_gid, transform_s_w):
         a = "ABC"
         b = "DEF"

--- a/test/unit/reductions/__init__.py
+++ b/test/unit/reductions/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.

--- a/test/unit/reductions/exponentiated_gradient/__init__.py
+++ b/test/unit/reductions/exponentiated_gradient/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.

--- a/test/unit/reductions/exponentiated_gradient/simple_learners.py
+++ b/test/unit/reductions/exponentiated_gradient/simple_learners.py
@@ -17,7 +17,7 @@ class LeastSquaresBinaryClassifierLearner:
         self.weights = pd.Series(self.lsqinfo[0], index=list(X))
 
     def predict(self, X):
-        pred = X.dot(self.weights)
+        pred = X.dot(np.asarray(self.weights))
         return 1 * (pred > 0.5)
 
 

--- a/test/unit/reductions/exponentiated_gradient/test_expgrad_arguments.py
+++ b/test/unit/reductions/exponentiated_gradient/test_expgrad_arguments.py
@@ -1,0 +1,60 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import pandas as pd
+import pytest
+
+
+from fairlearn.reductions import ExponentiatedGradient
+from fairlearn.reductions import DemographicParity
+from fairlearn.reductions import ErrorRate
+from .simple_learners import LeastSquaresBinaryClassifierLearner
+from .test_utilities import sensitive_features, X1, X2, X3, labels
+
+from test.unit.input_convertors import conversions_for_1d, ensure_ndarray, ensure_dataframe
+
+# ===============================================================
+
+# Ways of transforming the data
+candidate_X_transforms = [ensure_ndarray, ensure_dataframe]
+candidate_Y_transforms = conversions_for_1d
+candidate_A_transforms = conversions_for_1d
+
+# ================================================================
+
+
+class TestExpGradArguments:
+    def setup_method(self, method):
+        self.X = pd.DataFrame({"X1": X1, "X2": X2, "X3": X3})
+        self.y = pd.Series(labels)
+        self.A = pd.Series(sensitive_features)
+        self.learner = LeastSquaresBinaryClassifierLearner()
+        self._PRECISION = 1e-6
+
+    @pytest.mark.parametrize("transformA", candidate_A_transforms)
+    @pytest.mark.parametrize("transformY", candidate_Y_transforms)
+    @pytest.mark.parametrize("transformX", candidate_X_transforms)
+    def test_argument_types(self, transformX, transformY, transformA):
+        # This is an expanded-out version of one of the smoke tests
+        expgrad = ExponentiatedGradient(self.learner, constraints=DemographicParity(),
+                                        eps=0.1)
+        expgrad.fit(transformX(self.X), transformY(self.y), sensitive_features=transformA(self.A))
+
+        res = expgrad._expgrad_result._as_dict()
+        Q = res["best_classifier"]
+        res["n_classifiers"] = len(res["classifiers"])
+
+        disp = DemographicParity()
+        disp.load_data(self.X, self.y, sensitive_features=self.A)
+        error = ErrorRate()
+        error.load_data(self.X, self.y, sensitive_features=self.A)
+        res["disp"] = disp.gamma(Q).max()
+        res["error"] = error.gamma(Q)[0]
+
+        assert res["best_gap"] == pytest.approx(0.0000, abs=self._PRECISION)
+        assert res["last_t"] == 5
+        assert res["best_t"] == 5
+        assert res["disp"] == pytest.approx(0.1, abs=self._PRECISION)
+        assert res["error"] == pytest.approx(0.25, abs=self._PRECISION)
+        assert res["n_oracle_calls"] == 32
+        assert res["n_classifiers"] == 3

--- a/test/unit/reductions/exponentiated_gradient/test_expgrad_smoke.py
+++ b/test/unit/reductions/exponentiated_gradient/test_expgrad_smoke.py
@@ -8,8 +8,8 @@ import pytest
 from fairlearn.reductions import ExponentiatedGradient
 from fairlearn.reductions import DemographicParity, EqualizedOdds
 from fairlearn.reductions import ErrorRate
-from simple_learners import LeastSquaresBinaryClassifierLearner
-from test_utilities import sensitive_features, X1, X2, X3, labels
+from .simple_learners import LeastSquaresBinaryClassifierLearner
+from .test_utilities import sensitive_features, X1, X2, X3, labels
 
 
 class TestExpgradSmoke:

--- a/test/unit/reductions/grid_search/__init__.py
+++ b/test/unit/reductions/grid_search/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.

--- a/test/unit/reductions/grid_search/test_grid_search_arguments.py
+++ b/test/unit/reductions/grid_search/test_grid_search_arguments.py
@@ -12,47 +12,15 @@ from fairlearn.reductions import GridSearch
 from fairlearn.reductions import DemographicParity, EqualizedOdds
 from fairlearn.reductions import GroupLossMoment, ZeroOneLoss
 
+from test.unit.input_convertors import conversions_for_1d, ensure_ndarray, ensure_dataframe
+
 # ==============================================================
-
-# The following are functions which convert ndarrays into other datatypes
-# They are used to generate different argument types for calls to
-# GridSearch
-
-
-def identity(X):
-    return X
-
-
-def pylist(X):
-    return X.tolist()
-
-
-def pandasdf(X):
-    return pd.DataFrame(X)
-
-
-def pandasseries(X):
-    # Will not work if ndarray has more than one dimension
-    return pd.Series(X)
-
-
-def ndarray2d(X):
-    # Adds a second dimension of length 1 onto a 1D
-    # array. This is for checking that shapes n and
-    # n*1 behave the same
-    if len(X.shape) != 1:
-        raise RuntimeError("ndarray2d requires 1d ndarray")
-
-    X = np.expand_dims(X, 1)
-    assert len(X.shape) == 2
-    return X
-
 
 # List the different datatypes which need to succeed for
 # all GridSearch calls
-candidate_X_transforms = [identity, pandasdf]
-candidate_Y_transforms = [identity, pylist, pandasdf, pandasseries, ndarray2d]
-candidate_A_transforms = [identity, pylist, pandasdf, pandasseries, ndarray2d]
+candidate_X_transforms = [ensure_ndarray, ensure_dataframe]
+candidate_Y_transforms = conversions_for_1d
+candidate_A_transforms = conversions_for_1d
 
 
 # Base class for tests


### PR DESCRIPTION
Create and use a standard set of convertors for use with our 'argument type' tests. This has required adding several `__init__.py` files to the `test` directory to enable `pytest` to find the common code.

Also add an 'argument type' test to `ExponentiatedGradient`