### PR TITLE
Add more flake8 checks

### DIFF
--- a/fairlearn/__init__.py
+++ b/fairlearn/__init__.py
@@ -1,9 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-"""The fairlearn package contains a number of tools for analyzing and mitigating disparity in
-Machine Learning models.
-"""
+"""Tools for analyzing and mitigating disparity in Machine Learning models."""
 
 import os
 import sys
@@ -50,7 +48,7 @@ if fairlearn_logs is not None:
     logger.addHandler(handler)
     logger.info('Initializing logging file for fairlearn')
 
-    def close_handler():
+    def close_handler():  # noqa: D103
         handler.close()
         logger.removeHandler(handler)
     atexit.register(close_handler)

--- a/fairlearn/exceptions.py
+++ b/fairlearn/exceptions.py
@@ -3,5 +3,4 @@
 
 
 class NotFittedException(ValueError):
-    """ Exception to use if predict is called before fit.
-    """
+    """Exception to use if predict is called before fit."""

--- a/fairlearn/metrics/__init__.py
+++ b/fairlearn/metrics/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+# noqa: RST902
+
 """Functionality for computing metrics, with a particular focus on group metrics.
 
 For our purpose, a metric is a function with signature
@@ -130,4 +132,4 @@ _engine = [
 ]
 
 
-__all__ = _engine + _extra_metrics + _group_metrics  # noqa: RST902
+__all__ = _engine + _extra_metrics + _group_metrics

--- a/fairlearn/metrics/__init__.py
+++ b/fairlearn/metrics/__init__.py
@@ -1,8 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-"""This module contains the functionality for computing metrics, with a
-particular focus on group metrics.
+"""Functionality for computing metrics, with a particular focus on group metrics.
 
 For our purpose, a metric is a function with signature
 ``f(y_true, y_pred, ....)``
@@ -131,4 +130,4 @@ _engine = [
 ]
 
 
-__all__ = _engine + _extra_metrics + _group_metrics
+__all__ = _engine + _extra_metrics + _group_metrics  # noqa: RST902

--- a/fairlearn/metrics/__init__.py
+++ b/fairlearn/metrics/__init__.py
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-# noqa: RST902
-
 """Functionality for computing metrics, with a particular focus on group metrics.
 
 For our purpose, a metric is a function with signature

--- a/fairlearn/metrics/_balanced_root_mean_squared_error.py
+++ b/fairlearn/metrics/_balanced_root_mean_squared_error.py
@@ -16,7 +16,7 @@ def balanced_root_mean_squared_error(y_true, y_pred, sample_weight=None):
     Used for binary logistic regression, this computes the error as
 
     .. math::
-       \frac{RMSE(Y=0) + RMSE(Y=1)}{2}
+       \frac{\text{RMSE}(Y=0) + \text{RMSE}(Y=1)}{2}
 
     The classes are constrained to be :math:`\in {0, 1}`. The :code:`y_true` values must
     always be one of these, while :code:`y_pred` can be a continuous probability

--- a/fairlearn/metrics/_balanced_root_mean_squared_error.py
+++ b/fairlearn/metrics/_balanced_root_mean_squared_error.py
@@ -11,17 +11,20 @@ _Y_TRUE_NOT_0_1 = "Only 0 and 1 are allowed in y_true and both must be present"
 
 
 def balanced_root_mean_squared_error(y_true, y_pred, sample_weight=None):
-    """
+    r"""The mean of the root mean squared error (RMSE) for the positive and negative cases.
+
     Used for binary logistic regression, this computes the error as
-    [RMSE(Y=0) + RMSE(Y=1)]/2
-    The classes are constrained to be {0, 1}. The `y_true` values must
-    always be one of these, while `y_pred` can be a continuous probability
+
+    .. math::
+       \frac{RMSE(Y=0) + RMSE(Y=1)}{2}
+
+    The classes are constrained to be :math:`\in {0, 1}`. The :code:`y_true` values must
+    always be one of these, while :code:`y_pred` can be a continuous probability
     (which could be thresholded to get a predicted class).
 
     Internally, this builds on the
     :any:`sklearn.metrics.mean_squared_error` routine.
     """
-
     y_ta = _convert_to_ndarray_and_squeeze(y_true)
     y_pa = _convert_to_ndarray_and_squeeze(y_pred)
     s_w = np.ones(len(y_ta))

--- a/fairlearn/metrics/_extra_metrics.py
+++ b/fairlearn/metrics/_extra_metrics.py
@@ -1,8 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-"""This module contains a variety of extra metrics which are useful for assessing fairness
-which are not available as part of scikit-learn.
+"""A variety of extra metrics useful for assessing fairness.
+
+These are metrics which are not part of `scikit-learn`.
 """
 
 import sklearn.metrics as skm
@@ -13,10 +14,10 @@ from ._selection_rate import selection_rate  # noqa: F401,E501
 
 
 def specificity_score(y_true, y_pred, sample_weight=None):
-    """
-    The specificity score is also known as the True Negative Rate.
+    r"""The specificity score is also known as the True Negative Rate.
+
     At the present time, this routine only supports binary
-    classifiers with labels taken from {0, 1}.
+    classifiers with labels :math:`\in {0, 1}`.
     The calculation uses the :any:`sklearn.metrics.confusion_matrix` routine.
     """
     cm = skm.confusion_matrix(y_true, y_pred, sample_weight=sample_weight)
@@ -28,10 +29,10 @@ def specificity_score(y_true, y_pred, sample_weight=None):
 
 
 def miss_rate(y_true, y_pred, sample_weight=None):
-    """
-    The miss rate is also known as the False Negative Rate.
+    r"""The miss rate is also known as the False Negative Rate.
+
     At the present time, this routine only supports binary
-    classifiers with labels taken from {0, 1}.
+    classifiers with labels :math:`\in {0, 1}`.
     By definition, this is the complement of the True Positive
     Rate, so this routine uses the
     :any:`sklearn.metrics.recall_score` routine.
@@ -44,10 +45,10 @@ def miss_rate(y_true, y_pred, sample_weight=None):
 
 
 def fallout_rate(y_true, y_pred, sample_weight=None):
-    """
-    The fallout rate is also known as the False Positive Rate.
+    r"""The fallout rate is also known as the False Positive Rate.
+
     At the present time, this routine only supports binary
-    classifiers with labels taken from {0, 1}.
+    classifiers with labels :math:`\in {0, 1}`.
     By definition, this is the complement of the
     Specificity, and so uses :any:`specificity_score` in its
     calculation.

--- a/fairlearn/metrics/_group_metric_result.py
+++ b/fairlearn/metrics/_group_metric_result.py
@@ -3,8 +3,10 @@
 
 
 class GroupMetricResult:
-    """Class to hold the result of a grouped metric, produced by calling
-    the :func:`metric_by_group` function.
+    """Class to hold the result of a grouped metric.
+
+    Grouped metrics are produced by the :func:`metric_by_group`
+    function.
     """
 
     def __init__(self):
@@ -28,9 +30,7 @@ class GroupMetricResult:
 
     @property
     def overall(self):
-        """Gets the value of the metric calculated
-        over the entire dataset
-        """
+        """The metric calculated over the entire dataset."""
         return self._overall
 
     @overall.setter
@@ -39,8 +39,8 @@ class GroupMetricResult:
 
     @property
     def by_group(self):
-        """Gets the value of the metric calculated for each sub-group
-        in the dataset.
+        """The metric calculated for each sub-group in the dataset.
+
         This is a dictionary whose keys are the unique members of
         the ``group_membership`` data. The corresponding values are
         the result of applying the metric function to the set of
@@ -54,9 +54,9 @@ class GroupMetricResult:
 
     @property
     def minimum(self):
-        """Gets the minimum value of the metric found in the
-        ``by_group`` dictionary, if the value is a scalar.
-        Otherwise, this will not be set.
+        """The minimum value of the metric in the ``by_group`` dictionary.
+
+        This is only set if the metric is a scalar.
         """
         return self._minimum
 
@@ -66,9 +66,9 @@ class GroupMetricResult:
 
     @property
     def maximum(self):
-        """Gets the maxumum value of the metric found in the
-        ``by_group`` dictionary, if the values is a scalar.
-        Otherwise, this will not be set
+        """The maximum value of the metric in the ``by_group`` dictionary.
+
+        This is only set if the metric is a scalar.
         """
         return self._maximum
 
@@ -78,10 +78,10 @@ class GroupMetricResult:
 
     @property
     def argmin_set(self):
-        """If ``minimum`` is set, this is the set of
-        groups (that is, keys in the ``by_group``
-        dictionary) corresponding to the minimum value
-        of the metric.
+        """The set of groups corresponding to the ``minimum``.
+
+        This is only set if the metric is a scalar, and will be
+        a set of keys to tbe ``by_group`` dictionary.
         """
         return self._argmin_set
 
@@ -91,10 +91,10 @@ class GroupMetricResult:
 
     @property
     def argmax_set(self):
-        """If ``maximum`` is set, this is the set of
-        groups (that is, keys in the ``by_group``
-        dictionary) corresponding to the maximum value
-        of the metric.
+        """The set of groups corresponding to the ``minimum``.
+
+        This is only set if the metric is a scalar, and will be
+        a set of keys to tbe ``by_group`` dictionary.
         """
         return self._argmax_set
 
@@ -102,21 +102,23 @@ class GroupMetricResult:
     def argmax_set(self, value):
         self._argmax_set = value
 
-    @property
+    @property  # noqa: A003
     def range(self):
-        """If ``maximum`` and ``minimum`` are set, this
-        will be set to the difference between them
+        """The value of :code:`maximum-minimum`.
+
+        This is only set if the metric is a scalar.
         """
         return self._range
 
-    @range.setter
+    @range.setter  # noqa: A003
     def range(self, value):
         self._range = value
 
     @property
     def range_ratio(self):
-        """If ``maximum`` and ``minimum`` are set, this
-        will be set to the ratio ``minimum/maximum``
+        """The value of :code:`minimum/maximum`.
+
+        This is only set if the metric is a scalar.
         """
         return self._range_ratio
 

--- a/fairlearn/metrics/_input_manipulations.py
+++ b/fairlearn/metrics/_input_manipulations.py
@@ -4,11 +4,12 @@
 import numpy as np
 
 
-def _convert_to_ndarray_and_squeeze(input):
-    """Converts to a numpy.ndarray and calls squeeze (to dispose of unit length dimensions),
-    with a special case to stop single element arrays being converted to scalars.
+def _convert_to_ndarray_and_squeeze(target):
+    """Converts to a `numpy.ndarray` and calls squeeze (to dispose of unit length dimensions).
+
+    There is a special case to stop single element arrays being converted to scalars.
     """
-    result = np.asarray(input)
+    result = np.asarray(target)
 
     if result.size > 1:
         result = np.squeeze(result)

--- a/fairlearn/metrics/_mean_predictions.py
+++ b/fairlearn/metrics/_mean_predictions.py
@@ -7,11 +7,11 @@ from ._input_manipulations import _convert_to_ndarray_and_squeeze
 
 
 def mean_prediction(y_true, y_pred, sample_weight=None):
-    """Returns the (weighted) mean prediction. The true
-    values are ignored, but required as an argument in order
+    """Returns the (weighted) mean prediction.
+
+    The true values are ignored, but required as an argument in order
     to maintain a consistent interface
     """
-
     y_p = _convert_to_ndarray_and_squeeze(y_pred)
     s_w = np.ones(len(y_p))
     if sample_weight is not None:
@@ -21,11 +21,11 @@ def mean_prediction(y_true, y_pred, sample_weight=None):
 
 
 def mean_overprediction(y_true, y_pred, sample_weight=None):
-    """Returns the (weighted) mean overprediction. That is
-    the (weighted) mean of the error where any negative errors
-    (i.e. underpredictions) are set to zero
-    """
+    """Returns the (weighted) mean overprediction.
 
+    This is the (weighted) mean of the error where any negative
+    errors (i.e. underpredictions) are set to zero
+    """
     y_t = _convert_to_ndarray_and_squeeze(y_true)
     y_p = _convert_to_ndarray_and_squeeze(y_pred)
     s_w = np.ones(len(y_p))
@@ -39,9 +39,12 @@ def mean_overprediction(y_true, y_pred, sample_weight=None):
 
 
 def mean_underprediction(y_true, y_pred, sample_weight=None):
-    """Returns the (weighted) mean underprediction. That is
-    the (weighted) mean of the error where any positive errors
-    (i.e. overpredictions) are set to zero
+    """Returns the (weighted) mean underprediction.
+
+    This is the (weighted) mean of the error where any
+    positive errors (i.e. overpredictions) are set to zero.
+    The absolute value of the underpredictions is used, so the
+    returned value is always positive.
     """
     y_t = _convert_to_ndarray_and_squeeze(y_true)
     y_p = _convert_to_ndarray_and_squeeze(y_pred)

--- a/fairlearn/metrics/_metrics_engine.py
+++ b/fairlearn/metrics/_metrics_engine.py
@@ -10,7 +10,7 @@ _MESSAGE_SIZE_MISMATCH = "Array {0} is not the same size as {1}"
 
 
 def metric_by_group(metric_function, y_true, y_pred, group_membership, sample_weight=None):
-    """ Applies a metric to each subgroup of a set of data
+    """Applies a metric to each subgroup of a set of data.
 
     :param metric_function: Function with signature ``(y_true, y_pred, sample_weight=None)``
      which returns a scalar
@@ -91,7 +91,7 @@ def metric_by_group(metric_function, y_true, y_pred, group_membership, sample_we
 
 
 def make_group_metric(metric_function):
-    """Function to turn a regular metric into a grouped metric
+    """Function to turn a regular metric into a grouped metric.
 
     :param metric_function: The function to be wrapped. This must have signature
         ``(y_true, y_pred, sample_weight)``

--- a/fairlearn/metrics/_selection_rate.py
+++ b/fairlearn/metrics/_selection_rate.py
@@ -7,9 +7,9 @@ from ._metrics_engine import metric_by_group
 
 
 def selection_rate(y_true, y_pred, *, pos_label=1, sample_weight=None):
-    """
-    The selection rate is the fraction of predicted labels which
-    match the 'good' outcome (as specified by `pos_label`)
+    """The fraction of predicted labels matching the 'good' outcome.
+
+    The argument `pos_label` specifies the 'good' outcome.
     """
     selected = (np.squeeze(np.asarray(y_pred)) == pos_label)
     s_w = np.ones(len(selected))
@@ -22,10 +22,10 @@ def selection_rate(y_true, y_pred, *, pos_label=1, sample_weight=None):
 def group_selection_rate(y_true, y_pred, group_membership,
                          *, pos_label=1, sample_weight=None):
     """This is the grouped version of :func:`selection_rate`.
+
     The arguments are the same, with the addition of the
     `group_membership` array.
     """
-
     def internal_sel_wrapper(y_true, y_pred, sample_weight=None):
         return selection_rate(y_true, y_pred, pos_label=pos_label, sample_weight=sample_weight)
 

--- a/fairlearn/metrics/_skm_wrappers.py
+++ b/fairlearn/metrics/_skm_wrappers.py
@@ -10,12 +10,12 @@ def group_accuracy_score(y_true, y_pred, group_membership, *,
                          normalize=True,
                          sample_weight=None):
     """A wrapper around the :any:`sklearn.metrics.accuracy_score` routine.
+
     The arguments remain the same, with `group_membership` added.
     However, the only positional arguments supported are `y_true`,
     `y_pred` and `group_membership`.
     All others must be specified by name.
     """
-
     def internal_acc_wrapper(y_true, y_pred, sample_weight=None):
         return skm.accuracy_score(y_true, y_pred,
                                   normalize,
@@ -28,12 +28,12 @@ def group_confusion_matrix(y_true, y_pred, group_membership, *,
                            labels=None,
                            sample_weight=None):
     """A wrapper around the :any:`sklearn.metrics.confusion_matrix` routine.
+
     The arguments remain the same, with `group_membership` added.
     However, the only positional arguments supported are `y_true`,
     `y_pred` and `group_membership`.
     All others must be specified by name.
     """
-
     def internal_cm_wrapper(y_true, y_pred, sample_weight=None):
         return skm.confusion_matrix(y_true, y_pred,
                                     labels,
@@ -46,12 +46,12 @@ def group_precision_score(y_true, y_pred, group_membership, *,
                           labels=None, pos_label=1, average='binary',
                           sample_weight=None):
     """A wrapper around the :any:`sklearn.metrics.precision_score` routine.
+
     The arguments remain the same, with `group_membership` added.
     However, the only positional arguments supported are `y_true`,
     `y_pred` and `group_membership`.
     All others must be specified by name.
     """
-
     def internal_prec_wrapper(y_true, y_pred, sample_weight=None):
         return skm.precision_score(y_true, y_pred,
                                    labels=labels, pos_label=pos_label, average=average,
@@ -64,12 +64,12 @@ def group_recall_score(y_true, y_pred, group_membership, *,
                        labels=None, pos_label=1, average='binary',
                        sample_weight=None):
     """A wrapper around the :any:`sklearn.metrics.recall_score` routine.
+
     The arguments remain the same, with `group_membership` added.
     However, the only positional arguments supported are `y_true`,
     `y_pred` and `group_membership`.
     All others must be specified by name.
     """
-
     def internal_recall_wrapper(y_true, y_pred, sample_weight=None):
         return skm.recall_score(y_true, y_pred,
                                 labels=labels, pos_label=pos_label, average=average,
@@ -83,12 +83,12 @@ def group_roc_auc_score(y_true, y_pred, group_membership, *,
                         average='macro', max_fpr=None,
                         sample_weight=None):
     """A wrapper around the :any:`sklearn.metrics.roc_auc_score` routine.
+
     The arguments remain the same, with `group_membership` added.
     However, the only positional arguments supported are `y_true`,
     `y_pred` and `group_membership`.
     All others must be specified by name.
     """
-
     def internal_ras_wrapper(y_true, y_pred, sample_weight=None):
         return skm.roc_auc_score(y_true, y_pred,
                                  average=average, max_fpr=max_fpr,
@@ -102,12 +102,12 @@ def group_zero_one_loss(y_true, y_pred, group_membership, *,
                         normalize=True,
                         sample_weight=None):
     """A wrapper around the :any:`sklearn.metrics.zero_one_loss` routine.
+
     The arguments remain the same, with `group_membership` added.
     However, the only positional arguments supported are `y_true`,
     `y_pred` and `group_membership`.
     All others must be specified by name.
     """
-
     def internal_zol_wrapper(y_true, y_pred, sample_weight=None):
         return skm.zero_one_loss(y_true, y_pred,
                                  normalize=normalize,
@@ -122,12 +122,12 @@ def group_mean_squared_error(y_true, y_pred, group_membership, *,
                              multioutput='uniform_average',
                              sample_weight=None):
     """A wrapper around the :any:`sklearn.metrics.mean_squared_error` routine.
+
     The arguments remain the same, with `group_membership` added.
     However, the only positional arguments supported are `y_true`,
     `y_pred` and `group_membership`.
     All others must be specified by name.
     """
-
     def internal_mse_wrapper(y_true, y_pred, sample_weight=None):
         return skm.mean_squared_error(y_true, y_pred,
                                       multioutput=multioutput,
@@ -141,13 +141,13 @@ def group_root_mean_squared_error(y_true, y_pred, group_membership, *,
                                   multioutput='uniform_average',
                                   sample_weight=None):
     """A wrapper around the :any:`sklearn.metrics.mean_squared_error` routine.
+
     The arguments remain the same, with `group_membership` added.
     The result is then square rooted.
     However, the only positional arguments supported are `y_true`,
     `y_pred` and `group_membership`.
     All others must be specified by name.
     """
-
     def internal_rmse_wrapper(y_true, y_pred, sample_weight=None):
         return sqrt(skm.mean_squared_error(y_true, y_pred,
                                            multioutput=multioutput,
@@ -161,12 +161,12 @@ def group_r2_score(y_true, y_pred, group_membership, *,
                    multioutput='uniform_average',
                    sample_weight=None):
     """A wrapper around the :any:`sklearn.metrics.r2_score` routine.
+
     The arguments remain the same, with `group_membership` added.
     However, the only positional arguments supported are `y_true`,
     `y_pred` and `group_membership`.
     All others must be specified by name.
     """
-
     def internal_r2_wrapper(y_true, y_pred, sample_weight=None):
         return skm.r2_score(y_true, y_pred,
                             multioutput=multioutput,

--- a/fairlearn/postprocessing/__init__.py
+++ b/fairlearn/postprocessing/__init__.py
@@ -1,9 +1,10 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-"""This module contains methods which operate on a predictor, rather than an estimator. The
-predictor's output is adjusted to fulfill specified parity constraints. The postprocessors learn
-how exactly to adjust the predictor's output from the training data.
+"""This module contains methods which operate on a predictor, rather than an estimator.
+
+The predictor's output is adjusted to fulfill specified parity constraints. The postprocessors
+learn how to adjust the predictor's output from the training data.
 """
 
 from ._postprocessing import PostProcessing  # noqa: F401

--- a/fairlearn/postprocessing/_curve_plotting_utilities.py
+++ b/fairlearn/postprocessing/_curve_plotting_utilities.py
@@ -1,8 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-""" Utilities for plotting curves
-"""
+"""Utilities for plotting curves."""
 
 import matplotlib.pyplot as plt
 import matplotlib.cm as cm

--- a/fairlearn/postprocessing/_interpolated_prediction.py
+++ b/fairlearn/postprocessing/_interpolated_prediction.py
@@ -32,12 +32,12 @@ class InterpolatedPredictor:
         self._p1 = p1
 
         logger.debug(OUTPUT_SEPARATOR)
-        logger.debug("p_ignore: {}", p_ignore)
-        logger.debug("prediction_constant: {}", prediction_constant)
-        logger.debug("p0: {}", p0)
-        logger.debug("operation0: {}", operation0)
-        logger.debug("p1: {}", p1)
-        logger.debug("operation1: {}", operation1)
+        logger.debug("p_ignore: %s", p_ignore)
+        logger.debug("prediction_constant: %s", prediction_constant)
+        logger.debug("p0: %s", p0)
+        logger.debug("operation0: %s", operation0)
+        logger.debug("p1: %s", p1)
+        logger.debug("operation1: %s", operation1)
         logger.debug(OUTPUT_SEPARATOR)
 
     def __repr__(self):  # noqa: D105

--- a/fairlearn/postprocessing/_interpolated_prediction.py
+++ b/fairlearn/postprocessing/_interpolated_prediction.py
@@ -9,8 +9,9 @@ logger = logging.getLogger(__name__)
 
 class InterpolatedPredictor:
     def __init__(self, p_ignore, prediction_constant, p0, operation0, p1, operation1):
-        """ Creates the interpolated prediction between two predictions. The predictions
-        are represented through the threshold rules operation0 and operation1.
+        """Creates the interpolated prediction between two predictions.
+
+        The predictions are represented through the threshold rules operation0 and operation1.
 
         :param p_ignore: p_ignore changes the interpolated prediction P to the desired
             solution using the transformation p_ignore * prediction_constant + (1 - p_ignore) * P
@@ -31,22 +32,24 @@ class InterpolatedPredictor:
         self._p1 = p1
 
         logger.debug(OUTPUT_SEPARATOR)
-        logger.debug("p_ignore: {}".format(p_ignore))
-        logger.debug("prediction_constant: {}".format(prediction_constant))
-        logger.debug("p0: {}".format(p0))
-        logger.debug("operation0: {}".format(operation0))
-        logger.debug("p1: {}".format(p1))
-        logger.debug("operation1: {}".format(operation1))
+        logger.debug("p_ignore: {}", p_ignore)
+        logger.debug("prediction_constant: {}", prediction_constant)
+        logger.debug("p0: {}", p0)
+        logger.debug("operation0: {}", operation0)
+        logger.debug("p1: {}", p1)
+        logger.debug("operation1: {}", operation1)
         logger.debug(OUTPUT_SEPARATOR)
 
-    def __repr__(self):
+    def __repr__(self):  # noqa: D105
         return "[p_ignore: {}, prediction_constant: {}, " \
             "p0: {}, operation0: {}, p1: {}, operation1: {}]" \
             .format(self._p_ignore, self._prediction_constant, self._p0, self._operation0,
                     self._p1, self._operation1)
 
     def predict(self, scores):
-        """ Creates the interpolated prediction based on two threshold operations and the
+        """Creates the interpolated prediction.
+
+        The interpolation is based on two threshold operations and the
         transformation adjustment.
 
         :param scores: the scores from an unconstrained predictor to which the threshold

--- a/fairlearn/postprocessing/_postprocessing.py
+++ b/fairlearn/postprocessing/_postprocessing.py
@@ -10,7 +10,7 @@ MISSING_PREDICT_ERROR_MESSAGE = "The predictor does not have a callable 'predict
 
 
 class PostProcessing:
-    """Abstract base class for postprocessing approaches for disparity mitigation
+    """Abstract base class for postprocessing approaches for disparity mitigation.
 
     :param unconstrained_predictor: a predictor with a `predict` function that has already been
         trained on the training data; the predictor will subsequently be used in the mitigator
@@ -23,6 +23,7 @@ class PostProcessing:
     :param constraints: the parity constraints to be enforced represented as a string
     :type constraints: str
     """
+
     def __init__(self, *, unconstrained_predictor=None, estimator=None,
                  constraints=None):
         if unconstrained_predictor and estimator:
@@ -39,9 +40,12 @@ class PostProcessing:
             raise ValueError(PREDICTOR_OR_ESTIMATOR_REQUIRED_ERROR_MESSAGE)
 
     def fit(self, X, y, *, sensitive_features, **kwargs):
-        """ Fit the model based on training features and labels, sensitive features,
+        """Fits the model.
+
+        The fit is based on training features and labels, sensitive features,
         as well as the fairness-unaware predictor or estimator. If an estimator was passed
-        in the constructor this fit method will call `fit(X, y, **kwargs)` on said estimator.
+        in the constructor this fit method will call :code:`fit(X, y, **kwargs)` on said
+        estimator.
 
         :param X: Feature matrix
         :type X: numpy.ndarray or pandas.DataFrame
@@ -55,7 +59,7 @@ class PostProcessing:
         raise NotImplementedError(self.fit.__name__ + " is not implemented")
 
     def predict(self, X, *, sensitive_features):
-        """ Predict label for each sample in X while taking into account sensitive features.
+        """Predict label for each sample in X while taking into account sensitive features.
 
         :param X: Feature matrix
         :type X: numpy.ndarray or pandas.DataFrame
@@ -68,7 +72,7 @@ class PostProcessing:
         raise NotImplementedError(self.predict.__name__ + " is not implemented")
 
     def _pmf_predict(self, X, *, sensitive_features):
-        """ Probabilistic mass function
+        """Probabilistic mass function.
 
         :param X: Feature matrix
         :type X: numpy.ndarray or pandas.DataFrame
@@ -83,15 +87,13 @@ class PostProcessing:
         raise NotImplementedError(self._pmf_predict.__name__ + " is not implemented")
 
     def _validate_predictor(self):
-        """ Validate that the _unconstrained_predictor member has a predict function.
-        """
+        """Validate that the _unconstrained_predictor member has a predict function."""
         predict_function = getattr(self._unconstrained_predictor, "predict", None)
         if not predict_function or not callable(predict_function):
             raise ValueError(MISSING_PREDICT_ERROR_MESSAGE)
 
     def _validate_estimator(self):
-        """ Validate that the `_estimator` member has both a fit and a predict function.
-        """
+        """Validate that the `_estimator` member has both a fit and a predict function."""
         fit_function = getattr(self._estimator, "fit", None)
         predict_function = getattr(self._estimator, "predict", None)
         if not predict_function or not fit_function or not callable(predict_function) or \

--- a/fairlearn/postprocessing/_roc_curve_utilities.py
+++ b/fairlearn/postprocessing/_roc_curve_utilities.py
@@ -11,7 +11,8 @@ DEGENERATE_LABELS_ERROR_MESSAGE = "Degenerate labels for sensitive feature value
 
 
 def _get_roc(data, sensitive_feature_value, flip=True):
-    """Get ROC curve's convex hull based on data columns 'score' and 'label'
+    """Get ROC curve's convex hull based on data columns 'score' and 'label'.
+
     Scores represent output values from the predictor.
 
     :param data: the DataFrame containing scores and labels
@@ -31,7 +32,9 @@ def _get_roc(data, sensitive_feature_value, flip=True):
 
 
 def _filter_points_to_get_convex_hull(roc_sorted):
-    """ Uses a simplified version of Andrew's monotone chain convex hull algorithm
+    """Finds the convex hull.
+
+    Uses a simplified version of Andrew's monotone chain convex hull algorithm
     https://en.wikibooks.org/wiki/Algorithm_Implementation/Geometry/Convex_hull/Monotone_chain
     to get the convex hull. Since we can assume the points (0,0) and (1,1) to be part
     of the convex hull the problem is simpler and we only need to make a single pass
@@ -68,6 +71,7 @@ def _filter_points_to_get_convex_hull(roc_sorted):
 
 def _interpolate_curve(data, x_col, y_col, content_col, x_grid):
     """Interpolates the DataFrame in `data` along the values in `x_grid`.
+
     Assumes: (1) data[y_col] is convex and non-decreasing in data[x_col]
              (2) min and max in x_grid are below/above min and max in data[x_col]
              (3) data is indexed 0,...,len(data)
@@ -120,7 +124,9 @@ def _interpolate_curve(data, x_col, y_col, content_col, x_grid):
 
 
 def _calculate_roc_points(data, sensitive_feature_value, flip=True):
-    """ Calculates the ROC points from the scores and labels by iterating through all possible
+    """Calculates the ROC points from the scores and labels.
+
+    This is done by iterating through all possible
     thresholds that could be set based on the available scores.
 
     :param data: the DataFrame containing scores and labels
@@ -176,8 +182,9 @@ def _calculate_roc_points(data, sensitive_feature_value, flip=True):
 
 
 def _get_scores_labels_and_counts(data):
-    """ Order samples by scores (ascending), and count the number of positive, negative, and
-    overall samples.
+    """Order samples by scores, counting number of positive, negative, and overall samples.
+
+    The samples are sorted into ascending order.
 
     :param data: the DataFrame containing scores and labels
     :type data: pandas.DataFrame
@@ -196,7 +203,7 @@ def _get_scores_labels_and_counts(data):
 
 
 def _get_counts(labels):
-    """ Returns the overall, positive, and negative counts of the labels.
+    """Returns the overall, positive, and negative counts of the labels.
 
     :param labels: the labels of the samples
     :type labels: list

--- a/fairlearn/postprocessing/_threshold_operation.py
+++ b/fairlearn/postprocessing/_threshold_operation.py
@@ -3,7 +3,8 @@
 
 
 class ThresholdOperation():
-    """ A class representing the threshold operations that are used in postprocessing approaches.
+    """Represents the threshold operations that are used in postprocessing approaches.
+
     Threshold operations simply indicate a threshold and an operator, thereby defining a function.
     The function can be evaluated at arbitrary points (usually the scores returned from
     unconstrained predictors) to return a bool value.
@@ -13,6 +14,7 @@ class ThresholdOperation():
     :param threshold: the threshold, can be numpy.inf or -numpy.inf
     :type threshold: float
     """
+
     def __init__(self, operator, threshold):
         if operator not in ['>', '<']:
             raise ValueError("Unrecognized operator: " + operator)
@@ -28,7 +30,7 @@ class ThresholdOperation():
         return self._operator
 
     def get_predictor_from_operation(self):
-        """ Encodes the threshold rule Y_hat > t or Y_hat < t
+        """Encodes the threshold rule `Y_hat > t` or `Y_hat < t`.
 
         :return: a function that takes a single argument to evaluate it against the threshold rule
         :rtype: lambda
@@ -40,5 +42,5 @@ class ThresholdOperation():
         else:
             raise ValueError("Unrecognized operator: " + self._operator)
 
-    def __repr__(self):
+    def __repr__(self):  # noqa: D105
         return "[{}{}]".format(self._operator, self._threshold)

--- a/fairlearn/postprocessing/_threshold_optimizer.py
+++ b/fairlearn/postprocessing/_threshold_optimizer.py
@@ -3,9 +3,9 @@
 
 """Threshold Optimization Post Processing algorithm.
 
-This is based on M. Hardt,
-E. Price, N. Srebro's paper "`Equality of Opportunity in Supervised
-Learning <https://arxiv.org/pdf/1610.02413.pdf>`_" for binary
+This is based on M. Hardt, E. Price, N. Srebro's paper
+"`Equality of Opportunity in Supervised Learning
+<https://arxiv.org/pdf/1610.02413.pdf>`_" for binary
 classification with one categorical sensitive feature.
 """
 

--- a/fairlearn/postprocessing/_threshold_optimizer.py
+++ b/fairlearn/postprocessing/_threshold_optimizer.py
@@ -275,7 +275,7 @@ def _threshold_optimization_demographic_parity(sensitive_features, labels, score
             selection_error_curve[sensitive_feature_value]['error']
 
         logger.debug(OUTPUT_SEPARATOR)
-        logger.debug("Processing {0}", str(sensitive_feature_value))
+        logger.debug("Processing {}", str(sensitive_feature_value))
         logger.debug(OUTPUT_SEPARATOR)
         logger.debug("DATA")
         logger.debug(group)
@@ -365,7 +365,7 @@ def _threshold_optimization_equalized_odds(sensitive_features, labels, scores, g
         y_values[sensitive_feature_value] = roc[sensitive_feature_value]['y']
 
         logger.debug(OUTPUT_SEPARATOR)
-        logger.debug("Processing {0}", str(sensitive_feature_value))
+        logger.debug("Processing {}", str(sensitive_feature_value))
         logger.debug(OUTPUT_SEPARATOR)
         logger.debug("DATA")
         logger.debug(group)

--- a/fairlearn/postprocessing/_threshold_optimizer.py
+++ b/fairlearn/postprocessing/_threshold_optimizer.py
@@ -275,7 +275,7 @@ def _threshold_optimization_demographic_parity(sensitive_features, labels, score
             selection_error_curve[sensitive_feature_value]['error']
 
         logger.debug(OUTPUT_SEPARATOR)
-        logger.debug("Processing {}", str(sensitive_feature_value))
+        logger.debug("Processing %s", str(sensitive_feature_value))
         logger.debug(OUTPUT_SEPARATOR)
         logger.debug("DATA")
         logger.debug(group)
@@ -306,7 +306,7 @@ def _threshold_optimization_demographic_parity(sensitive_features, labels, score
 
     logger.debug(OUTPUT_SEPARATOR)
     logger.debug("From ROC curves")
-    logger.debug("Best DP: error={0:.3f}, selection rate={1:.3f}",
+    logger.debug("Best DP: error=%.3f, selection rate=%.3f",
                  error_given_selection[i_best_DP], x_best)
     logger.debug(OUTPUT_SEPARATOR)
     if plot:
@@ -365,7 +365,7 @@ def _threshold_optimization_equalized_odds(sensitive_features, labels, scores, g
         y_values[sensitive_feature_value] = roc[sensitive_feature_value]['y']
 
         logger.debug(OUTPUT_SEPARATOR)
-        logger.debug("Processing {}", str(sensitive_feature_value))
+        logger.debug("Processing %s", str(sensitive_feature_value))
         logger.debug(OUTPUT_SEPARATOR)
         logger.debug("DATA")
         logger.debug(group)
@@ -413,7 +413,7 @@ def _threshold_optimization_equalized_odds(sensitive_features, labels, scores, g
 
     logger.debug(OUTPUT_SEPARATOR)
     logger.debug("From ROC curves")
-    logger.debug("Best EO: error={0:.3f}, FP rate={1:.3f}, TP rate={2:.3f}",
+    logger.debug("Best EO: error=%.3f}, FP rate=%.3f}, TP rate=%.3f}",
                  error_given_x[i_best_EO], x_best, y_best)
     logger.debug(OUTPUT_SEPARATOR)
     if plot:

--- a/fairlearn/postprocessing/_threshold_optimizer.py
+++ b/fairlearn/postprocessing/_threshold_optimizer.py
@@ -1,7 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-""" Threshold Optimization Post Processing algorithm based on M. Hardt,
+"""Threshold Optimization Post Processing algorithm.
+
+This is based on M. Hardt,
 E. Price, N. Srebro's paper "`Equality of Opportunity in Supervised
 Learning <https://arxiv.org/pdf/1610.02413.pdf>`_" for binary
 classification with one categorical sensitive feature.
@@ -44,7 +46,9 @@ logger = logging.getLogger(__name__)
 
 
 class ThresholdOptimizer(PostProcessing):
-    """An Estimator which implements the threshold optimization approach of
+    """An Estimator based on the threshold optimization approach.
+
+    The procedure followed is described in detail in
     `Hardt et al. (2016) <https://arxiv.org/abs/1610.02413>`_.
 
     :param unconstrained_predictor: The trained predictor whose output will be post processed
@@ -79,7 +83,9 @@ class ThresholdOptimizer(PostProcessing):
         self._post_processed_predictor_by_sensitive_feature = None
 
     def fit(self, X, y, *, sensitive_features, **kwargs):
-        """Fit the model based on training features and labels, sensitive features,
+        """Fit the model.
+
+        The fit is based on training features and labels, sensitive features,
         as well as the fairness-unaware predictor or estimator. If an estimator was passed
         in the constructor this fit method will call `fit(X, y, **kwargs)` on said estimator.
 
@@ -123,7 +129,7 @@ class ThresholdOptimizer(PostProcessing):
             sensitive_features, y, scores, self._grid_size, self._flip, self._plot)
 
     def predict(self, X, *, sensitive_features, random_state=None):
-        """ Predict label for each sample in X while taking into account sensitive features.
+        """Predict label for each sample in X while taking into account sensitive features.
 
         :param X: feature matrix
         :type X: numpy.ndarray or pandas.DataFrame
@@ -149,7 +155,7 @@ class ThresholdOptimizer(PostProcessing):
         return (positive_probs >= np.random.rand(len(positive_probs))) * 1
 
     def _pmf_predict(self, X, *, sensitive_features):
-        """ Probabilistic mass function
+        """Probabilistic mass function.
 
         :param X: Feature matrix
         :type X: numpy.ndarray or pandas.DataFrame
@@ -200,7 +206,9 @@ class ThresholdOptimizer(PostProcessing):
 
 def _threshold_optimization_demographic_parity(sensitive_features, labels, scores, grid_size=1000,
                                                flip=True, plot=False):
-    """ Calculates selection and error rates for every sensitive feature value at different
+    """Calculates selection and error rates for every sensitive feature value.
+
+    These calculations are made at different
     thresholds over the scores. Subsequently weighs each sensitive feature value's error by the
     frequency of the sensitive feature value in the data. The minimum error point is the selected
     solution, which is recreated by interpolating between two points on the convex hull of all
@@ -267,7 +275,7 @@ def _threshold_optimization_demographic_parity(sensitive_features, labels, score
             selection_error_curve[sensitive_feature_value]['error']
 
         logger.debug(OUTPUT_SEPARATOR)
-        logger.debug("Processing " + str(sensitive_feature_value))
+        logger.debug("Processing {0}", str(sensitive_feature_value))
         logger.debug(OUTPUT_SEPARATOR)
         logger.debug("DATA")
         logger.debug(group)
@@ -298,8 +306,8 @@ def _threshold_optimization_demographic_parity(sensitive_features, labels, score
 
     logger.debug(OUTPUT_SEPARATOR)
     logger.debug("From ROC curves")
-    logger.debug("Best DP: error={0:.3f}, selection rate={1:.3f}"
-                 .format(error_given_selection[i_best_DP], x_best))
+    logger.debug("Best DP: error={0:.3f}, selection rate={1:.3f}",
+                 error_given_selection[i_best_DP], x_best)
     logger.debug(OUTPUT_SEPARATOR)
     if plot:
         plot_solution_and_show_plot(
@@ -310,8 +318,9 @@ def _threshold_optimization_demographic_parity(sensitive_features, labels, score
 
 def _threshold_optimization_equalized_odds(sensitive_features, labels, scores, grid_size=1000,
                                            flip=True, plot=False):
-    """ Calculates the ROC curve of every sensitive feature value at different thresholds over the
-    scores. Subsequently takes the overlapping region of the ROC curves, and finds the best
+    """Calculates the ROC curve of every sensitive feature value at different thresholds.
+
+    Subsequently takes the overlapping region of the ROC curves, and finds the best
     solution by selecting the point on the curve with minimal error.
 
     This method assumes that sensitive_features, labels, and scores are non-empty data structures
@@ -356,7 +365,7 @@ def _threshold_optimization_equalized_odds(sensitive_features, labels, scores, g
         y_values[sensitive_feature_value] = roc[sensitive_feature_value]['y']
 
         logger.debug(OUTPUT_SEPARATOR)
-        logger.debug("Processing " + str(sensitive_feature_value))
+        logger.debug("Processing {0}", str(sensitive_feature_value))
         logger.debug(OUTPUT_SEPARATOR)
         logger.debug("DATA")
         logger.debug(group)
@@ -404,8 +413,8 @@ def _threshold_optimization_equalized_odds(sensitive_features, labels, scores, g
 
     logger.debug(OUTPUT_SEPARATOR)
     logger.debug("From ROC curves")
-    logger.debug("Best EO: error={0:.3f}, FP rate={1:.3f}, TP rate={2:.3f}"
-                 .format(error_given_x[i_best_EO], x_best, y_best))
+    logger.debug("Best EO: error={0:.3f}, FP rate={1:.3f}, TP rate={2:.3f}",
+                 error_given_x[i_best_EO], x_best, y_best)
     logger.debug(OUTPUT_SEPARATOR)
     if plot:
         plot_overlap(x_grid, y_min)
@@ -416,8 +425,10 @@ def _threshold_optimization_equalized_odds(sensitive_features, labels, scores, g
 
 
 def _vectorized_prediction(function_dict, sensitive_features, scores):
-    """ Make predictions for all samples with all provided functions, but use only the results
-    from the function that corresponds to the sensitive feature value of the sample.
+    """Make predictions for all samples with all provided functions.
+
+    However, only use the results from the function that corresponds to the
+    sensitive feature value of the sample.
 
     This method assumes that sensitive_features and scores are of equal length.
 
@@ -438,7 +449,7 @@ def _vectorized_prediction(function_dict, sensitive_features, scores):
 
 
 def _convert_to_ndarray(data, dataframe_multiple_columns_error_message):
-    """ Converts input data from list, pandas.Series, or pandas.DataFrame to numpy.ndarray.
+    """Converts input data from list, pandas.Series, or pandas.DataFrame to numpy.ndarray.
 
     :param data: the data to be converted into a numpy.ndarray
     :type data: numpy.ndarray, pandas.Series, pandas.DataFrame, or list
@@ -461,9 +472,11 @@ def _convert_to_ndarray(data, dataframe_multiple_columns_error_message):
 
 
 def _reformat_and_group_data(sensitive_features, labels, scores, sensitive_feature_names=None):
-    """ Reformats the provided three categories of data (`sensitive_features`, `labels`, `scores`)
-    into a newly created pandas.DataFrame. That DataFrame is grouped by sensitive feature values
-    so that subsequently each group can be handled separately.
+    """Reformats the data into a new pandas.DataFrame and group by sensitive feature values.
+
+    The data are provided as three arguments (`sensitive_features`, `labels`, `scores`) and
+    the new  DataFrame is grouped by sensitive feature values so that subsequently each group
+    can be handled separately.
 
     :param sensitive_features: the sensitive features based on which the grouping is determined;
         currently only a single sensitive feature is supported
@@ -498,8 +511,10 @@ def _reformat_and_group_data(sensitive_features, labels, scores, sensitive_featu
 
 
 def _reformat_data_into_dict(key, data_dict, additional_data):
-    """ Reformat `additional_data` into numpy.ndarray or list and add it to the provided
-    `data_dict` dictionary at the indicated `key`.
+    """Add `additional_data` to `data_dict` with key `key`.
+
+    Before `additional_data` is added to `data_dict` it is first
+    reformatted into a numpy.ndarray or list.
 
     :param key: the key in `data_dict` at which `additional_data` should be stored;
         `key` should describe the purpose of `additional_data` in `data_dict`

--- a/fairlearn/reductions/__init__.py
+++ b/fairlearn/reductions/__init__.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 """This module contains algorithms implementing the reductions approach to disparity mitigation.
+
 In this approach, disparity constraints are cast as Lagrange multipliers, which cause the
 reweighting and relabelling of the input data. This *reduces* the problem back to standard machine
 learning training.

--- a/fairlearn/reductions/_exponentiated_gradient/__init__.py
+++ b/fairlearn/reductions/_exponentiated_gradient/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+"""Package for Exponentiated Gradient."""
+
 from .exponentiated_gradient import ExponentiatedGradient  # noqa: F401
 from .exponentiated_gradient import ExponentiatedGradientResult  # noqa: F401
 

--- a/fairlearn/reductions/_exponentiated_gradient/_lagrangian.py
+++ b/fairlearn/reductions/_exponentiated_gradient/_lagrangian.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class _Lagrangian:
-    """ Operations related to the Lagrangian
+    """Operations related to the Lagrangian.
 
     :param X: the training features
     :type X: Array
@@ -55,7 +55,7 @@ class _Lagrangian:
         self.last_linprog_result = None
 
     def _eval_from_error_gamma(self, error, gamma, lambda_vec):
-        """ Return the value of the Lagrangian.
+        """Return the value of the Lagrangian.
 
         :return: tuple `(L, L_high)` where `L` is the value of the Lagrangian, and
             `L_high` is the value of the Lagrangian under the best response of the lambda player
@@ -74,7 +74,7 @@ class _Lagrangian:
         return L, L_high
 
     def _eval(self, h, lambda_vec):
-        """ Return the value of the Lagrangian.
+        """Return the value of the Lagrangian.
 
         :return: tuple `(L, L_high, gamma, error)` where `L` is the value of the Lagrangian,
             `L_high` is the value of the Lagrangian under the best response of the lambda player,
@@ -90,13 +90,12 @@ class _Lagrangian:
         return L, L_high, gamma, error
 
     def eval_gap(self, h, lambda_hat, nu):
-        """ Return the duality gap object for the given h and lambda_hat
-        """
+        r"""Return the duality gap object for the given :math:`h` and :math:`\hat{\lambda}`."""
         L, L_high, gamma, error = self._eval(h, lambda_hat)
         result = _GapResult(L, L, L_high, gamma, error)
         for mul in [1.0, 2.0, 5.0, 10.0]:
             h_hat, h_hat_idx = self.best_h(mul * lambda_hat)
-            logger.debug("%smul=%.0f" % (_INDENTATION, mul))
+            logger.debug("%smul=%.0f", _INDENTATION, mul)
             L_low_mul, _, _, _ = self._eval(
                 pd.Series({h_hat_idx: 1.0}), lambda_hat)
             if L_low_mul < result.L_low:
@@ -132,8 +131,10 @@ class _Lagrangian:
         return self.last_linprog_result
 
     def best_h(self, lambda_vec):
-        """Return the classifier that solves the best-response problem
-        for the vector of Lagrange multipliers lambda_vec.
+        """Solve the best-response problem.
+
+        Returns the classifier that solves the best-response problem for
+        the vector of Lagrange multipliers `lambda_vec`.
         """
         signed_weights = self.obj.signed_weights() + self.constraints.signed_weights(lambda_vec)
         redY = 1 * (signed_weights > 0)
@@ -158,7 +159,7 @@ class _Lagrangian:
             best_value = np.PINF
 
         if h_value < best_value - _PRECISION:
-            logger.debug("%sbest_h: val improvement %f" % (_LINE, best_value - h_value))
+            logger.debug("%sbest_h: val improvement %f", _LINE, best_value - h_value)
             h_idx = len(self.hs)
             self.hs.at[h_idx] = h
             self.classifiers.at[h_idx] = classifier
@@ -171,8 +172,7 @@ class _Lagrangian:
 
 
 class _GapResult:
-    """ The result of a duality gap computation
-    """
+    """The result of a duality gap computation."""
 
     def __init__(self, L, L_low, L_high, gamma, error):
         self.L = L

--- a/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
+++ b/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
@@ -39,19 +39,19 @@ class ExponentiatedGradientResult:
     def best_classifier(self):
         """The best classifier found by the algorithm.
 
-        A function that maps a DataFrame X containing covariates to a Series containing the
+        A function that maps a DataFrame `X` containing covariates to a Series containing the
         corresponding probabilistic decisions in :math:`[0,1]`
         """
         return self._best_classifier
 
     @property
     def best_gap(self):
-        """The quality of best_classifier.
+        """The quality of `best_classifier`.
 
-        If the algorithm has converged then `best_gap <= nu`;
-        the solution best_classifier is guaranteed to have the classification error within
-        `2*best_gap` of the best error under constraint eps; the constraint violation is at most
-        `2*(eps+best_gap)`
+        If the algorithm has converged then :code:`best_gap <= nu`;
+        the solution `best_classifier` is guaranteed to have the classification error within
+        :code:`2*best_gap` of the best error under constraint `eps`; the constraint violation
+        is at most :code:`2*(eps+best_gap)`
         """
         return self._best_gap
 
@@ -62,12 +62,12 @@ class ExponentiatedGradientResult:
 
     @property
     def weights(self):
-        """The weights of those classifiers within best_classifier."""
+        """The weights of those classifiers within `best_classifier`."""
         return self._weights
 
     @property
     def last_t(self):
-        """The last executed iteration; always `last_t < T`."""
+        """The last executed iteration; always :code:`last_t < T`."""
         return self._last_t
 
     @property
@@ -106,14 +106,14 @@ class ExponentiatedGradient(Reduction):
     :param constraints: The disparity constraints expressed as moments
     :type constraints: fairlearn.reductions.Moment
     :param eps: Allowed fairness constraint violation; the solution best_classifier is
-        guaranteed to have the classification error within `2*best_gap` of the best error
-        under constraint eps; the constraint violation is at most `2*(eps+best_gap)`
+        guaranteed to have the classification error within :code:`2*best_gap` of the best error
+        under constraint eps; the constraint violation is at most :code:`2*(eps+best_gap)`
     :type eps: float
     :param T: Maximum number of iterations
     :type T: int
     :param nu: Convergence threshold for the duality gap, corresponding to a
         conservative automatic setting based on the statistical uncertainty in measuring
-        classification error)
+        classification error
     :type nu: float
     :param eta_mul: Initial setting of the learning rate
     :type eta_mul: float

--- a/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
+++ b/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
@@ -1,10 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-"""This module implements the Lagrangian reduction of fair binary
-classification to standard binary classification.
-"""
-
 import logging
 import numpy as np
 import pandas as pd
@@ -18,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 def _mean_pred(X, hs, weights):
-    """Return a weighted average of predictions produced by classifiers in hs"""
+    """Return a weighted average of predictions produced by classifiers in `hs`."""
     pred = pd.DataFrame()
     for t in range(len(hs)):
         pred[t] = hs[t](X)
@@ -26,13 +22,11 @@ def _mean_pred(X, hs, weights):
 
 
 class ExponentiatedGradientResult:
-    """Class to hold the result of an ExponentiatedGradient estimator
-    """
+    """Class to hold the result of an `ExponentiatedGradient` estimator."""
 
     def __init__(self, best_classifier, best_gap, classifiers, weights, last_t, best_t,
                  n_oracle_calls):
-        """ Result object for the exponentiated gradient reduction operation.
-        """
+        """Result object for the exponentiated gradient reduction operation."""
         self._best_classifier = best_classifier
         self._best_gap = best_gap
         self._classifiers = classifiers
@@ -43,14 +37,18 @@ class ExponentiatedGradientResult:
 
     @property
     def best_classifier(self):
-        """ A function that maps a DataFrame X containing covariates to a Series containing the
+        """The best classifier found by the algorithm.
+
+        A function that maps a DataFrame X containing covariates to a Series containing the
         corresponding probabilistic decisions in :math:`[0,1]`
         """
         return self._best_classifier
 
     @property
     def best_gap(self):
-        """ The quality of best_classifier; if the algorithm has converged then `best_gap <= nu`;
+        """The quality of best_classifier.
+
+        If the algorithm has converged then `best_gap <= nu`;
         the solution best_classifier is guaranteed to have the classification error within
         `2*best_gap` of the best error under constraint eps; the constraint violation is at most
         `2*(eps+best_gap)`
@@ -59,32 +57,27 @@ class ExponentiatedGradientResult:
 
     @property
     def classifiers(self):
-        """ The base classifiers generated (instances of estimator).
-        """
+        """The base classifiers generated (instances of estimator)."""
         return self._classifiers
 
     @property
     def weights(self):
-        """ The weights of those classifiers within best_classifier.
-        """
+        """The weights of those classifiers within best_classifier."""
         return self._weights
 
     @property
     def last_t(self):
-        """ The last executed iteration; always `last_t < T`.
-        """
+        """The last executed iteration; always `last_t < T`."""
         return self._last_t
 
     @property
     def best_t(self):
-        """ The iteration in which best_classifier was obtained.
-        """
+        """The iteration in which best_classifier was obtained."""
         return self._best_t
 
     @property
     def n_oracle_calls(self):
-        """ The number of times the estimator was called.
-        """
+        """The number of times the estimator was called."""
         return self._n_oracle_calls
 
     def _as_dict(self):
@@ -100,8 +93,10 @@ class ExponentiatedGradientResult:
 
 
 class ExponentiatedGradient(Reduction):
-    """An Estimator which implements the exponentiated gradient approach to
-    reductions described by `Agarwal et al. (2018) <https://arxiv.org/abs/1803.02453>`_.
+    """An Estimator which implements the exponentiated gradient approach to reductions.
+
+    The exponentiated gradient algorithm is described in detail by
+    `Agarwal et al. (2018) <https://arxiv.org/abs/1803.02453>`_.
 
     :param estimator: An estimator implementing methods :code:`fit(X, y, sample_weight)` and
         :code:`predict(X)`, where `X` is the set of features, `y` is the set of labels, and
@@ -135,8 +130,7 @@ class ExponentiatedGradient(Reduction):
         self._classifiers = None
 
     def fit(self, X, y, **kwargs):
-        """ Return a fair classifier under specified fairness constraints via
-        exponentiated-gradient reduction.
+        """Return a fair classifier under specified fairness constraints.
 
         :param X: The array of training features
         :type X: Array
@@ -163,7 +157,7 @@ class ExponentiatedGradient(Reduction):
         last_regret_checked = _REGRET_CHECK_START_T
         last_gap = np.PINF
         for t in range(0, self._T):
-            logger.debug("...iter=%03d" % t)
+            logger.debug("...iter=%03d", t)
 
             # set lambdas for every constraint
             lambda_vec = B * np.exp(theta) / (1 + np.exp(theta).sum())
@@ -179,8 +173,8 @@ class ExponentiatedGradient(Reduction):
                     self._nu = _ACCURACY_MUL * (pred_h - y_train).abs().std() / np.sqrt(n)
                 eta_min = self._nu / (2 * B)
                 eta = self._eta_mul / B
-                logger.debug("...eps=%.3f, B=%.1f, nu=%.6f, T=%d, eta_min=%.6f"
-                             % (self._eps, B, self._nu, self._T, eta_min))
+                logger.debug("...eps=%.3f, B=%.1f, nu=%.6f, T=%d, eta_min=%.6f",
+                             self._eps, B, self._nu, self._T, eta_min)
 
             if h_idx not in Qsum.index:
                 Qsum.at[h_idx] = 0.0
@@ -208,11 +202,11 @@ class ExponentiatedGradient(Reduction):
                 gaps.append(gap_LP)
 
             logger.debug("%seta=%.6f, L_low=%.3f, L=%.3f, L_high=%.3f"
-                         ", gap=%.6f, disp=%.3f, err=%.3f, gap_LP=%.6f"
-                         % (_INDENTATION, eta, result_EG.L_low,
-                            result_EG.L, result_EG.L_high,
-                            gap_EG, result_EG.gamma.max(),
-                            result_EG.error, gap_LP))
+                         ", gap=%.6f, disp=%.3f, err=%.3f, gap_LP=%.6f",
+                         _INDENTATION, eta, result_EG.L_low,
+                         result_EG.L, result_EG.L_high,
+                         gap_EG, result_EG.gamma.max(),
+                         result_EG.error, gap_LP)
 
             if (gaps[t] < self._nu) and (t >= _MIN_T):
                 # solution found
@@ -237,8 +231,9 @@ class ExponentiatedGradient(Reduction):
 
     def predict(self, X):
         """Provide a prediction for the given input data.
+
         Note that this is non-deterministic, due to the nature of the
-        exponentiated gradient algorithm
+        exponentiated gradient algorithm.
 
         :param X: The data for which predictions are required
         :type X: Array
@@ -283,10 +278,10 @@ class ExponentiatedGradient(Reduction):
             best_t,
             lagrangian.n_oracle_calls)
 
-        logger.debug("...eps=%.3f, B=%.1f, nu=%.6f, T=%d, eta_min=%.6f"
-                     % (self._eps, B, self._nu, self._T, eta_min))
-        logger.debug("...last_t=%d, best_t=%d, best_gap=%.6f, n_oracle_calls=%d, n_hs=%d"
-                     % (last_t, best_t, best_gap, lagrangian.n_oracle_calls,
-                        len(lagrangian.classifiers)))
+        logger.debug("...eps=%.3f, B=%.1f, nu=%.6f, T=%d, eta_min=%.6f",
+                     self._eps, B, self._nu, self._T, eta_min)
+        logger.debug("...last_t=%d, best_t=%d, best_gap=%.6f, n_oracle_calls=%d, n_hs=%d",
+                     last_t, best_t, best_gap, lagrangian.n_oracle_calls,
+                     len(lagrangian.classifiers))
 
         return result

--- a/fairlearn/reductions/_grid_search/__init__.py
+++ b/fairlearn/reductions/_grid_search/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+"""Package for Grid Search."""
+
 from .grid_search_result import GridSearchResult  # noqa: F401
 from .grid_search import GridSearch  # noqa: F401
 

--- a/fairlearn/reductions/_grid_search/grid_search.py
+++ b/fairlearn/reductions/_grid_search/grid_search.py
@@ -204,7 +204,7 @@ class GridSearch(Reduction):
         objective_in_the_span = (self.constraints.default_objective_lambda_vec is not None)
 
         if self.grid is None:
-            logger.debug("Creating grid of size {0}", self.grid_size)
+            logger.debug("Creating grid of size %i", self.grid_size)
             grid = _GridGenerator(self.grid_size,
                                   self.grid_limit,
                                   pos_basis,

--- a/fairlearn/reductions/_grid_search/grid_search.py
+++ b/fairlearn/reductions/_grid_search/grid_search.py
@@ -19,8 +19,7 @@ TRADEOFF_OPTIMIZATION = "tradeoff_optimization"
 
 
 class _GridGenerator:
-    """A generator of a grid of points with a bounded L1 norm.
-    """
+    """A generator of a grid of points with a bounded L1 norm."""
 
     def __init__(self, grid_size, grid_limit, pos_basis, neg_basis, neg_allowed, force_L1_norm):
         # grid parameters
@@ -80,9 +79,10 @@ class _GridGenerator:
 
 
 class GridSearch(Reduction):
-    """Estimator to perform a grid search given a blackbox estimator algorithm. The approach used
-    is taken from section 3.4 of `Agarwal et al. (2018) <https://arxiv.org/abs/1803.02453>`_.
+    """Estimator to perform a grid search given a blackbox estimator algorithm.
 
+    The approach used is taken from section 3.4 of
+    `Agarwal et al. (2018) <https://arxiv.org/abs/1803.02453>`_.
 
     :param estimator: The underlying estimator to be used. Must provide a
         :code:`fit(X, y, sample_weights)` method
@@ -111,6 +111,7 @@ class GridSearch(Reduction):
     :param grid: Instead of supplying a size and limit for the grid, users may specify the exact
         set of Lagrange multipliers they desire using this argument.
     """
+
     _MESSAGE_Y_NOT_BINARY = "Supplied y labels are not 0 or 1"
 
     def __init__(self,
@@ -121,8 +122,7 @@ class GridSearch(Reduction):
                  grid_size=10,
                  grid_limit=2.0,
                  grid=None):
-        """Constructor for a GridSearch object
-        """
+        """Constructor for a GridSearch object."""
         self.estimator = estimator
         if not isinstance(constraints, Moment):
             raise RuntimeError("Unsupported disparity metric")
@@ -146,23 +146,25 @@ class GridSearch(Reduction):
 
     @property
     def all_results(self):
-        """A list of :class:`GridSearchResult` from each
-        point in the grid
-        """
+        """A list of :class:`GridSearchResult` from each point in the grid."""
         return self._all_results
 
     @property
     def best_result(self):
         """The best result found from the grid search.
+
         The predictor contained in this instance of
         :class:`GridSearchResult` is used in calls to
-        :code:`predict`` and :code:`predict_proba.
+        :code:`predict` and :code:`predict_proba`.
         """
         return self._best_result
 
     def fit(self, X, y, **kwargs):
-        """Runs the grid search. This will result in multiple copies of the
-        estimator being made, and the :code:`fit` method of each one called.
+        """Runs the grid search.
+
+        This will result in multiple copies of the
+        estimator being made, and the :code:`fit` method
+        of each one called.
 
         :param X: The feature data for the machine learning problem
         :type X: Array
@@ -202,7 +204,7 @@ class GridSearch(Reduction):
         objective_in_the_span = (self.constraints.default_objective_lambda_vec is not None)
 
         if self.grid is None:
-            logger.debug("Creating grid of size {0}".format(self.grid_size))
+            logger.debug("Creating grid of size {0}", self.grid_size)
             grid = _GridGenerator(self.grid_size,
                                   self.grid_limit,
                                   pos_basis,
@@ -253,8 +255,7 @@ class GridSearch(Reduction):
         return
 
     def predict(self, X):
-        """Provides a prediction for the given input data based
-        on the best model found by the grid search.
+        """Provides a prediction for the given input data based on the best model found by the grid search.
 
         :param X: The data for which predictions are required
         :type X: Array
@@ -268,9 +269,9 @@ class GridSearch(Reduction):
         return self.best_result.predictor.predict(X)
 
     def predict_proba(self, X):
-        """Provides the result of :code:`predict_proba` from the
-        best model found by the grid search. The underlying
-        estimator must support :code:`predict_proba` for this
+        """Provides the result of :code:`predict_proba` from the best model found by the grid search.
+
+        The underlying estimator must support :code:`predict_proba` for this
         to work.
 
         :param X: The data for which predictions are required

--- a/fairlearn/reductions/_grid_search/grid_search.py
+++ b/fairlearn/reductions/_grid_search/grid_search.py
@@ -98,14 +98,14 @@ class GridSearch(Reduction):
 
     :param constraint_weight: When the `selection_rule` is "tradeoff_optimization" this specifies
         the relative weight put on the constraint violation when selecting the best model.
-        The weight placed on the error rate will be `1-constraint_weight`
+        The weight placed on the error rate will be :code:`1-constraint_weight`
     :type constraint_weight: float
 
     :param grid_size: The number of Lagrange multipliers to generate in the grid
     :type grid_size: int
 
     :param grid_limit: The largest Lagrange multiplier to generate. The grid will contain values
-        :math:`[-grid_limit, grid_limit]` by default
+        distributed between :code:`-grid_limit` and :code:`grid_limit` by default
     :type grid_limit: float
 
     :param grid: Instead of supplying a size and limit for the grid, users may specify the exact

--- a/fairlearn/reductions/_grid_search/grid_search_result.py
+++ b/fairlearn/reductions/_grid_search/grid_search_result.py
@@ -3,8 +3,7 @@
 
 
 class GridSearchResult:
-    """Class to hold a single result from the :class:`GridSearch` class.
-    """
+    """Class to hold a single result from the :class:`GridSearch` class."""
 
     def __init__(self, predictor, lambda_vec, objective, gamma):
         self._predictor = predictor
@@ -14,28 +13,24 @@ class GridSearchResult:
 
     @property
     def predictor(self):
-        """The predictor trained for this particular result
-        from :class:`GridSearch`
-        """
+        """The predictor trained for this particular result from :class:`GridSearch`."""
         return self._predictor
 
     @property
     def lambda_vec(self):
-        """The Lagrange multiplier corresponding to this
-        result. The exact contents of this are defined
-        by the `constraints` argument passed to
-        :class:`GridSearch`
+        """The Lagrange multiplier corresponding to this result.
+
+        The exact contents of this are defined by the `constraints`
+        argument passed to :class:`GridSearch`
         """
         return self._lambda_vec
 
     @property
     def objective(self):
-        """Description goes here
-        """
+        """Description goes here."""
         return self._objective
 
     @property
     def gamma(self):
-        """Description goes here
-        """
+        """Description goes here."""
         return self._gamma

--- a/fairlearn/reductions/_moments/__init__.py
+++ b/fairlearn/reductions/_moments/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+"""Holds the various Moments."""
+
 from .moment import Moment  # noqa: F401
 from .moment import ClassificationMoment, LossMoment  # noq: F401
 

--- a/fairlearn/reductions/_moments/bounded_group_loss.py
+++ b/fairlearn/reductions/_moments/bounded_group_loss.py
@@ -9,7 +9,7 @@ from fairlearn._input_validation import _KW_SENSITIVE_FEATURES
 
 
 class ConditionalLossMoment(LossMoment):
-    """A moment that quantifies a loss by group"""
+    """A moment that quantifies a loss by group."""
 
     def __init__(self, loss, no_groups=False):
         super().__init__(loss)
@@ -42,9 +42,7 @@ class ConditionalLossMoment(LossMoment):
             i += 1
 
     def gamma(self, predictor):
-        """ Calculates the degree to which constraints are currently violated by
-        the predictor.
-        """
+        """Calculates degree to which constraints are currently violated by the predictor."""
         self.tags[_PREDICTION] = predictor(self.X)
         self.tags[_LOSS] = self.reduction_loss.eval(self.tags[_LABEL], self.tags[_PREDICTION])
         expect_attr = self.tags.groupby(_GROUP_ID).mean()
@@ -87,7 +85,7 @@ class SquareLoss:
         self.min = 0
         self.max = (max_val-min_val) ** 2
 
-    def eval(self, y_true, y_pred):
+    def eval(self, y_true, y_pred):  # noqa: A003
         return (np.clip(y_true, self.min_val, self.max_val)
                 - np.clip(y_pred, self.min_val, self.max_val)) ** 2
 
@@ -100,7 +98,7 @@ class AbsoluteLoss:
         self.min = 0
         self.max = np.abs(max_val-min_val)
 
-    def eval(self, y_true, y_pred):
+    def eval(self, y_true, y_pred):  # noqa: A003
         return np.abs(np.clip(y_true, self.min_val, self.max_val)
                       - np.clip(y_pred, self.min_val, self.max_val))
 

--- a/fairlearn/reductions/_moments/conditional_selection_rate.py
+++ b/fairlearn/reductions/_moments/conditional_selection_rate.py
@@ -10,7 +10,7 @@ _DIFF = "diff"
 
 
 class ConditionalSelectionRate(ClassificationMoment):
-    """Generic fairness metric including DemographicParity and EqualizedOdds"""
+    """Generic fairness metric including :class:`DemographicParity` and :class:`EqualizedOdds`."""
 
     def default_objective(self):
         return ErrorRate()
@@ -45,9 +45,7 @@ class ConditionalSelectionRate(ClassificationMoment):
                 i += 1
 
     def gamma(self, predictor):
-        """ Calculates the degree to which constraints are currently violated by
-        the predictor.
-        """
+        """Calculates degree to which constraints are currently violated by the predictor."""
         pred = predictor(self.X)
         self.tags[_PREDICTION] = pred
         expect_event = self.tags.groupby(_EVENT).mean()
@@ -88,12 +86,14 @@ ConditionalSelectionRate.__module__ = "fairlearn.reductions"
 
 
 class DemographicParity(ConditionalSelectionRate):
-    """Implementation of Demographic Parity as a moment.
+    r"""Implementation of Demographic Parity as a moment.
+
     A classifier :math:`h(X)` satisfies DemographicParity if
 
     .. math::
-      P[h(X) = y' | A = a] = P[h(X) = y'] \\; \\forall a, y'
+      P[h(X) = y' | A = a] = P[h(X) = y'] \; \forall a, y'
     """
+
     short_name = "DemographicParity"
 
     def load_data(self, X, y, **kwargs):
@@ -101,12 +101,14 @@ class DemographicParity(ConditionalSelectionRate):
 
 
 class EqualizedOdds(ConditionalSelectionRate):
-    """Implementation of Equalized Odds as a moment.
+    r"""Implementation of Equalized Odds as a moment.
+
     Adds conditioning on label compared to Demographic parity, i.e.
 
     .. math::
-       P[h(X) = y' | A = a, Y = y] = P[h(X) = y' | Y = y] \\; \\forall a, y, y'
+       P[h(X) = y' | A = a, Y = y] = P[h(X) = y' | Y = y] \; \forall a, y, y'
     """
+
     short_name = "EqualizedOdds"
 
     def load_data(self, X, y, **kwargs):

--- a/fairlearn/reductions/_moments/error_rate.py
+++ b/fairlearn/reductions/_moments/error_rate.py
@@ -7,7 +7,8 @@ from .moment import _ALL, _LABEL
 
 
 class ErrorRate(ClassificationMoment):
-    """Misclassification error"""
+    """Misclassification error."""
+
     short_name = "Err"
 
     def load_data(self, X, y, **kwargs):

--- a/fairlearn/reductions/_moments/moment.py
+++ b/fairlearn/reductions/_moments/moment.py
@@ -14,14 +14,15 @@ _SIGN = "sign"
 
 
 class Moment:
-    """Generic moment"""
+    """Generic moment."""
 
     def __init__(self):
         self.data_loaded = False
 
     def load_data(self, X, y, **kwargs):
-        """Load a set of data for use by this object. The keyword arguments
-        can contain a :code:`sensitive_features` array.
+        """Load a set of data for use by this object.
+
+        The keyword arguments can contain a :code:`sensitive_features` array.
 
         :param X: The feature data
         :type X: array
@@ -55,8 +56,7 @@ Moment.__module__ = "fairlearn.reductions"
 
 
 class ClassificationMoment(Moment):
-    """Moment that can be expressed as weighted classification error
-    """
+    """Moment that can be expressed as weighted classification error."""
 
 
 # Ensure that ClassificationMoment shows up in correct place in documentation
@@ -65,8 +65,7 @@ ClassificationMoment.__module__ = "fairlearn.reductions"
 
 
 class LossMoment(Moment):
-    """Moment that can be expressed as weighted loss
-    """
+    """Moment that can be expressed as weighted loss."""
 
     def __init__(self, loss):
         super().__init__()

--- a/fairlearn/reductions/_reduction.py
+++ b/fairlearn/reductions/_reduction.py
@@ -3,8 +3,7 @@
 
 
 class Reduction:
-    """Base class for our reduction-implementing estimators
-    """
+    """Base class for our reduction-implementing estimators."""
 
     def fit(self, X, y, **kwargs):
         raise NotImplementedError()

--- a/fairlearn/widget/fairlearnDashboard.py
+++ b/fairlearn/widget/fairlearnDashboard.py
@@ -42,9 +42,7 @@ class FairlearnDashboard(object):
             y_true, y_pred,
             sensitive_feature_names=None,
             is_classifier=None):
-
-        """Initialize the fairlearn Dashboard.
-        """
+        """Initialize the fairlearn Dashboard."""
         self._widget_instance = FairlearnWidget()
         if sensitive_features is None or y_true is None or y_pred is None:
             raise ValueError("Required parameters not provided")
@@ -195,7 +193,7 @@ class FairlearnDashboard(object):
         try:
             new = change.new
             response = copy.deepcopy(self._widget_instance.response)
-            for id in new:
+            for id in new:  # noqa: A001
                 try:
                     if id not in response:
                         data = new[id]

--- a/fairlearn/widget/fairlearnWidget.py
+++ b/fairlearn/widget/fairlearnWidget.py
@@ -9,7 +9,7 @@ from traitlets import Unicode, Dict
 
 @widgets.register
 class FairlearnWidget(widgets.DOMWidget):
-    """The python widget definition for the Fairlearn dashboard."""
+    """The python widget definition for the fairlearn dashboard."""
 
     _view_name = Unicode('FairlearnView').tag(sync=True)
     _model_name = Unicode('FairlearnModel').tag(sync=True)

--- a/fairlearn/widget/fairlearnWidget.py
+++ b/fairlearn/widget/fairlearnWidget.py
@@ -9,8 +9,7 @@ from traitlets import Unicode, Dict
 
 @widgets.register
 class FairlearnWidget(widgets.DOMWidget):
-    """The python widget definition for the Fairlearn dashboard.
-    """
+    """The python widget definition for the Fairlearn dashboard."""
 
     _view_name = Unicode('FairlearnView').tag(sync=True)
     _model_name = Unicode('FairlearnModel').tag(sync=True)

--- a/requirements-fixed.txt
+++ b/requirements-fixed.txt
@@ -8,6 +8,11 @@ scipy==1.3.1
 # Required for environment
 autopep8
 flake8
+flake8-blind-except
+flake8-builtins
+flake8-docstrings
+flake8-logging-format
+flake8-rst-docstrings
 requirements-parser
 
 # Required for test

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,11 @@ scipy>=1.3.1
 # Required for environment
 autopep8
 flake8
+flake8-blind-except
+flake8-builtins
+flake8-docstrings
+flake8-logging-format
+flake8-rst-docstrings
 requirements-parser
 
 # Required for test

--- a/scripts/requirementscheck.py
+++ b/scripts/requirementscheck.py
@@ -61,7 +61,6 @@ def load_requirements_file(filename):
     """Loads the specified requirements file
     and checks that the specs are OK by themselves
     """
-
     print("Loading {0}".format(filename))
 
     good_requirements = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,5 +7,7 @@ enable-extensions = G
 per-file-ignores = 
     setup.py:D100
     docs/*.py:D100,A001
-    fairlearn/*/*.py:D100,D101,D102,D103,D107
+    fairlearn/*.py:D100
+    fairlearn/*/*.py:D100,D101,D102,D103,D107,D401
+    scripts/*.py:D100,D101,D102,D103,D104,D107
     test/*/*.py:D100,D101,D102,D103,D104,D107

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,5 @@
 [flake8]
 max-line-length = 99
 enable-extensions=G
+per-file-ignores = 
+    test/*:D100,D103

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,4 @@ per-file-ignores =
     setup.py:D100
     docs/*.py:D100,A001
     fairlearn/**/*.py:D100,D101,D102,D103,D107
-    test/**/*.py:D100,D101,D103,D104,D107
+    test/**/*.py:D100,D101,D102,D103,D104,D107

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length = 99
+enable-extensions=G

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ per-file-ignores =
     docs/*.py:D100,A001
     fairlearn/*.py:D100
     fairlearn/*/*.py:D100,D101,D102,D103,D107,D401,RST304
+    fairlearn/metrics/__init__.py: RST902
     scripts/*.py:D100,D101,D102,D103,D104,D107,D205,D400,D401,RST201,RST205,RST301
     test/*.py:D104
     test/*/*.py:D100,D101,D102,D103,D104,D105,D107

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,5 +7,5 @@ enable-extensions = G
 per-file-ignores = 
     setup.py:D100
     docs/*.py:D100,A001
-    fairlearn/**/*.py:D100,D101,D102,D103,D107
-    test/**/*.py:D100,D101,D102,D103,D104,D107
+    fairlearn/*/*.py:D100,D101,D102,D103,D107
+    test/*/*.py:D100,D101,D102,D103,D104,D107

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,6 @@ per-file-ignores =
     docs/*.py:D100,A001
     fairlearn/*.py:D100
     fairlearn/*/*.py:D100,D101,D102,D103,D107,D401
-    scripts/*.py:D100,D101,D102,D103,D104,D107
+    scripts/*.py:D100,D101,D102,D103,D104,D107,D205,D400,D401,RST201,RST205,RST301
     test/*.py:D104
     test/*/*.py:D100,D101,D102,D103,D104,D105,D107

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ per-file-ignores =
     setup.py:D100
     docs/*.py:D100,A001
     fairlearn/*.py:D100
-    fairlearn/*/*.py:D100,D101,D102,D103,D107,D401
+    fairlearn/*/*.py:D100,D101,D102,D103,D107,D401,RST304
     scripts/*.py:D100,D101,D102,D103,D104,D107,D205,D400,D401,RST201,RST205,RST301
     test/*.py:D104
     test/*/*.py:D100,D101,D102,D103,D104,D105,D107

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,4 +10,5 @@ per-file-ignores =
     fairlearn/*.py:D100
     fairlearn/*/*.py:D100,D101,D102,D103,D107,D401
     scripts/*.py:D100,D101,D102,D103,D104,D107
-    test/*/*.py:D100,D101,D102,D103,D104,D107
+    test/*.py:D104
+    test/*/*.py:D100,D101,D102,D103,D104,D105,D107

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,11 @@
 [flake8]
 max-line-length = 99
-enable-extensions=G
+enable-extensions = G
+
+# Will want to remove all the ignores for the fairlearn directory
+# However, the initial enforcement has to be kept to within reasonable limits
 per-file-ignores = 
-    test/*:D100,D103
+    setup.py:D100
+    docs/*.py:D100,A001
+    fairlearn/**/*.py:D100,D101,D102,D103,D107
+    test/**/*.py:D100,D101,D103,D104,D107

--- a/test/setup.cfg
+++ b/test/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+ignore = D100, D103

--- a/test/setup.cfg
+++ b/test/setup.cfg
@@ -1,2 +1,0 @@
-[flake8]
-ignore = D100, D103

--- a/test/unit/reductions/grid_search/test_grid_search_arguments.py
+++ b/test/unit/reductions/grid_search/test_grid_search_arguments.py
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import logging
 import numpy as np
 import pandas as pd
 import pytest
@@ -259,7 +258,6 @@ class ConditionalOpportunityTests(ArgumentTests):
 # Set up DemographicParity
 class TestDemographicParity(ConditionalOpportunityTests):
     def setup_method(self, method):
-        logging.info("setup_method      method:%s" % method.__name__)
         self.estimator = LogisticRegression(solver='liblinear')
         self.disparity_criterion = DemographicParity()
 
@@ -267,7 +265,6 @@ class TestDemographicParity(ConditionalOpportunityTests):
 # Test EqualizedOdds
 class TestEqualizedOdds(ConditionalOpportunityTests):
     def setup_method(self, method):
-        logging.info("setup_method      method:%s" % method.__name__)
         self.estimator = LogisticRegression(solver='liblinear')
         self.disparity_criterion = EqualizedOdds()
 
@@ -275,6 +272,5 @@ class TestEqualizedOdds(ConditionalOpportunityTests):
 # Tests specific to BoundedGroupLoss
 class TestBoundedGroupLoss(ArgumentTests):
     def setup_method(self, method):
-        logging.info("setup_method      method:%s" % method.__name__)
         self.estimator = LinearRegression()
         self.disparity_criterion = GroupLossMoment(ZeroOneLoss())


### PR DESCRIPTION
Add a number of extra flake8 checks:
- flake8-blind-except
- flake8-builtins
- flake8-docstrings
- flake8-logging-format
- flake8-rst-docstrings

Since these create a huge number of issues, suppress a lot of these for now in `setup.cfg` (plus a handful of special cases done inline). Put in fixes for the simpler complaints, such as:
- Separate summaries in docstrings
- Spacing within and around docstrings
- Deferring string interpolation in `logging` calls