### PR TITLE
Unblock PR-Gate

### DIFF
--- a/devops/PR-Gate.yml
+++ b/devops/PR-Gate.yml
@@ -12,22 +12,26 @@ jobs:
   parameters:
     name: Linux
     vmImage: 'ubuntu-16.04'
+    requirementsFile: 'requirements-fixed.txt'
     pyVersions: [3.5]
 
 - template: all-tests-job-template.yml
   parameters:
     name: Windows
     vmImage:  'vs2017-win2016'
+    requirementsFile: 'requirements-fixed.txt'
     pyVersions: [3.6]
     
 - template: all-tests-job-template.yml
   parameters:
     name: MacOS
     vmImage:  'macos-latest'
+    requirementsFile: 'requirements-fixed.txt'
     pyVersions: [3.7] 
 
 - template: notebook-job-template.yml
   parameters:
     pyVersions: [3.6]
+    requirementsFile: 'requirements-fixed.txt'
 
 - template: build-widget-job-template.yml

--- a/devops/PR-Gate.yml
+++ b/devops/PR-Gate.yml
@@ -13,7 +13,7 @@ jobs:
     name: Linux
     vmImage: 'ubuntu-16.04'
     requirementsFile: 'requirements-fixed.txt'
-    pyVersions: [3.5]
+    pyVersions: [3.6]
 
 - template: all-tests-job-template.yml
   parameters:

--- a/requirements-fixed.txt
+++ b/requirements-fixed.txt
@@ -1,5 +1,5 @@
 # Required for fairlearn
-matplotlib==3.0.3
+matplotlib==3.1.0
 numpy==1.17.2
 pandas==0.25.1
 scikit-learn==0.21.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Required for fairlearn
-matplotlib>=3.0.3
+matplotlib>=3.1.0
 numpy>=1.17.2
 pandas>=0.25.1
 scikit-learn>=0.21.3


### PR DESCRIPTION
A recent update to a package on PyPI (tentatively, v0.22.0 of `scikit-learn`) is causing trouble with the Law School notebook.

While this is being debugged, switch the PR-Gate to using the pinned requirements. This in turn causes issues with `matplotlib`, MacOS and older versions of Python.