### PR TITLE
Pin scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 matplotlib>=3.0.3
 numpy>=1.17.2
 pandas>=0.25.1
-scikit-learn>=0.21.3
+scikit-learn==0.21.3
 scipy>=1.3.1
 
 # Required for environment


### PR DESCRIPTION
The recent update to scikit-learn is causing a break in one of the Notebooks. Until this is debugged, pin the version