### PR TITLE
Fix for Law School Notebook

### DIFF
--- a/notebooks/Mitigating Disparities in Ranking from Binary Data.ipynb
+++ b/notebooks/Mitigating Disparities in Ranking from Binary Data.ipynb
@@ -476,8 +476,8 @@
    "source": [
     "from fairlearn.reductions import ExponentiatedGradient\n",
     "\n",
-    "XA_train = pd.concat([X_train, A_train=='black'], axis=1)\n",
-    "XA_test = pd.concat([X_test, A_test=='black'], axis=1)\n",
+    "XA_train = pd.concat([X_train, A_train=='black'], axis=1).astype(float)\n",
+    "XA_test = pd.concat([X_test, A_test=='black'], axis=1).astype(float)\n",
     "\n",
     "expgrad_X = ExponentiatedGradient(\n",
     "    LogisticRegression(solver='liblinear', fit_intercept=True),\n",
@@ -612,7 +612,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 matplotlib>=3.0.3
 numpy>=1.17.2
 pandas>=0.25.1
-scikit-learn==0.21.3
+scikit-learn>=0.21.3
 scipy>=1.3.1
 
 # Required for environment


### PR DESCRIPTION
Tweak the Law School notebook so that it works with the latest `scikit-learn`

This enables us to unpin the version of `scikit-learn` in our `requirements.txt` file