### PR TITLE
Workaround Python 3.5 issue with Linux

### DIFF
--- a/devops/PR-Gate.yml
+++ b/devops/PR-Gate.yml
@@ -11,7 +11,7 @@ jobs:
 - template: all-tests-job-template.yml
   parameters:
     name: Linux
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-latest'
     pyVersions: [3.5]
 
 - template: all-tests-job-template.yml

--- a/devops/PR-Gate.yml
+++ b/devops/PR-Gate.yml
@@ -12,13 +12,13 @@ jobs:
   parameters:
     name: Linux
     vmImage: 'ubuntu-latest'
-    pyVersions: [3.5]
+    pyVersions: [3.6]
 
 - template: all-tests-job-template.yml
   parameters:
     name: Windows
     vmImage:  'vs2017-win2016'
-    pyVersions: [3.6]
+    pyVersions: [3.5]
     
 - template: all-tests-job-template.yml
   parameters:

--- a/devops/PR-Gate.yml
+++ b/devops/PR-Gate.yml
@@ -11,7 +11,7 @@ jobs:
 - template: all-tests-job-template.yml
   parameters:
     name: Linux
-    vmImage: 'ubuntu-latest'
+    vmImage: 'ubuntu-16.04'
     pyVersions: [3.6]
 
 - template: all-tests-job-template.yml

--- a/devops/nightly-requirements-fixed.yml
+++ b/devops/nightly-requirements-fixed.yml
@@ -22,6 +22,7 @@ jobs:
     name: Linux
     vmImage: 'ubuntu-16.04'
     requirementsFile: 'requirements-fixed.txt'
+    pyVersions: [3.6, 3.7] 
 
 - template: all-tests-job-template.yml
   parameters:

--- a/devops/nightly-requirements-fixed.yml
+++ b/devops/nightly-requirements-fixed.yml
@@ -35,5 +35,6 @@ jobs:
     name: LinuxNotebooks
     vmImage: 'ubuntu-16.04'
     requirementsFile: 'requirements-fixed.txt'
+    pyVersions: [3.6, 3.7] 
 
 - template: build-widget-job-template.yml

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -37,5 +37,6 @@ jobs:
   parameters:
     name: LinuxNotebooks
     vmImage: 'ubuntu-16.04'
+    pyVersions: [3.6, 3.7] 
 
 - template: build-widget-job-template.yml

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -20,6 +20,7 @@ jobs:
   parameters:
     name: Linux
     vmImage: 'ubuntu-16.04'
+    pyVersions: [3.6, 3.7] 
 
 - template: all-tests-job-template.yml
   parameters:

--- a/devops/pypi-deployment-stages-template.yml
+++ b/devops/pypi-deployment-stages-template.yml
@@ -97,7 +97,7 @@ stages:
     parameters:
       name: Linux
       vmImage: 'ubuntu-16.04'
-      pyVersions: [3.5, 3.6, 3.7]
+      pyVersions: [3.6, 3.7]
       targetType: ${{parameters.targetType}}
       versionFileArtifact: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
       versionFileName: '${{parameters.versionFileStem}}${{parameters.targetType}}'

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -36,7 +36,7 @@ stages:
     parameters:
       name: Linux
       vmImage: 'ubuntu-16.04'
-      pyVersions: [3.5,3.6,3.7]
+      pyVersions: [3.6,3.7]
 
   - template: all-tests-job-template.yml
     parameters:


### PR DESCRIPTION
An issue with the `pip` install of `shap` has appeared on the Linux agents under Python 3.5. Reasons are currently obscure, but this is blocking a release. Since Python 3.5 continues to work on Windows, rely on that (pending further debugging)