### PR TITLE
Pin troublesome package

### DIFF
--- a/requirements-fixed.txt
+++ b/requirements-fixed.txt
@@ -28,3 +28,6 @@ shap
 
 # Required for documentation
 sphinx
+
+# Required by something
+colorama==0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,6 @@ shap
 
 # Required for documentation
 sphinx
+
+# Required by something
+colorama==0.4.1


### PR DESCRIPTION
During our release process, a new version of `colorama` (required by one of our dependencies) was released. This has issues with the Windows/3.7 build.

Unblock the release by pinning the version

Signed-off-by: Richard Edgar <riedgar@microsoft.com>