### PR TITLE
Use pip freeze during releases

### DIFF
--- a/devops/all-tests-job-template.yml
+++ b/devops/all-tests-job-template.yml
@@ -4,7 +4,7 @@ parameters:
   pyVersions: [3.5, 3.6, 3.7]
   requirementsFile: 'requirements.txt'
   storeFreeze: false
-  freezeArtifactFormat:
+  freezeArtifactStem:
   freezeFile: 
 
 jobs:
@@ -17,7 +17,7 @@ jobs:
       ${{ each pyVer in parameters.pyVersions }}:
         ${{ pyVer }}:
           PyVer: ${{ pyVer }}
-          FreezeArtifact: ${{ format( parameters.freezeArtifactFormat, parameters.name, pyVer)}}
+          FreezeArtifact: ${{ format( '{0}{1}{2}', parameters.freezeArtifactStem, parameters.name, pyVer)}}
 
   steps:
   - task: UsePythonVersion@0

--- a/devops/all-tests-job-template.yml
+++ b/devops/all-tests-job-template.yml
@@ -17,7 +17,7 @@ jobs:
       ${{ each pyVer in parameters.pyVersions }}:
         ${{ pyVer }}:
           PyVer: ${{ pyVer }}
-          FreezeArtifact: ${{ format(parameters.freezeArtifactFormat, parameters.name, pyVer)}}
+          FreezeArtifact: ${{ format('PipFreeze{0}{1}', parameters.name, pyVer)}}
 
   steps:
   - task: UsePythonVersion@0
@@ -47,7 +47,7 @@ jobs:
       displayName: "Run pip freeze"
 
     - task: PublishPipelineArtifact@1
-      displayName: "Publish pip freeze file"
+      displayName: "Publish pip freeze file to artifact $(FreezeArtifact)"
       inputs:
         path: '$(System.DefaultWorkingDirectory)/${{parameters.freezeFile}}'
         artifact: $(FreezeArtifact)

--- a/devops/all-tests-job-template.yml
+++ b/devops/all-tests-job-template.yml
@@ -42,12 +42,8 @@ jobs:
     displayName: 'Publish Test Results **/TEST-*.xml'
     condition: succeededOrFailed()
 
-  - ${{ if parameters.storeFreeze }}:
-    - script: pip freeze > ${{parameters.freezeFile}}
-      displayName: "Run pip freeze"
-
-    - task: PublishPipelineArtifact@1
-      displayName: "Publish pip freeze file to artifact $(FreezeArtifact)"
-      inputs:
-        path: '$(System.DefaultWorkingDirectory)/${{parameters.freezeFile}}'
-        artifact: $(FreezeArtifact)
+  - template: pip-freeze-to-artifact-template.yml
+    parameters:
+      storeFreeze: ${{parameters.storeFreeze}}
+      freezeArtifact: $(FreezeArtifact)
+      freezeFile: ${{parameters.freezeFile}}

--- a/devops/all-tests-job-template.yml
+++ b/devops/all-tests-job-template.yml
@@ -3,6 +3,9 @@ parameters:
   vmImage: ''
   pyVersions: [3.5, 3.6, 3.7]
   requirementsFile: 'requirements.txt'
+  storeFreeze: false
+  freezeArtifact: ''
+  freezeFilenameFormat: 'requirements-freeze-{0}-{1}.txt'
 
 jobs:
 - job: ${{ parameters.name }}
@@ -14,6 +17,7 @@ jobs:
       ${{ each pyVer in parameters.pyVersions }}:
         ${{ pyVer }}:
           PyVer: ${{ pyVer }}
+          FreezeFile: ${{ format(parameters.freezeFilenameFormat, parameters.name, pyVer)}}
 
   steps:
   - task: UsePythonVersion@0
@@ -37,3 +41,13 @@ jobs:
   - task: PublishTestResults@2
     displayName: 'Publish Test Results **/TEST-*.xml'
     condition: succeededOrFailed()
+
+  - ${{ if parameters.storeFreeze }}
+    - script: pip freeze > $(FreezeFile)
+      displayName: "Run pip freeze"
+
+    - task: PublishPipelineArtifact@1
+      displayName: "Publish pip freeze file"
+      inputs:
+        path: '$(System.DefaultWorkingDirectory)/$(FreezeFile)'
+        artifact: '${{parameters.freezeArtifact}}'

--- a/devops/all-tests-job-template.yml
+++ b/devops/all-tests-job-template.yml
@@ -4,8 +4,8 @@ parameters:
   pyVersions: [3.5, 3.6, 3.7]
   requirementsFile: 'requirements.txt'
   storeFreeze: false
-  freezeArtifact: ''
-  freezeFilenameFormat: 'requirements-freeze-{0}-{1}.txt'
+  freezeArtifactFormat:
+  freezeFile: 
 
 jobs:
 - job: ${{ parameters.name }}
@@ -17,7 +17,7 @@ jobs:
       ${{ each pyVer in parameters.pyVersions }}:
         ${{ pyVer }}:
           PyVer: ${{ pyVer }}
-          FreezeFile: ${{ format(parameters.freezeFilenameFormat, parameters.name, pyVer)}}
+          FreezeArtifact: ${{ format(parameters.freezeArtifactFormat, parameters.name, pyVer)}}
 
   steps:
   - task: UsePythonVersion@0
@@ -43,11 +43,11 @@ jobs:
     condition: succeededOrFailed()
 
   - ${{ if parameters.storeFreeze }}:
-    - script: pip freeze > $(FreezeFile)
+    - script: pip freeze > ${{parameters.freezeFile}}
       displayName: "Run pip freeze"
 
     - task: PublishPipelineArtifact@1
       displayName: "Publish pip freeze file"
       inputs:
-        path: '$(System.DefaultWorkingDirectory)/$(FreezeFile)'
-        artifact: '${{parameters.freezeArtifact}}'
+        path: '$(System.DefaultWorkingDirectory)/${{parameters.freezeFile}}'
+        artifact: $(FreezeArtifact)

--- a/devops/all-tests-job-template.yml
+++ b/devops/all-tests-job-template.yml
@@ -17,7 +17,7 @@ jobs:
       ${{ each pyVer in parameters.pyVersions }}:
         ${{ pyVer }}:
           PyVer: ${{ pyVer }}
-          FreezeArtifact: ${{ format(parameters.freezeArtifactFormat, parameters.name, pyVer)}}
+          FreezeArtifact: ${{ format( parameters.freezeArtifactFormat, parameters.name, pyVer)}}
 
   steps:
   - task: UsePythonVersion@0

--- a/devops/all-tests-job-template.yml
+++ b/devops/all-tests-job-template.yml
@@ -17,7 +17,7 @@ jobs:
       ${{ each pyVer in parameters.pyVersions }}:
         ${{ pyVer }}:
           PyVer: ${{ pyVer }}
-          FreezeArtifact: ${{ format('PipFreeze{0}{1}', parameters.name, pyVer)}}
+          FreezeArtifact: ${{ format(parameters.freezeArtifactFormat, parameters.name, pyVer)}}
 
   steps:
   - task: UsePythonVersion@0

--- a/devops/all-tests-job-template.yml
+++ b/devops/all-tests-job-template.yml
@@ -42,7 +42,7 @@ jobs:
     displayName: 'Publish Test Results **/TEST-*.xml'
     condition: succeededOrFailed()
 
-  - ${{ if parameters.storeFreeze }}
+  - ${{ if parameters.storeFreeze }}:
     - script: pip freeze > $(FreezeFile)
       displayName: "Run pip freeze"
 

--- a/devops/all-tests-job-template.yml
+++ b/devops/all-tests-job-template.yml
@@ -17,7 +17,7 @@ jobs:
       ${{ each pyVer in parameters.pyVersions }}:
         ${{ pyVer }}:
           PyVer: ${{ pyVer }}
-          FreezeArtifact: ${{ format( '{0}{1}{2}', parameters.freezeArtifactStem, parameters.name, pyVer)}}
+          FreezeArtifact: '${{parameters.freezeArtifactStem}}${{parameters.name}}${{pyVer}}'
 
   steps:
   - task: UsePythonVersion@0

--- a/devops/create-wheel-step-template.yml
+++ b/devops/create-wheel-step-template.yml
@@ -7,6 +7,8 @@ parameters:
   versionFilename: ''
   packageArtifactName: ''
   versionArtifactName: ''
+  freezeArtifact: ''
+  freezeFile: ''
 
 steps:
 - task: UsePythonVersion@0
@@ -18,8 +20,11 @@ steps:
 - script: pip install setuptools wheel 
   displayName: 'Install setuptools'
 
-- script: pip install -r requirements.txt
-  displayName: "Install fairlearn requirements"
+- template: pip-install-from-artifact-steps.template.yml
+  parameters:
+    freezeArtifact: ${{parameters.freezeArtifact}}
+    freeseFile: ${{parameters.freezeFile}}
+
 
 - task: PowerShell@2
   displayName: 'Build widget'

--- a/devops/create-wheel-step-template.yml
+++ b/devops/create-wheel-step-template.yml
@@ -20,7 +20,7 @@ steps:
 - script: pip install setuptools wheel 
   displayName: 'Install setuptools'
 
-- template: pip-install-from-artifact-steps.template.yml
+- template: pip-install-from-artifact-steps-template.yml
   parameters:
     freezeArtifact: ${{parameters.freezeArtifact}}
     freeseFile: ${{parameters.freezeFile}}

--- a/devops/create-wheel-step-template.yml
+++ b/devops/create-wheel-step-template.yml
@@ -22,8 +22,8 @@ steps:
 
 - template: pip-install-from-artifact-steps-template.yml
   parameters:
-    freezeArtifactStem: ${{parameters.freezeArtifactStem}}
-    freeseFile: ${{parameters.freezeFile}}
+    freezeArtifact: '${{parameters.freezeArtifactStem}}Linux${{parameters.pyVer}}'
+    freezeFile: ${{parameters.freezeFile}}
 
 
 - task: PowerShell@2

--- a/devops/create-wheel-step-template.yml
+++ b/devops/create-wheel-step-template.yml
@@ -7,7 +7,7 @@ parameters:
   versionFilename: ''
   packageArtifactName: ''
   versionArtifactName: ''
-  freezeArtifact: ''
+  freezeArtifactStem: ''
   freezeFile: ''
 
 steps:
@@ -22,7 +22,7 @@ steps:
 
 - template: pip-install-from-artifact-steps-template.yml
   parameters:
-    freezeArtifact: ${{parameters.freezeArtifact}}
+    freezeArtifactStem: ${{parameters.freezeArtifactStem}}
     freeseFile: ${{parameters.freezeFile}}
 
 

--- a/devops/notebook-job-template.yml
+++ b/devops/notebook-job-template.yml
@@ -3,6 +3,9 @@ parameters:
   vmImage: 'ubuntu-latest'
   pyVersions: [3.5, 3.6, 3.7]
   requirementsFile: 'requirements.txt'
+  storeFreeze: false
+  freezeArtifactStem:
+  freezeFile: 
 
 jobs:
 - job:  ${{ parameters.name }}
@@ -14,6 +17,7 @@ jobs:
       ${{ each pyVer in parameters.pyVersions }}:
         ${{ pyVer }}:
           PyVer: ${{ pyVer }}
+          FreezeArtifact: '${{parameters.freezeArtifactStem}}${{parameters.name}}${{pyVer}}'
 
   steps:
   - task: UsePythonVersion@0
@@ -34,3 +38,9 @@ jobs:
   - task: PublishTestResults@2
     displayName: 'Publish Test Results **/TEST-*.xml'
     condition: succeededOrFailed()
+
+  - template: pip-freeze-to-artifact-template.yml
+    parameters:
+      storeFreeze: ${{parameters.storeFreeze}}
+      freezeArtifact: $(FreezeArtifact)
+      freezeFile: ${{parameters.freezeFile}}

--- a/devops/notebook-pypi-job-template.yml
+++ b/devops/notebook-pypi-job-template.yml
@@ -58,7 +58,7 @@ jobs:
   - template: pip-install-from-artifact-steps-template.yml
     parameters:
       freezeArtifact: $(FreezeArtifact)
-      freeseFile: ${{parameters.freezeFile}}
+      freezeFile: ${{parameters.freezeFile}}
 
   # Install fairlearn withe the specified version from the appropriate PyPI index
   - script: pip install --index-url $(pypiUrl) fairlearn==$(fairlearnVersionForpip)

--- a/devops/notebook-pypi-job-template.yml
+++ b/devops/notebook-pypi-job-template.yml
@@ -10,8 +10,8 @@ parameters:
   targetType:
   versionFileArtifact:
   versionFileName:
-  freezeArtifact: ''
-  freezeFile: ''
+  freezeArtifactStem:
+  freezeFile: 
 
 jobs:
 - job: ${{ parameters.name }}
@@ -31,6 +31,7 @@ jobs:
       ${{ each pyVer in parameters.pyVersions }}:
         ${{ pyVer }}:
           PyVer: ${{ pyVer }}
+          FreezeArtifact: '${{parameters.freezeArtifactStem}}${{parameters.name}}${{pyVer}}'
 
   steps:
   # Remove the fairlearn/ directory (and some others)
@@ -56,7 +57,7 @@ jobs:
   # Install our requirements from regular PyPI
   - template: pip-install-from-artifact-steps-template.yml
     parameters:
-      freezeArtifact: ${{parameters.freezeArtifact}}
+      freezeArtifact: $(FreezeArtifact)
       freeseFile: ${{parameters.freezeFile}}
 
   # Install fairlearn withe the specified version from the appropriate PyPI index

--- a/devops/notebook-pypi-job-template.yml
+++ b/devops/notebook-pypi-job-template.yml
@@ -7,10 +7,11 @@ parameters:
   name: ''
   vmImage: ''
   pyVersions: [3.5, 3.6, 3.7]
-  requirementsFile: 'requirements.txt'
   targetType:
   versionFileArtifact:
   versionFileName:
+  freezeArtifact: ''
+  freezeFile: ''
 
 jobs:
 - job: ${{ parameters.name }}
@@ -53,8 +54,10 @@ jobs:
       addToPath: true
 
   # Install our requirements from regular PyPI
-  - script: pip install -r ${{ parameters.requirementsFile }}
-    displayName: 'Install required packages specified in ${{ parameters.requirementsFile }}'
+  - template: pip-install-from-artifact-steps.template.yml
+    parameters:
+      freezeArtifact: ${{parameters.freezeArtifact}}
+      freeseFile: ${{parameters.freezeFile}}
 
   # Install fairlearn withe the specified version from the appropriate PyPI index
   - script: pip install --index-url $(pypiUrl) fairlearn==$(fairlearnVersionForpip)

--- a/devops/notebook-pypi-job-template.yml
+++ b/devops/notebook-pypi-job-template.yml
@@ -54,7 +54,7 @@ jobs:
       addToPath: true
 
   # Install our requirements from regular PyPI
-  - template: pip-install-from-artifact-steps.template.yml
+  - template: pip-install-from-artifact-steps-template.yml
     parameters:
       freezeArtifact: ${{parameters.freezeArtifact}}
       freeseFile: ${{parameters.freezeFile}}

--- a/devops/pip-freeze-to-artifact-template.yml
+++ b/devops/pip-freeze-to-artifact-template.yml
@@ -1,0 +1,16 @@
+parameters:
+  storeFreeze: false
+  freezeArtifact:
+  freezeFile:
+
+  
+steps:
+  - ${{ if parameters.storeFreeze }}:
+    - script: pip freeze > ${{parameters.freezeFile}}
+      displayName: "Run pip freeze"
+
+    - task: PublishPipelineArtifact@1
+      displayName: "Publish pip freeze file to artifact ${{parameters.freezeArtifact}}"
+      inputs:
+        path: '$(System.DefaultWorkingDirectory)/${{parameters.freezeFile}}'
+        artifact: ${{parameters.freezeArtifact}}

--- a/devops/pip-install-from-artifact-steps-template.yml
+++ b/devops/pip-install-from-artifact-steps-template.yml
@@ -1,0 +1,9 @@
+parameters:
+  freezeArtifact: 'PipFreeze'
+  freezeFile: 'requirements-freeze.txt'
+
+steps:
+- script: ls -R $(Pipeline.Workspace)
+
+- script: pip install -r $(Pipeline.Workspace)/${{parameters.freezeArtifact}}/${{parameters.freezeFile}}
+  displayName: "Install fairlearn requirements from ${{parameters.freezeArtifact}}/${{parameters.freezeFile}}"

--- a/devops/pip-install-from-artifact-steps-template.yml
+++ b/devops/pip-install-from-artifact-steps-template.yml
@@ -3,7 +3,13 @@ parameters:
   freezeFile: 'requirements-freeze.txt'
 
 steps:
-- script: ls -R $(Pipeline.Workspace)
+- task: DownloadPipelineArtifact@2
+  displayName: "Download version Artifact"
+  inputs:
+    artifactName: ${{parameters.freezeArtifact}}
+
+- script: ls $(Pipeline.Workspace)
+  displayName: "List Pipeline.Workspace"
 
 - script: pip install -r $(Pipeline.Workspace)/${{parameters.freezeArtifact}}/${{parameters.freezeFile}}
   displayName: "Install fairlearn requirements from ${{parameters.freezeArtifact}}/${{parameters.freezeFile}}"

--- a/devops/pip-install-from-artifact-steps-template.yml
+++ b/devops/pip-install-from-artifact-steps-template.yml
@@ -11,5 +11,5 @@ steps:
 - script: ls $(Pipeline.Workspace)
   displayName: "List Pipeline.Workspace"
 
-- script: pip install -r $(Pipeline.Workspace)/${{parameters.freezeArtifact}}/${{parameters.freezeFile}}
-  displayName: "Install fairlearn requirements from ${{parameters.freezeArtifact}}/${{parameters.freezeFile}}"
+- script: pip install -r $(Pipeline.Workspace)/${{parameters.freezeFile}}
+  displayName: "Install fairlearn requirements from ${{parameters.freezeFile}}"

--- a/devops/pip-install-from-artifact-steps-template.yml
+++ b/devops/pip-install-from-artifact-steps-template.yml
@@ -11,5 +11,5 @@ steps:
 - script: ls $(Pipeline.Workspace)
   displayName: "List Pipeline.Workspace"
 
-- script: pip install -r $(Pipeline.Workspace)/${{parameters.freezeFile}}
-  displayName: "Install fairlearn requirements from ${{parameters.freezeFile}}"
+- script: pip install -r $(Pipeline.Workspace)/${{parameters.freezeArtifact}}/${{parameters.freezeFile}}
+  displayName: "Install fairlearn requirements from ${{parameters.freezeArtifact}}/${{parameters.freezeFile}}"

--- a/devops/pip-install-from-artifact-steps-template.yml
+++ b/devops/pip-install-from-artifact-steps-template.yml
@@ -1,10 +1,10 @@
 parameters:
-  freezeArtifact: 'PipFreeze'
-  freezeFile: 'requirements-freeze.txt'
+  freezeArtifact: 
+  freezeFile: 
 
 steps:
 - task: DownloadPipelineArtifact@2
-  displayName: "Download version Artifact"
+  displayName: "Download version Artifact ${{parameters.freezeArtifact}}"
   inputs:
     artifactName: ${{parameters.freezeArtifact}}
 

--- a/devops/pip-install-from-artifact-steps-template.yml
+++ b/devops/pip-install-from-artifact-steps-template.yml
@@ -1,6 +1,6 @@
 parameters:
-  freezeArtifact: 
-  freezeFile: 
+  freezeArtifact: "NeedOverride"
+  freezeFile: "FileNeedsOverride"
 
 steps:
 - task: DownloadPipelineArtifact@2

--- a/devops/pypi-deployment-stages-template.yml
+++ b/devops/pypi-deployment-stages-template.yml
@@ -105,7 +105,7 @@ stages:
       targetType: ${{parameters.targetType}}
       versionFileArtifact: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
       versionFileName: '${{parameters.versionFileStem}}${{parameters.targetType}}'
-      freezeArtifact: ${{parameters.freezeArtifact}}
+      freezeArtifactStem: ${{parameters.freezeArtifactStem}}
       freeseFile: ${{parameters.freezeFile}}
 
   - template: unit-tests-pypi-job-template.yml
@@ -116,7 +116,7 @@ stages:
       targetType: ${{parameters.targetType}}
       versionFileArtifact: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
       versionFileName: '${{parameters.versionFileStem}}${{parameters.targetType}}'
-      freezeArtifact: ${{parameters.freezeArtifact}}
+      freezeArtifactStem: ${{parameters.freezeArtifactStem}}
       freeseFile: ${{parameters.freezeFile}}
 
   - template: unit-tests-pypi-job-template.yml
@@ -127,7 +127,7 @@ stages:
       targetType: ${{parameters.targetType}}
       versionFileArtifact: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
       versionFileName: '${{parameters.versionFileStem}}${{parameters.targetType}}'
-      freezeArtifact: ${{parameters.freezeArtifact}}
+      freezeArtifactStem: ${{parameters.freezeArtifactStem}}
       freeseFile: ${{parameters.freezeFile}}
 
   - template: notebook-pypi-job-template.yml
@@ -138,5 +138,5 @@ stages:
       targetType: ${{parameters.targetType}}
       versionFileArtifact: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
       versionFileName: '${{parameters.versionFileStem}}${{parameters.targetType}}'
-      freezeArtifact: ${{parameters.freezeArtifact}}
+      freezeArtifactStem: ${{parameters.freezeArtifactStem}}
       freeseFile: ${{parameters.freezeFile}}

--- a/devops/pypi-deployment-stages-template.yml
+++ b/devops/pypi-deployment-stages-template.yml
@@ -11,8 +11,8 @@ parameters:
   poolPythonVersion: 3.6
   targetType: 'Test'
   targetEnvironment: 'PyPI-Test Deployment'
-  freezeArtifact: 'PipFreeze'
-  freezeFile: 'requirements-freeze.txt'
+  freezeArtifact:
+  freezeFile:
   packageArtifactStem: 'Packages'
   versionArtifactStem: 'Version'
   versionFileStem: 'versionInfo'
@@ -20,8 +20,6 @@ parameters:
   kvVaultName:
   kvUsername:
   kvPassword:
-  freezeArtifact: 'PipFreeze'
-  freezeFile: 'requirements-freeze.txt'
 
 stages:
 # Create the PyPI package and save as a artifact
@@ -41,7 +39,7 @@ stages:
         versionArtifactName: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
         versionFilename: '${{parameters.versionFileStem}}${{parameters.targetType}}'
         freezeArtifact: ${{parameters.freezeArtifact}}
-        freeseFile: ${{parameters.freezeFile}}
+        freezeFile: ${{parameters.freezeFile}}
 
 
 # Upload the package to the appropriate PyPI index

--- a/devops/pypi-deployment-stages-template.yml
+++ b/devops/pypi-deployment-stages-template.yml
@@ -106,7 +106,7 @@ stages:
       versionFileArtifact: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
       versionFileName: '${{parameters.versionFileStem}}${{parameters.targetType}}'
       freezeArtifactStem: ${{parameters.freezeArtifactStem}}
-      freeseFile: ${{parameters.freezeFile}}
+      freezeFile: ${{parameters.freezeFile}}
 
   - template: unit-tests-pypi-job-template.yml
     parameters:
@@ -117,7 +117,7 @@ stages:
       versionFileArtifact: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
       versionFileName: '${{parameters.versionFileStem}}${{parameters.targetType}}'
       freezeArtifactStem: ${{parameters.freezeArtifactStem}}
-      freeseFile: ${{parameters.freezeFile}}
+      freezeFile: ${{parameters.freezeFile}}
 
   - template: unit-tests-pypi-job-template.yml
     parameters:
@@ -128,7 +128,7 @@ stages:
       versionFileArtifact: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
       versionFileName: '${{parameters.versionFileStem}}${{parameters.targetType}}'
       freezeArtifactStem: ${{parameters.freezeArtifactStem}}
-      freeseFile: ${{parameters.freezeFile}}
+      freezeFile: ${{parameters.freezeFile}}
 
   - template: notebook-pypi-job-template.yml
     parameters:
@@ -139,4 +139,4 @@ stages:
       versionFileArtifact: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
       versionFileName: '${{parameters.versionFileStem}}${{parameters.targetType}}'
       freezeArtifactStem: ${{parameters.freezeArtifactStem}}
-      freeseFile: ${{parameters.freezeFile}}
+      freezeFile: ${{parameters.freezeFile}}

--- a/devops/pypi-deployment-stages-template.yml
+++ b/devops/pypi-deployment-stages-template.yml
@@ -11,6 +11,8 @@ parameters:
   poolPythonVersion: 3.6
   targetType: 'Test'
   targetEnvironment: 'PyPI-Test Deployment'
+  freezeArtifact: 'PipFreeze'
+  freezeFile: 'requirements-freeze.txt'
   packageArtifactStem: 'Packages'
   versionArtifactStem: 'Version'
   versionFileStem: 'versionInfo'
@@ -18,6 +20,8 @@ parameters:
   kvVaultName:
   kvUsername:
   kvPassword:
+  freezeArtifact: 'PipFreeze'
+  freezeFile: 'requirements-freeze.txt'
 
 stages:
 # Create the PyPI package and save as a artifact
@@ -36,6 +40,8 @@ stages:
         packageArtifactName: '${{parameters.packageArtifactStem}}${{parameters.targetType}}'
         versionArtifactName: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
         versionFilename: '${{parameters.versionFileStem}}${{parameters.targetType}}'
+        freezeArtifact: ${{parameters.freezeArtifact}}
+        freeseFile: ${{parameters.freezeFile}}
 
 
 # Upload the package to the appropriate PyPI index
@@ -101,6 +107,8 @@ stages:
       targetType: ${{parameters.targetType}}
       versionFileArtifact: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
       versionFileName: '${{parameters.versionFileStem}}${{parameters.targetType}}'
+      freezeArtifact: ${{parameters.freezeArtifact}}
+      freeseFile: ${{parameters.freezeFile}}
 
   - template: unit-tests-pypi-job-template.yml
     parameters:
@@ -110,6 +118,8 @@ stages:
       targetType: ${{parameters.targetType}}
       versionFileArtifact: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
       versionFileName: '${{parameters.versionFileStem}}${{parameters.targetType}}'
+      freezeArtifact: ${{parameters.freezeArtifact}}
+      freeseFile: ${{parameters.freezeFile}}
 
   - template: unit-tests-pypi-job-template.yml
     parameters:
@@ -119,6 +129,8 @@ stages:
       targetType: ${{parameters.targetType}}
       versionFileArtifact: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
       versionFileName: '${{parameters.versionFileStem}}${{parameters.targetType}}'
+      freezeArtifact: ${{parameters.freezeArtifact}}
+      freeseFile: ${{parameters.freezeFile}}
 
   - template: notebook-pypi-job-template.yml
     parameters:
@@ -128,3 +140,5 @@ stages:
       targetType: ${{parameters.targetType}}
       versionFileArtifact: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
       versionFileName: '${{parameters.versionFileStem}}${{parameters.targetType}}'
+      freezeArtifact: ${{parameters.freezeArtifact}}
+      freeseFile: ${{parameters.freezeFile}}

--- a/devops/pypi-deployment-stages-template.yml
+++ b/devops/pypi-deployment-stages-template.yml
@@ -11,8 +11,8 @@ parameters:
   poolPythonVersion: 3.6
   targetType: 'Test'
   targetEnvironment: 'PyPI-Test Deployment'
-  freezeArtifact:
-  freezeFile:
+  freezeArtifactStem:
+  freezeFile: 
   packageArtifactStem: 'Packages'
   versionArtifactStem: 'Version'
   versionFileStem: 'versionInfo'
@@ -38,7 +38,7 @@ stages:
         packageArtifactName: '${{parameters.packageArtifactStem}}${{parameters.targetType}}'
         versionArtifactName: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
         versionFilename: '${{parameters.versionFileStem}}${{parameters.targetType}}'
-        freezeArtifact: ${{parameters.freezeArtifact}}
+        freezeArtifactStem: ${{parameters.freezeArtifactStem}}
         freezeFile: ${{parameters.freezeFile}}
 
 

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -63,6 +63,7 @@ stages:
 
   - template: notebook-job-template.yml
     parameters:
+      name: Notebooks_Linux
       pyVersions: [3.6]
       storeFreeze: true
       freezeArtifactStem: $(FreezeArtifactStem)

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -40,7 +40,7 @@ stages:
       vmImage: 'ubuntu-16.04'
       pyVersions: [3.6,3.7]
       storeFreeze: true
-      freezeArtifactFormat: $(freezeArtifactFormat)
+      freezeArtifactFormat: 'PipFreeze{0}{1}'
       freezeFile: $(freezeFile)
 
   - template: all-tests-job-template.yml

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -41,6 +41,7 @@ stages:
       pyVersions: [3.6,3.7]
       storeFreeze: true
       freezeArtifactFormat: $(freezeArtifactFormat)
+      freezeFile: $(freezeFile)
 
   - template: all-tests-job-template.yml
     parameters:
@@ -49,6 +50,7 @@ stages:
       pyVersions: [3.5, 3.6, 3.7]
       storeFreeze: true
       freezeArtifactFormat: $(freezeArtifactFormat)
+      freezeFile: $(freezeFile)
       
   - template: all-tests-job-template.yml
     parameters:
@@ -57,6 +59,7 @@ stages:
       pyVersions: [3.6, 3.7] 
       storeFreeze: true
       freezeArtifactFormat: $(freezeArtifactFormat)
+      freezeFile: $(freezeFile)
 
   - template: notebook-job-template.yml
     parameters:

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -78,7 +78,7 @@ stages:
     kvVaultName: fairlearndeploy
     kvUsername: 'usernametest'
     kvPassword: 'passwordtest'
-    freezeArtifact: 
+    freezeArtifactStem: $(FreezeArtifactStem)
     freezeFile: $(freezeFile)
 
 # =================================================================================================================
@@ -92,5 +92,5 @@ stages:
     kvVaultName: fairlearndeploy
     kvUsername: 'usernameprod'
     kvPassword: 'passwordprod'
-    freezeArtifact: 
+    freezeArtifactStem: 
     freezeFile: $(freezeFile)

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -64,7 +64,7 @@ stages:
   - template: notebook-job-template.yml
     parameters:
       name: Notebooks_Linux
-      pyVersions: [3.6]
+      pyVersions: [3.6,3.7]
       storeFreeze: true
       freezeArtifactStem: $(FreezeArtifactStem)
       freezeFile: $(FreezeFile)

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -39,29 +39,28 @@ stages:
       name: Linux
       vmImage: 'ubuntu-16.04'
       pyVersions: [3.6,3.7]
+      storeFreeze: true
+      freezeArtifact: $(freezeArtifact)
 
   - template: all-tests-job-template.yml
     parameters:
       name: Windows
       vmImage:  'vs2017-win2016'
       pyVersions: [3.5, 3.6, 3.7]
+      storeFreeze: true
+      freezeArtifact: $(freezeArtifact)
       
   - template: all-tests-job-template.yml
     parameters:
       name: MacOS
       vmImage:  'macos-latest'
       pyVersions: [3.6, 3.7] 
+      storeFreeze: true
+      freezeArtifact: $(freezeArtifact)
 
   - template: notebook-job-template.yml
     parameters:
       pyVersions: [3.6]
-
-  - template: store-pip-freeze-job-template.yml
-    parameters:
-      vmImage: 'ubuntu-16.04'
-      pythonVersion: 3.6
-      freezeArtifact: $(freezeArtifact)
-      freezeFile: $(freezeFile)
 
 
 # =================================================================================================================

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -20,7 +20,7 @@
 variables:
   poolImage: "ubuntu-latest"
   poolPythonVersion: 3.6
-  freezeArtifactFormat: 'PipFreeze{0}{1}'
+  freezeArtifactFormat: "PipFreeze{0}{1}"
   freezeFile: "requirements-freeze.txt"
 
 trigger: none # No CI build

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -96,5 +96,5 @@ stages:
     kvVaultName: fairlearndeploy
     kvUsername: 'usernameprod'
     kvPassword: 'passwordprod'
-    freezeArtifactStem: 
+    freezeArtifactStem: $(FreezeArtifactStem)
     freezeFile: $(freezeFile)

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -20,7 +20,7 @@
 variables:
   poolImage: "ubuntu-latest"
   poolPythonVersion: 3.6
-  freezeArtifactFormat: "PipFreeze{0}{1}"
+  freezeArtifactFormat: 'PipFreeze{0}{1}'
   freezeFile: "requirements-freeze.txt"
 
 trigger: none # No CI build

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -20,7 +20,7 @@
 variables:
   poolImage: "ubuntu-latest"
   poolPythonVersion: 3.6
-  freezeArtifactFormat: "PipFreeze{0}{1}"
+  freezeArtifactStem: "PipFreeze"
   freezeFile: "requirements-freeze.txt"
 
 trigger: none # No CI build
@@ -40,7 +40,7 @@ stages:
       vmImage: 'ubuntu-16.04'
       pyVersions: [3.6,3.7]
       storeFreeze: true
-      freezeArtifactFormat: 'PipFreeze{0}{1}'
+      freezeArtifactStem: $(freezeArtifactStem)
       freezeFile: $(freezeFile)
 
   - template: all-tests-job-template.yml
@@ -49,7 +49,7 @@ stages:
       vmImage:  'vs2017-win2016'
       pyVersions: [3.5, 3.6, 3.7]
       storeFreeze: true
-      freezeArtifactFormat: $(freezeArtifactFormat)
+      freezeArtifactStem: $(freezeArtifactStem)
       freezeFile: $(freezeFile)
       
   - template: all-tests-job-template.yml
@@ -58,7 +58,7 @@ stages:
       vmImage:  'macos-latest'
       pyVersions: [3.6, 3.7] 
       storeFreeze: true
-      freezeArtifactFormat: $(freezeArtifactFormat)
+      freezeArtifactStem: $(freezeArtifactStem)
       freezeFile: $(freezeFile)
 
   - template: notebook-job-template.yml

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -64,7 +64,7 @@ stages:
   - template: notebook-job-template.yml
     parameters:
       name: Notebooks_Linux
-      pyVersions: [3.6,3.7]
+      pyVersions: [3.6, 3.7]
       storeFreeze: true
       freezeArtifactStem: $(FreezeArtifactStem)
       freezeFile: $(FreezeFile)

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -20,6 +20,8 @@
 variables:
   poolImage: "ubuntu-latest"
   poolPythonVersion: 3.6
+  freezeArtifact: "PipFreeze"
+  freezeFile: "requirements-freeze.txt"
 
 trigger: none # No CI build
 
@@ -58,6 +60,8 @@ stages:
     parameters:
       vmImage: 'ubuntu-16.04'
       pythonVersion: 3.6
+      freezeArtifact: $(freezeArtifact)
+      freezeFile: $(freezeFile)
 
 
 # =================================================================================================================
@@ -72,6 +76,8 @@ stages:
     kvVaultName: fairlearndeploy
     kvUsername: 'usernametest'
     kvPassword: 'passwordtest'
+    freezeArtifact: $(freezeArtifact)
+    freezeFile: $(freezeFile)
 
 # =================================================================================================================
 
@@ -84,3 +90,5 @@ stages:
     kvVaultName: fairlearndeploy
     kvUsername: 'usernameprod'
     kvPassword: 'passwordprod'
+    freezeArtifact: $(freezeArtifact)
+    freezeFile: $(freezeFile)

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -20,8 +20,8 @@
 variables:
   poolImage: "ubuntu-latest"
   poolPythonVersion: 3.6
-  freezeArtifactStem: "PipFreeze"
-  freezeFile: "requirements-freeze.txt"
+  FreezeArtifactStem: "PipFreeze"
+  FreezeFile: "requirements-freeze.txt"
 
 trigger: none # No CI build
 
@@ -40,8 +40,8 @@ stages:
       vmImage: 'ubuntu-16.04'
       pyVersions: [3.6,3.7]
       storeFreeze: true
-      freezeArtifactStem: $(freezeArtifactStem)
-      freezeFile: $(freezeFile)
+      freezeArtifactStem: $(FreezeArtifactStem)
+      freezeFile: $(FreezeFile)
 
   - template: all-tests-job-template.yml
     parameters:
@@ -49,8 +49,8 @@ stages:
       vmImage:  'vs2017-win2016'
       pyVersions: [3.5, 3.6, 3.7]
       storeFreeze: true
-      freezeArtifactStem: $(freezeArtifactStem)
-      freezeFile: $(freezeFile)
+      freezeArtifactStem: $(FreezeArtifactStem)
+      freezeFile: $(FreezeFile)
       
   - template: all-tests-job-template.yml
     parameters:
@@ -58,8 +58,8 @@ stages:
       vmImage:  'macos-latest'
       pyVersions: [3.6, 3.7] 
       storeFreeze: true
-      freezeArtifactStem: $(freezeArtifactStem)
-      freezeFile: $(freezeFile)
+      freezeArtifactStem: $(FreezeArtifactStem)
+      freezeFile: $(FreezeFile)
 
   - template: notebook-job-template.yml
     parameters:

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -54,6 +54,11 @@ stages:
     parameters:
       pyVersions: [3.6]
 
+  - template: store-pip-freeze-job-template.yml
+    parameters:
+      vmImage: 'ubuntu-16.04'
+      pythonVersion: 3.6
+
 
 # =================================================================================================================
 

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -64,6 +64,9 @@ stages:
   - template: notebook-job-template.yml
     parameters:
       pyVersions: [3.6]
+      storeFreeze: true
+      freezeArtifactStem: $(FreezeArtifactStem)
+      freezeFile: $(FreezeFile)
 
 
 # =================================================================================================================

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -20,7 +20,7 @@
 variables:
   poolImage: "ubuntu-latest"
   poolPythonVersion: 3.6
-  freezeArtifact: "PipFreeze"
+  freezeArtifactFormat: "PipFreeze{0}{1}"
   freezeFile: "requirements-freeze.txt"
 
 trigger: none # No CI build
@@ -40,7 +40,7 @@ stages:
       vmImage: 'ubuntu-16.04'
       pyVersions: [3.6,3.7]
       storeFreeze: true
-      freezeArtifact: $(freezeArtifact)
+      freezeArtifactFormat: $(freezeArtifactFormat)
 
   - template: all-tests-job-template.yml
     parameters:
@@ -48,7 +48,7 @@ stages:
       vmImage:  'vs2017-win2016'
       pyVersions: [3.5, 3.6, 3.7]
       storeFreeze: true
-      freezeArtifact: $(freezeArtifact)
+      freezeArtifactFormat: $(freezeArtifactFormat)
       
   - template: all-tests-job-template.yml
     parameters:
@@ -56,7 +56,7 @@ stages:
       vmImage:  'macos-latest'
       pyVersions: [3.6, 3.7] 
       storeFreeze: true
-      freezeArtifact: $(freezeArtifact)
+      freezeArtifactFormat: $(freezeArtifactFormat)
 
   - template: notebook-job-template.yml
     parameters:
@@ -75,7 +75,7 @@ stages:
     kvVaultName: fairlearndeploy
     kvUsername: 'usernametest'
     kvPassword: 'passwordtest'
-    freezeArtifact: $(freezeArtifact)
+    freezeArtifact: 
     freezeFile: $(freezeFile)
 
 # =================================================================================================================
@@ -89,5 +89,5 @@ stages:
     kvVaultName: fairlearndeploy
     kvUsername: 'usernameprod'
     kvPassword: 'passwordprod'
-    freezeArtifact: $(freezeArtifact)
+    freezeArtifact: 
     freezeFile: $(freezeFile)

--- a/devops/store-pip-freeze-job-template.yml
+++ b/devops/store-pip-freeze-job-template.yml
@@ -6,7 +6,7 @@ parameters:
   freezeFile: 'requirements-freeze.txt'
 
 jobs:
-- job: "Save pip freeze to artifact"
+- job: "pip_freeze_to_Artifact"
   pool:
     vmImage: ${{ parameters.vmImage }}
   

--- a/devops/store-pip-freeze-job-template.yml
+++ b/devops/store-pip-freeze-job-template.yml
@@ -1,0 +1,30 @@
+parameters:
+  poolImage: ''
+  poolPythonVersion: 3.6
+  requirementsFile: 'requirements.txt'
+  freezeArtifact: 'PipFreeze'
+  freezeFile: 'requirements-freeze.txt'
+
+jobs:
+- job: "Save pip freeze to artifact"
+  pool:
+    vmImage: ${{ parameters.vmImage }}
+  
+  steps:
+  - task: UsePythonVersion@0
+    displayName: 'Use Python ${{parameters.pyVer}}'
+    inputs:
+      versionSpec: ${{parameters.pyVer}}
+      addToPath: true
+
+  - script: pip install -r ${{parameters.requirementsFile}}
+    displayName: "Install fairlearn requirements from ${{parameters.requirementsFile}}"
+
+  - script: pip freeze > ${{parameters.FreezeFile}}
+    displayName: "Run pip freeze"
+
+  - task: PublishPipelineArtifact@1
+    displayName: "Publish pip freeze file"
+    inputs:
+      path: '$(System.DefaultWorkingDirectory)/${{parameters.freezeFile}}'
+      artifact: '${{parameters.freezeArtifact}}'

--- a/devops/store-pip-freeze-job-template.yml
+++ b/devops/store-pip-freeze-job-template.yml
@@ -12,9 +12,9 @@ jobs:
   
   steps:
   - task: UsePythonVersion@0
-    displayName: 'Use Python ${{parameters.pyVer}}'
+    displayName: 'Use Python ${{parameters.pythonVersion}}'
     inputs:
-      versionSpec: ${{parameters.pyVer}}
+      versionSpec: ${{parameters.pythonVersion}}
       addToPath: true
 
   - script: pip install -r ${{parameters.requirementsFile}}

--- a/devops/store-pip-freeze-job-template.yml
+++ b/devops/store-pip-freeze-job-template.yml
@@ -1,6 +1,6 @@
 parameters:
-  poolImage: ''
-  poolPythonVersion: 3.6
+  vmImage: ''
+  pythonVersion: 3.6
   requirementsFile: 'requirements.txt'
   freezeArtifact: 'PipFreeze'
   freezeFile: 'requirements-freeze.txt'

--- a/devops/unit-tests-pypi-job-template.yml
+++ b/devops/unit-tests-pypi-job-template.yml
@@ -58,7 +58,7 @@ jobs:
   # Install our requirements from regular PyPI
   - template: pip-install-from-artifact-steps-template.yml
     parameters:
-      freezeArtifact: ${{parameters.freezeArtifact}}
+      freezeArtifact: $(FreezeArtifact)
       freeseFile: ${{parameters.freezeFile}}
 
   # Install fairlearn withe the specified version from the appropriate PyPI index

--- a/devops/unit-tests-pypi-job-template.yml
+++ b/devops/unit-tests-pypi-job-template.yml
@@ -55,7 +55,7 @@ jobs:
       addToPath: true
 
   # Install our requirements from regular PyPI
-  - template: pip-install-from-artifact-steps.template.yml
+  - template: pip-install-from-artifact-steps-template.yml
     parameters:
       freezeArtifact: ${{parameters.freezeArtifact}}
       freeseFile: ${{parameters.freezeFile}}

--- a/devops/unit-tests-pypi-job-template.yml
+++ b/devops/unit-tests-pypi-job-template.yml
@@ -11,8 +11,8 @@ parameters:
   targetType:
   versionFileArtifact:
   versionFileName:
-  freezeArtifact: ''
-  freezeFile: ''
+  freezeArtifactStem:
+  freezeFile: 
 
 jobs:
 - job: ${{ parameters.name }}
@@ -32,6 +32,7 @@ jobs:
       ${{ each pyVer in parameters.pyVersions }}:
         ${{ pyVer }}:
           PyVer: ${{ pyVer }}
+          FreezeArtifact: '${{parameters.freezeArtifactStem}}${{parameters.name}}${{pyVer}}'
 
   steps:
   # Remove the fairlearn/ directory (and some others)

--- a/devops/unit-tests-pypi-job-template.yml
+++ b/devops/unit-tests-pypi-job-template.yml
@@ -11,6 +11,8 @@ parameters:
   targetType:
   versionFileArtifact:
   versionFileName:
+  freezeArtifact: ''
+  freezeFile: ''
 
 jobs:
 - job: ${{ parameters.name }}
@@ -53,8 +55,10 @@ jobs:
       addToPath: true
 
   # Install our requirements from regular PyPI
-  - script: pip install -r ${{ parameters.requirementsFile }}
-    displayName: 'Install required packages specified in ${{ parameters.requirementsFile }}'
+  - template: pip-install-from-artifact-steps.template.yml
+    parameters:
+      freezeArtifact: ${{parameters.freezeArtifact}}
+      freeseFile: ${{parameters.freezeFile}}
 
   # Install fairlearn withe the specified version from the appropriate PyPI index
   - script: pip install --index-url $(pypiUrl) fairlearn==$(fairlearnVersionForpip)

--- a/devops/unit-tests-pypi-job-template.yml
+++ b/devops/unit-tests-pypi-job-template.yml
@@ -59,7 +59,7 @@ jobs:
   - template: pip-install-from-artifact-steps-template.yml
     parameters:
       freezeArtifact: $(FreezeArtifact)
-      freeseFile: ${{parameters.freezeFile}}
+      freezeFile: ${{parameters.freezeFile}}
 
   # Install fairlearn withe the specified version from the appropriate PyPI index
   - script: pip install --index-url $(pypiUrl) fairlearn==$(fairlearnVersionForpip)


### PR DESCRIPTION
Adjusts the release pipeline so that `pip freeze` is called at the beginning. The freeze files generated are stored in Artifacts and used in subsequent steps.

This avoids the problem of another group releasing an update when we have a release in flight.