### PR TITLE
ReadMe Processor for Releases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,11 @@ postprocessor.predict(X, sensitive_features=sensitive_features)
 
 We have a [Azure DevOps Pipeline](https://dev.azure.com/responsibleai/fairlearn/_build?definitionId=48&_a=summary) which takes care of building wheels and pushing to PyPI. Validations are also performed prior to any deployments, and also following the uploads to Test-PyPI and PyPI. To use it:
 1. Ensure that `_base_version` in `fairlearn/__init__.py` is set correctly for PyPI
-1. When queuing the pipeline, set the variable `DEV_VERSION` to an integer
-1. When the package is uploaded to Test-PyPI, this number will be appended to the version as a `dev[n]` suffix
+1. Put down a tag corresponding to this `_base_version` but preprended with `v`. For example, version `0.5.0` should be tagged wtih `v0.5.0`
+1. Queue the pipeline at this tag, with a variable `DEV_VERSION` set to zero. When the package is uploaded to Test-PyPI, this number will be appended to the version as a `dev[n]` suffix
 
-The pipeline requires sign offs immediately prior to the deployments to Test-PyPI and PyPI. One feature currently missing from the pipeline is tagging the released version. This can be done manually in the github page.
+The pipeline requires sign offs immediately prior to the deployments to Test-PyPI and PyPI. If there is an issue found, then after applying the fix, update the location of the tag, and queue a new release pipeline with the value of `DEV_VERSION` increased by one.
+
+The `DEV_VERSION` variable is to work around the PyPI behaviour where uploads are immutable and published immediately. This means that each upload to PyPI 'uses up' that particular version (on that particular PyPI instance). Since we wish to deploy exactly the same bits to both Test-PyPI and PyPI, without this workaround the version released to PyPI would depend on the number of issues discovered when uploading to Test-PyPI. If PyPI updates their release process to separate the 'upload' and 'publish' steps (i.e. until a package is published, it remains hidden and mutable) then the code associated with `DEV_VERSION` should be removed.
+
+As part of the release process, the `build-wheels.ps1` script uses `process_readme.py` to turn all the relative links in the ReadMe file into absolute ones (this is the reason why the applied tag has be of the form `v[_base_version]`). The `process_readme.py` script is slightly fragile with respect to the contents of the ReadMe, so after significant changes its output should be verified.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The fairlearn project seeks to enable anyone involved in the development of arti
 
 ## Current release
 
-- The current stable release is available at [fairlearn v0.4.0](https://github.com/fairlearn/fairlearn/tree/release/0.4.0).
+- The current stable release is available at [fairlearn v0.4.0](https://github.com/fairlearn/fairlearn/tree/v0.4.0).
 
 - Our current version differs substantially from version 0.2 or earlier. Users of these older versions should visit our [onboarding guide](#onboarding-guide).
 

--- a/scripts/build-wheels.ps1
+++ b/scripts/build-wheels.ps1
@@ -36,7 +36,7 @@ python $versionScript > $versionFilename
 Write-Host
 Write-Host "Updating ReadMe file"
 $readMeScript = Join-Path -resolve scripts process_readme.py
-python $readMeScript --input ReadMe.md --ouput ReadMe.md --loglevel INFO
+python $readMeScript --input ReadMe.md --output ReadMe.md --loglevel INFO
 
 # Create the packages
 Write-Host

--- a/scripts/build-wheels.ps1
+++ b/scripts/build-wheels.ps1
@@ -39,8 +39,12 @@ if ($LASTEXITCODE -ne 0)
 # Update the ReadMe file
 Write-Host
 Write-Host "Updating ReadMe file"
+Write-Host
+Get-ChildItem
+
 $readMeScript = Join-Path -resolve scripts process_readme.py
-python $readMeScript --input ReadMe.md --output ReadMe.md --loglevel INFO
+$target = Join-Path -resolve $(Get-Location) README.md
+python $readMeScript --input $target --output $target --loglevel INFO
 if ($LASTEXITCODE -ne 0)
 {
     throw "process_readme.py failed with result code $LASTEXITCODE"

--- a/scripts/build-wheels.ps1
+++ b/scripts/build-wheels.ps1
@@ -20,23 +20,9 @@ if( Test-Path env:FAIRLEARN_DEV_VERSION )
     throw "Environment variable FAIRLEARN_DEV_VERSION must not be set"
 }
 
-if( $targetType -eq "Test" )
-{
-    $Env:FAIRLEARN_DEV_VERSION = $devVersion
-}
-
-
-# Store fairlearn version (including FAIRLEARN_DEV_VERSION) in the file
-Write-Host "Storing fairlearn version i $versionFilename"
-pip install .
-$versionScript = Join-Path -resolve scripts fairlearn_version.py
-python $versionScript > $versionFilename
-if ($LASTEXITCODE -ne 0)
-{
-    throw "fairlearn_version.py failed with result code $LASTEXITCODE"
-}
-
 # Update the ReadMe file
+# Do this before setting FAIRLEARN_DEV_VERSION so that the links
+# on Test-PyPI are still correct
 Write-Host
 Write-Host "Updating ReadMe file"
 $readMeScript = Join-Path -resolve scripts process_readme.py
@@ -45,6 +31,22 @@ python $readMeScript --input $target --output $target --loglevel INFO
 if ($LASTEXITCODE -ne 0)
 {
     throw "process_readme.py failed with result code $LASTEXITCODE"
+}
+
+# Set the environment variable for test if required
+if( $targetType -eq "Test" )
+{
+    $Env:FAIRLEARN_DEV_VERSION = $devVersion
+}
+
+# Store fairlearn version (including FAIRLEARN_DEV_VERSION) in the specified file
+Write-Host "Storing fairlearn version i $versionFilename"
+pip install .
+$versionScript = Join-Path -resolve scripts fairlearn_version.py
+python $versionScript > $versionFilename
+if ($LASTEXITCODE -ne 0)
+{
+    throw "fairlearn_version.py failed with result code $LASTEXITCODE"
 }
 
 # Create the packages

--- a/scripts/build-wheels.ps1
+++ b/scripts/build-wheels.ps1
@@ -39,9 +39,6 @@ if ($LASTEXITCODE -ne 0)
 # Update the ReadMe file
 Write-Host
 Write-Host "Updating ReadMe file"
-Write-Host
-Get-ChildItem
-
 $readMeScript = Join-Path -resolve scripts process_readme.py
 $target = Join-Path -resolve $(Get-Location) README.md
 python $readMeScript --input $target --output $target --loglevel INFO

--- a/scripts/build-wheels.ps1
+++ b/scripts/build-wheels.ps1
@@ -27,9 +27,16 @@ if( $targetType -eq "Test" )
 
 
 # Store fairlearn version (including FAIRLEARN_DEV_VERSION) in the file
+Write-Host "Storing fairlearn version i $versionFilename"
 pip install .
 $versionScript = Join-Path -resolve scripts fairlearn_version.py
 python $versionScript > $versionFilename
+
+# Update the ReadMe file
+Write-Host
+Write-Host "Updating ReadMe file"
+$readMeScript = Join-Path -resolve scripts process_readme.py
+python $readMeScript --input ReadMe.md --ouput ReadMe.md --loglevel INFO
 
 # Create the packages
 Write-Host

--- a/scripts/build-wheels.ps1
+++ b/scripts/build-wheels.ps1
@@ -20,6 +20,9 @@ if( Test-Path env:FAIRLEARN_DEV_VERSION )
     throw "Environment variable FAIRLEARN_DEV_VERSION must not be set"
 }
 
+# Install ourselves
+pip install -e .
+
 # Update the ReadMe file
 # Do this before setting FAIRLEARN_DEV_VERSION so that the links
 # on Test-PyPI are still correct
@@ -41,7 +44,6 @@ if( $targetType -eq "Test" )
 
 # Store fairlearn version (including FAIRLEARN_DEV_VERSION) in the specified file
 Write-Host "Storing fairlearn version i $versionFilename"
-pip install .
 $versionScript = Join-Path -resolve scripts fairlearn_version.py
 python $versionScript > $versionFilename
 if ($LASTEXITCODE -ne 0)

--- a/scripts/build-wheels.ps1
+++ b/scripts/build-wheels.ps1
@@ -31,12 +31,20 @@ Write-Host "Storing fairlearn version i $versionFilename"
 pip install .
 $versionScript = Join-Path -resolve scripts fairlearn_version.py
 python $versionScript > $versionFilename
+if ($LASTEXITCODE -ne 0)
+{
+    throw "fairlearn_version.py failed with result code $LASTEXITCODE"
+}
 
 # Update the ReadMe file
 Write-Host
 Write-Host "Updating ReadMe file"
 $readMeScript = Join-Path -resolve scripts process_readme.py
 python $readMeScript --input ReadMe.md --output ReadMe.md --loglevel INFO
+if ($LASTEXITCODE -ne 0)
+{
+    throw "process_readme.py failed with result code $LASTEXITCODE"
+}
 
 # Create the packages
 Write-Host

--- a/scripts/process_readme.py
+++ b/scripts/process_readme.py
@@ -1,5 +1,11 @@
 import argparse
+import re
 import sys
+
+_BASE_URI_FORMAT = "https://github.com/fairlearn/fairlearn/tree/release/{0}"
+_CURRENT_RELEASE_PATTERN = r"\[fairlearn v(\d+\.\d+\.\d+)\]\(https://github.com/fairlearn/fairlearn/tree/release/\1\)"
+_OTHER_MD_REF_PATTERN = r"\]\(\./(\w+\.md)"
+_SAME_MD_REF_PATTERN = r"\]\((#\w+)\)"
 
 
 def build_argument_parser():
@@ -8,12 +14,47 @@ def build_argument_parser():
     parser = argparse.ArgumentParser(description=desc)
     parser.add_argument("--input", help="Path to the file to be processed", required=True)
     parser.add_argument("--output", help="Path to store the processed file", required=True)
+    parser.add_argument("--version", help="Target version", required=True)
 
     return parser
 
 
-def process_line(line):
+def get_base_path(target_version):
+    return _BASE_URI_FORMAT.format(target_version)
+
+
+def update_current_version(line, target_version):
+    current_release_pattern = re.compile(_CURRENT_RELEASE_PATTERN)
+
+    # Extract the current version from the line
+    match = current_release_pattern.search(line)
+    if match:
+        # Replace with the updated version
+        return line.replace(match.groups()[0], target_version)
+    return line
+
+
+def update_other_markdown_references(line, target_version):
+    markdown_ref_pattern = re.compile(_OTHER_MD_REF_PATTERN)
     result = line
+    match = markdown_ref_pattern.search(line)
+    if match:
+        print(line)
+        for m in match.groups():
+            old_str = "./{0}".format(m)
+            new_str = "{0}/{1}".format(get_base_path(target_version), m)
+            result = result.replace(old_str, new_str)
+
+    return result
+
+
+
+
+
+def process_line(line, target_version):
+    result = update_current_version(line, target_version)
+    result = update_other_markdown_references(result, target_version)
+
     return result
 
 
@@ -25,7 +66,7 @@ def main(argv):
     with open(args.input, 'r') as f:
         text_lines = f.readlines()
 
-    result_lines = [process_line(l) for l in text_lines]
+    result_lines = [process_line(l, args.version) for l in text_lines]
 
     with open(args.output, 'w') as f:
         f.writelines(result_lines)

--- a/scripts/process_readme.py
+++ b/scripts/process_readme.py
@@ -1,3 +1,15 @@
+"""Script to dynamically update the ReadMe file for a particular release
+
+Since PyPI and GitHub have slightly different ideas about markdown, we have to update
+the ReadMe file when we upload to PyPI. This script makes the necessary changes.
+Most of the updates performed should be fairly robust. The one which may give trouble
+is in 'update_current_version' which looks for _CURRENT_RELEASE_PATTERN in the
+text in order to update both the text and the link.
+
+The produced file assumes that a tag 'vX' (where X corresponds to the current version
+of `fairlearn`) exists in the repo. Otherwise, the links won't work.
+"""
+
 import argparse
 import logging
 import os

--- a/scripts/process_readme.py
+++ b/scripts/process_readme.py
@@ -1,0 +1,33 @@
+import argparse
+import sys
+
+
+def build_argument_parser():
+    desc = "Process ReadMe file for PyPI"
+
+    parser = argparse.ArgumentParser(description=desc)
+    parser.add_argument("--input", help="Path to the file to be processed", required=True)
+    parser.add_argument("--output", help="Path to store the processed file", required=True)
+
+    return parser
+
+
+def read_file_by_lines(input_file_path):
+    with open(input_file_path, 'r') as f:
+        return f.readlines()
+
+
+def main(argv):
+    parser = build_argument_parser()
+    args = parser.parse_args(argv)
+
+    text_lines = []
+    with open(args.input, 'r') as f:
+        text_lines = f.readlines()
+
+    with open(args.output, 'w') as f:
+        f.writelines(text_lines)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/scripts/process_readme.py
+++ b/scripts/process_readme.py
@@ -12,9 +12,9 @@ def build_argument_parser():
     return parser
 
 
-def read_file_by_lines(input_file_path):
-    with open(input_file_path, 'r') as f:
-        return f.readlines()
+def process_line(line):
+    result = line
+    return result
 
 
 def main(argv):
@@ -25,8 +25,10 @@ def main(argv):
     with open(args.input, 'r') as f:
         text_lines = f.readlines()
 
+    result_lines = [process_line(l) for l in text_lines]
+
     with open(args.output, 'w') as f:
-        f.writelines(text_lines)
+        f.writelines(result_lines)
 
 
 if __name__ == "__main__":

--- a/scripts/process_readme.py
+++ b/scripts/process_readme.py
@@ -12,7 +12,6 @@ of `fairlearn`) exists in the repo. Otherwise, the links won't work.
 
 import argparse
 import logging
-import os
 import re
 import sys
 
@@ -38,7 +37,6 @@ def build_argument_parser():
 
 
 def get_fairlearn_version():
-    sys.path.insert(0, os.getcwd())
     import fairlearn
     return fairlearn.__version__
 

--- a/scripts/process_readme.py
+++ b/scripts/process_readme.py
@@ -5,7 +5,7 @@ import sys
 _BASE_URI_FORMAT = "https://github.com/fairlearn/fairlearn/tree/release/{0}"
 _CURRENT_RELEASE_PATTERN = r"\[fairlearn v(\d+\.\d+\.\d+)\]\(https://github.com/fairlearn/fairlearn/tree/release/\1\)"
 _OTHER_MD_REF_PATTERN = r"\]\(\./(\w+\.md)"
-_SAME_MD_REF_PATTERN = r"\]\((#\w+)\)"
+_SAME_MD_REF_PATTERN = r"\]\((#.+)\)"
 
 
 def build_argument_parser():
@@ -39,7 +39,6 @@ def update_other_markdown_references(line, target_version):
     result = line
     match = markdown_ref_pattern.search(line)
     if match:
-        print(line)
         for m in match.groups():
             old_str = "./{0}".format(m)
             new_str = "{0}/{1}".format(get_base_path(target_version), m)
@@ -48,12 +47,24 @@ def update_other_markdown_references(line, target_version):
     return result
 
 
+def update_same_page_references(line, target_version):
+    same_page_ref_pattern = re.compile(_SAME_MD_REF_PATTERN)
+    result = line
+    match = same_page_ref_pattern.search(line)
+    if match:
+        print(line)
+        for m in match.groups():
+            old_str = m
+            new_str = "{0}{1}".format(get_base_path(target_version), m)
+            result = result.replace(old_str, new_str)
 
+    return result
 
 
 def process_line(line, target_version):
     result = update_current_version(line, target_version)
     result = update_other_markdown_references(result, target_version)
+    result = update_same_page_references(result, target_version)
 
     return result
 

--- a/scripts/process_readme.py
+++ b/scripts/process_readme.py
@@ -7,7 +7,7 @@ import sys
 logger = logging.getLogger(__name__)
 
 _BASE_URI_FORMAT = "https://github.com/fairlearn/fairlearn/tree/v{0}"
-_CURRENT_RELEASE_PATTERN = r"\[fairlearn v(\S+)\]\(https://github.com/fairlearn/fairlearn/tree/v\1\)"
+_CURRENT_RELEASE_PATTERN = r"\[fairlearn v(\S+)\]\(https://github.com/fairlearn/fairlearn/tree/v\1\)"  # noqa: E501
 _OTHER_MD_REF_PATTERN = r"\]\(\./(\w+\.md)"
 _SAME_MD_REF_PATTERN = r"\]\((#.+)\)"
 


### PR DESCRIPTION
Create a python script to translate `ReadMe.md` from GitHub to PyPI. This will avoid the need to create a branch to do a release.

This script is slightly dependent on the structure of the file, so if there are substantial changes to that, this script will require updating. It also assumes that a tag `v(fairlearn.__version__)` exists in the repo.