### PR TITLE
Track pip dependencies

### DIFF
--- a/devops/PR-Gate.yml
+++ b/devops/PR-Gate.yml
@@ -39,7 +39,5 @@ jobs:
 - template: notebook-job-template.yml
   parameters:
     pyVersions: [3.6]
-    freezeArtifactStem: $(FreezeArtifactStem)
-    freezeFile: $(freezeFile)
 
 - template: build-widget-job-template.yml

--- a/devops/PR-Gate.yml
+++ b/devops/PR-Gate.yml
@@ -1,5 +1,5 @@
 variables:
-  StoreFreeze: true
+  StoreFreeze: True
   FreezeArtifactStem: 'freeze'
   FreezeFile: 'requirements-freeze.txt'
 

--- a/devops/PR-Gate.yml
+++ b/devops/PR-Gate.yml
@@ -1,5 +1,5 @@
 variables:
-  StoreFreeze: True
+  StoreFreeze: 'True'
   FreezeArtifactStem: 'freeze'
   FreezeFile: 'requirements-freeze.txt'
 

--- a/devops/PR-Gate.yml
+++ b/devops/PR-Gate.yml
@@ -1,3 +1,8 @@
+variables:
+  StoreFreeze: true
+  FreezeArtifactStem: 'freeze'
+  FreezeFile: 'requirements-freeze.txt'
+
 pr:
 - master
 - release/*
@@ -13,21 +18,33 @@ jobs:
     name: Linux
     vmImage: 'ubuntu-16.04'
     pyVersions: [3.6]
+    storeFreeze: $(StoreFreeze)
+    freezeArtifactStem: $(FreezeArtifactStem)
+    freezeFile: $(freezeFile)
 
 - template: all-tests-job-template.yml
   parameters:
     name: Windows
     vmImage:  'vs2017-win2016'
     pyVersions: [3.5]
+    storeFreeze: $(StoreFreeze)
+    freezeArtifactStem: $(FreezeArtifactStem)
+    freezeFile: $(freezeFile)
     
 - template: all-tests-job-template.yml
   parameters:
     name: MacOS
     vmImage:  'macos-latest'
     pyVersions: [3.7] 
+    storeFreeze: $(StoreFreeze)
+    freezeArtifactStem: $(FreezeArtifactStem)
+    freezeFile: $(freezeFile)
 
 - template: notebook-job-template.yml
   parameters:
     pyVersions: [3.6]
+    storeFreeze: $(StoreFreeze)
+    freezeArtifactStem: $(FreezeArtifactStem)
+    freezeFile: $(freezeFile)
 
 - template: build-widget-job-template.yml

--- a/devops/PR-Gate.yml
+++ b/devops/PR-Gate.yml
@@ -1,6 +1,6 @@
 variables:
   FreezeArtifactStem: 'freeze'
-  FreezeFile: 'requirements-freeze.txt'
+  FreezeFileStem: 'requirements-freeze'
 
 pr:
 - master
@@ -18,7 +18,7 @@ jobs:
     vmImage: 'ubuntu-16.04'
     pyVersions: [3.6]
     freezeArtifactStem: $(FreezeArtifactStem)
-    freezeFile: $(freezeFile)
+    freezeFileStem: $(FreezeFileStem)
 
 - template: all-tests-job-template.yml
   parameters:
@@ -26,7 +26,7 @@ jobs:
     vmImage:  'vs2017-win2016'
     pyVersions: [3.5]
     freezeArtifactStem: $(FreezeArtifactStem)
-    freezeFile: $(freezeFile)
+    freezeFileStem: $(FreezeFileStem)
     
 - template: all-tests-job-template.yml
   parameters:
@@ -34,7 +34,7 @@ jobs:
     vmImage:  'macos-latest'
     pyVersions: [3.7]
     freezeArtifactStem: $(FreezeArtifactStem)
-    freezeFile: $(freezeFile)
+    freezeFileStem: $(FreezeFileStem)
 
 - template: notebook-job-template.yml
   parameters:

--- a/devops/PR-Gate.yml
+++ b/devops/PR-Gate.yml
@@ -1,5 +1,4 @@
 variables:
-  StoreFreeze: 'True'
   FreezeArtifactStem: 'freeze'
   FreezeFile: 'requirements-freeze.txt'
 
@@ -18,7 +17,6 @@ jobs:
     name: Linux
     vmImage: 'ubuntu-16.04'
     pyVersions: [3.6]
-    storeFreeze: $(StoreFreeze)
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFile: $(freezeFile)
 
@@ -27,7 +25,6 @@ jobs:
     name: Windows
     vmImage:  'vs2017-win2016'
     pyVersions: [3.5]
-    storeFreeze: $(StoreFreeze)
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFile: $(freezeFile)
     
@@ -35,15 +32,13 @@ jobs:
   parameters:
     name: MacOS
     vmImage:  'macos-latest'
-    pyVersions: [3.7] 
-    storeFreeze: $(StoreFreeze)
+    pyVersions: [3.7]
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFile: $(freezeFile)
 
 - template: notebook-job-template.yml
   parameters:
     pyVersions: [3.6]
-    storeFreeze: $(StoreFreeze)
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFile: $(freezeFile)
 

--- a/devops/all-tests-job-template.yml
+++ b/devops/all-tests-job-template.yml
@@ -3,7 +3,7 @@ parameters:
   vmImage: ''
   pyVersions: [3.5, 3.6, 3.7]
   requirementsFile: 'requirements.txt'
-  storeFreeze: false
+  storeFreeze: False
   freezeArtifactStem: 
   freezeFile:
 

--- a/devops/all-tests-job-template.yml
+++ b/devops/all-tests-job-template.yml
@@ -3,6 +3,9 @@ parameters:
   vmImage: ''
   pyVersions: [3.5, 3.6, 3.7]
   requirementsFile: 'requirements.txt'
+  storeFreeze: false
+  freezeArtifactStem: 
+  freezeFile:
 
 jobs:
 - job: ${{ parameters.name }}
@@ -14,6 +17,7 @@ jobs:
       ${{ each pyVer in parameters.pyVersions }}:
         ${{ pyVer }}:
           PyVer: ${{ pyVer }}
+          FreezeArtifact: '${{parameters.freezeArtifactStem}}${{parameters.name}}${{pyVer}}'
 
   steps:
   - task: UsePythonVersion@0
@@ -24,6 +28,12 @@ jobs:
 
   - script: pip install -r ${{ parameters.requirementsFile }}
     displayName: 'Install required packages specified in ${{ parameters.requirementsFile }}'
+
+  - template: pip-freeze-to-artifact-steps-template.yml
+    parameters:
+      storeFreeze: ${{parameters.storeFreeze}}
+      freezeArtifact: $(FreezeArtifact)
+      freezeFile: ${{parameters.FreezeFile}}
     
   - script: python ./scripts/requirementscheck.py --fixed requirements-fixed.txt --lowerbound requirements.txt
     displayName: "Run check on requirements files"

--- a/devops/all-tests-job-template.yml
+++ b/devops/all-tests-job-template.yml
@@ -4,7 +4,7 @@ parameters:
   pyVersions: [3.5, 3.6, 3.7]
   requirementsFile: 'requirements.txt'
   freezeArtifactStem: 
-  freezeFile:
+  freezeFileStem:
 
 jobs:
 - job: ${{ parameters.name }}
@@ -17,6 +17,7 @@ jobs:
         ${{ pyVer }}:
           PyVer: ${{ pyVer }}
           FreezeArtifact: '${{parameters.freezeArtifactStem}}${{parameters.name}}${{pyVer}}'
+          FreezeFile: '${{parameters.freezeFileStem}}-${{parameters.name}}${{pyVer}}.txt'
 
   steps:
   - task: UsePythonVersion@0
@@ -31,7 +32,7 @@ jobs:
   - template: pip-freeze-to-artifact-steps-template.yml
     parameters:
       freezeArtifact: $(FreezeArtifact)
-      freezeFile: ${{parameters.FreezeFile}}
+      freezeFile: $(FreezeFile)
     
   - script: python ./scripts/requirementscheck.py --fixed requirements-fixed.txt --lowerbound requirements.txt
     displayName: "Run check on requirements files"

--- a/devops/all-tests-job-template.yml
+++ b/devops/all-tests-job-template.yml
@@ -3,7 +3,6 @@ parameters:
   vmImage: ''
   pyVersions: [3.5, 3.6, 3.7]
   requirementsFile: 'requirements.txt'
-  storeFreeze: False
   freezeArtifactStem: 
   freezeFile:
 
@@ -31,7 +30,6 @@ jobs:
 
   - template: pip-freeze-to-artifact-steps-template.yml
     parameters:
-      storeFreeze: ${{parameters.storeFreeze}}
       freezeArtifact: $(FreezeArtifact)
       freezeFile: ${{parameters.FreezeFile}}
     

--- a/devops/create-wheel-step-template.yml
+++ b/devops/create-wheel-step-template.yml
@@ -7,7 +7,6 @@ parameters:
   versionFilename: ''
   packageArtifactName: ''
   versionArtifactName: ''
-  storeFreeze: False
   freezeArtifactStem: 
   freezeFile:
 
@@ -26,7 +25,6 @@ steps:
 
 - template: pip-freeze-to-artifact-steps-template.yml
   parameters:
-    storeFreeze: ${{parameters.storeFreeze}}
     freezeArtifact: '${{parameters.freezeArtifactStem}}CreateWheel'
     freezeFile: ${{parameters.FreezeFile}}
 

--- a/devops/create-wheel-step-template.yml
+++ b/devops/create-wheel-step-template.yml
@@ -7,6 +7,9 @@ parameters:
   versionFilename: ''
   packageArtifactName: ''
   versionArtifactName: ''
+  storeFreeze: false
+  freezeArtifactStem: 
+  freezeFile:
 
 steps:
 - task: UsePythonVersion@0
@@ -20,6 +23,12 @@ steps:
 
 - script: pip install -r requirements.txt
   displayName: "Install fairlearn requirements"
+
+- template: pip-freeze-to-artifact-steps-template.yml
+  parameters:
+    storeFreeze: ${{parameters.storeFreeze}}
+    freezeArtifact: '${{parameters.freezeArtifactStem}}CreateWheel'
+    freezeFile: ${{parameters.FreezeFile}}
 
 - task: PowerShell@2
   displayName: 'Build widget'

--- a/devops/create-wheel-step-template.yml
+++ b/devops/create-wheel-step-template.yml
@@ -7,7 +7,7 @@ parameters:
   versionFilename: ''
   packageArtifactName: ''
   versionArtifactName: ''
-  storeFreeze: false
+  storeFreeze: False
   freezeArtifactStem: 
   freezeFile:
 

--- a/devops/nightly-requirements-fixed.yml
+++ b/devops/nightly-requirements-fixed.yml
@@ -2,7 +2,6 @@
 # This does not run on MacOS due to issues with the pinned requirements
 
 variables:
-  StoreFreeze: 'True'
   FreezeArtifactStem: 'freeze'
   FreezeFile: 'requirements-freeze.txt'
 
@@ -28,7 +27,6 @@ jobs:
     vmImage: 'ubuntu-16.04'
     requirementsFile: 'requirements-fixed.txt'
     pyVersions: [3.6, 3.7]
-    storeFreeze: $(StoreFreeze)
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFile: $(freezeFile)
 
@@ -37,7 +35,6 @@ jobs:
     name: Windows
     vmImage:  'vs2017-win2016'
     requirementsFile: 'requirements-fixed.txt'
-    storeFreeze: $(StoreFreeze)
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFile: $(freezeFile)
 

--- a/devops/nightly-requirements-fixed.yml
+++ b/devops/nightly-requirements-fixed.yml
@@ -2,7 +2,7 @@
 # This does not run on MacOS due to issues with the pinned requirements
 
 variables:
-  StoreFreeze: true
+  StoreFreeze: True
   FreezeArtifactStem: 'freeze'
   FreezeFile: 'requirements-freeze.txt'
 

--- a/devops/nightly-requirements-fixed.yml
+++ b/devops/nightly-requirements-fixed.yml
@@ -2,7 +2,7 @@
 # This does not run on MacOS due to issues with the pinned requirements
 
 variables:
-  StoreFreeze: True
+  StoreFreeze: 'True'
   FreezeArtifactStem: 'freeze'
   FreezeFile: 'requirements-freeze.txt'
 

--- a/devops/nightly-requirements-fixed.yml
+++ b/devops/nightly-requirements-fixed.yml
@@ -3,7 +3,7 @@
 
 variables:
   FreezeArtifactStem: 'freeze'
-  FreezeFile: 'requirements-freeze.txt'
+  FreezeFileStem: 'requirements-freeze'
 
 trigger: none # No CI build
 
@@ -28,7 +28,7 @@ jobs:
     requirementsFile: 'requirements-fixed.txt'
     pyVersions: [3.6, 3.7]
     freezeArtifactStem: $(FreezeArtifactStem)
-    freezeFile: $(freezeFile)
+    freezeFileStem: $(FreezeFileStem)
 
 - template: all-tests-job-template.yml
   parameters:
@@ -36,7 +36,7 @@ jobs:
     vmImage:  'vs2017-win2016'
     requirementsFile: 'requirements-fixed.txt'
     freezeArtifactStem: $(FreezeArtifactStem)
-    freezeFile: $(freezeFile)
+    freezeFileStem: $(FreezeFileStem)
 
 - template: notebook-job-template.yml
   parameters:

--- a/devops/nightly-requirements-fixed.yml
+++ b/devops/nightly-requirements-fixed.yml
@@ -1,6 +1,11 @@
 # Nightly build pipeline which uses the requirements-fixed.txt file
 # This does not run on MacOS due to issues with the pinned requirements
 
+variables:
+  StoreFreeze: true
+  FreezeArtifactStem: 'freeze'
+  FreezeFile: 'requirements-freeze.txt'
+
 trigger: none # No CI build
 
 pr: none # Not for pull requests
@@ -22,19 +27,25 @@ jobs:
     name: Linux
     vmImage: 'ubuntu-16.04'
     requirementsFile: 'requirements-fixed.txt'
-    pyVersions: [3.6, 3.7] 
+    pyVersions: [3.6, 3.7]
+    storeFreeze: $(StoreFreeze)
+    freezeArtifactStem: $(FreezeArtifactStem)
+    freezeFile: $(freezeFile)
 
 - template: all-tests-job-template.yml
   parameters:
     name: Windows
     vmImage:  'vs2017-win2016'
     requirementsFile: 'requirements-fixed.txt'
+    storeFreeze: $(StoreFreeze)
+    freezeArtifactStem: $(FreezeArtifactStem)
+    freezeFile: $(freezeFile)
 
 - template: notebook-job-template.yml
   parameters:
     name: LinuxNotebooks
     vmImage: 'ubuntu-16.04'
     requirementsFile: 'requirements-fixed.txt'
-    pyVersions: [3.6, 3.7] 
+    pyVersions: [3.6, 3.7]
 
 - template: build-widget-job-template.yml

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -1,7 +1,7 @@
 # Nightly build pipeline
 
 variables:
-  StoreFreeze: True
+  StoreFreeze: 'True'
   FreezeArtifactStem: 'freeze'
   FreezeFile: 'requirements-freeze.txt'
 

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -1,7 +1,6 @@
 # Nightly build pipeline
 
 variables:
-  StoreFreeze: 'True'
   FreezeArtifactStem: 'freeze'
   FreezeFile: 'requirements-freeze.txt'
 
@@ -26,7 +25,6 @@ jobs:
     name: Linux
     vmImage: 'ubuntu-16.04'
     pyVersions: [3.6, 3.7]
-    storeFreeze: $(StoreFreeze)
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFile: $(freezeFile)
 
@@ -34,7 +32,6 @@ jobs:
   parameters:
     name: Windows
     vmImage:  'vs2017-win2016'
-    storeFreeze: $(StoreFreeze)
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFile: $(freezeFile)
     
@@ -43,7 +40,6 @@ jobs:
     name: MacOS
     vmImage:  'macos-latest'
     pyVersions: [3.6, 3.7]
-    storeFreeze: $(StoreFreeze)
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFile: $(freezeFile)
 

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -1,7 +1,7 @@
 # Nightly build pipeline
 
 variables:
-  StoreFreeze: true
+  StoreFreeze: True
   FreezeArtifactStem: 'freeze'
   FreezeFile: 'requirements-freeze.txt'
 

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -1,5 +1,10 @@
 # Nightly build pipeline
 
+variables:
+  StoreFreeze: true
+  FreezeArtifactStem: 'freeze'
+  FreezeFile: 'requirements-freeze.txt'
+
 trigger: none # No CI build
 
 pr: none # Not for pull requests
@@ -20,18 +25,27 @@ jobs:
   parameters:
     name: Linux
     vmImage: 'ubuntu-16.04'
-    pyVersions: [3.6, 3.7] 
+    pyVersions: [3.6, 3.7]
+    storeFreeze: $(StoreFreeze)
+    freezeArtifactStem: $(FreezeArtifactStem)
+    freezeFile: $(freezeFile)
 
 - template: all-tests-job-template.yml
   parameters:
     name: Windows
     vmImage:  'vs2017-win2016'
+    storeFreeze: $(StoreFreeze)
+    freezeArtifactStem: $(FreezeArtifactStem)
+    freezeFile: $(freezeFile)
     
 - template: all-tests-job-template.yml
   parameters:
     name: MacOS
     vmImage:  'macos-latest'
-    pyVersions: [3.6, 3.7] 
+    pyVersions: [3.6, 3.7]
+    storeFreeze: $(StoreFreeze)
+    freezeArtifactStem: $(FreezeArtifactStem)
+    freezeFile: $(freezeFile)
 
 - template: notebook-job-template.yml
   parameters:

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -2,7 +2,7 @@
 
 variables:
   FreezeArtifactStem: 'freeze'
-  FreezeFile: 'requirements-freeze.txt'
+  FreezeFileStem: 'requirements-freeze'
 
 trigger: none # No CI build
 
@@ -26,14 +26,14 @@ jobs:
     vmImage: 'ubuntu-16.04'
     pyVersions: [3.6, 3.7]
     freezeArtifactStem: $(FreezeArtifactStem)
-    freezeFile: $(freezeFile)
+    freezeFileStem: $(FreezeFileStem)
 
 - template: all-tests-job-template.yml
   parameters:
     name: Windows
     vmImage:  'vs2017-win2016'
     freezeArtifactStem: $(FreezeArtifactStem)
-    freezeFile: $(freezeFile)
+    freezeFileStem: $(FreezeFileStem)
     
 - template: all-tests-job-template.yml
   parameters:
@@ -41,7 +41,7 @@ jobs:
     vmImage:  'macos-latest'
     pyVersions: [3.6, 3.7]
     freezeArtifactStem: $(FreezeArtifactStem)
-    freezeFile: $(freezeFile)
+    freezeFileStem: $(FreezeFileStem)
 
 - template: notebook-job-template.yml
   parameters:

--- a/devops/pip-freeze-to-artifact-steps-template.yml
+++ b/devops/pip-freeze-to-artifact-steps-template.yml
@@ -1,16 +1,14 @@
 parameters:
-  storeFreeze: 'False'
   freezeArtifact:
   freezeFile:
 
   
 steps:
-  - ${{ if eq( parameters.storeFreeze, 'True' ) }}:
-    - script: pip freeze > ${{parameters.freezeFile}}
-      displayName: "Run pip freeze"
+  - script: pip freeze > ${{parameters.freezeFile}}
+    displayName: "Run pip freeze"
 
-    - task: PublishPipelineArtifact@1
-      displayName: "Publish pip freeze file to artifact ${{parameters.freezeArtifact}}"
-      inputs:
-        path: '$(System.DefaultWorkingDirectory)/${{parameters.freezeFile}}'
-        artifact: ${{parameters.freezeArtifact}}
+  - task: PublishPipelineArtifact@1
+    displayName: "Publish pip freeze file to artifact ${{parameters.freezeArtifact}}"
+    inputs:
+      path: '$(System.DefaultWorkingDirectory)/${{parameters.freezeFile}}'
+      artifact: ${{parameters.freezeArtifact}}

--- a/devops/pip-freeze-to-artifact-steps-template.yml
+++ b/devops/pip-freeze-to-artifact-steps-template.yml
@@ -5,7 +5,7 @@ parameters:
 
   
 steps:
-  - ${{ if parameters.storeFreeze }}:
+  - ${{ if eq( 'True', parameters.storeFreeze ) }}:
     - script: pip freeze > ${{parameters.freezeFile}}
       displayName: "Run pip freeze"
 

--- a/devops/pip-freeze-to-artifact-steps-template.yml
+++ b/devops/pip-freeze-to-artifact-steps-template.yml
@@ -1,0 +1,16 @@
+parameters:
+  storeFreeze: false
+  freezeArtifact:
+  freezeFile:
+
+  
+steps:
+  - ${{ if parameters.storeFreeze }}:
+    - script: pip freeze > ${{parameters.freezeFile}}
+      displayName: "Run pip freeze"
+
+    - task: PublishPipelineArtifact@1
+      displayName: "Publish pip freeze file to artifact ${{parameters.freezeArtifact}}"
+      inputs:
+        path: '$(System.DefaultWorkingDirectory)/${{parameters.freezeFile}}'
+        artifact: ${{parameters.freezeArtifact}}

--- a/devops/pip-freeze-to-artifact-steps-template.yml
+++ b/devops/pip-freeze-to-artifact-steps-template.yml
@@ -1,11 +1,11 @@
 parameters:
-  storeFreeze: False
+  storeFreeze: 'False'
   freezeArtifact:
   freezeFile:
 
   
 steps:
-  - ${{ if eq( 'True', parameters.storeFreeze ) }}:
+  - ${{ if eq( parameters.storeFreeze, 'True' ) }}:
     - script: pip freeze > ${{parameters.freezeFile}}
       displayName: "Run pip freeze"
 

--- a/devops/pip-freeze-to-artifact-steps-template.yml
+++ b/devops/pip-freeze-to-artifact-steps-template.yml
@@ -1,5 +1,5 @@
 parameters:
-  storeFreeze: false
+  storeFreeze: False
   freezeArtifact:
   freezeFile:
 

--- a/devops/pypi-deployment-stages-template.yml
+++ b/devops/pypi-deployment-stages-template.yml
@@ -18,6 +18,9 @@ parameters:
   kvVaultName:
   kvUsername:
   kvPassword:
+  storeFreeze: false
+  freezeArtifactStem: 
+  freezeFile:
 
 stages:
 # Create the PyPI package and save as a artifact
@@ -36,6 +39,9 @@ stages:
         packageArtifactName: '${{parameters.packageArtifactStem}}${{parameters.targetType}}'
         versionArtifactName: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
         versionFilename: '${{parameters.versionFileStem}}${{parameters.targetType}}'
+        storeFreeze: ${{parameters.storeFreeze}}
+        freezeArtifactStem: '${{parameters.freezeArtifactStem}}${{parameters.targetType}}'
+        freezeFile: ${{parameters.freezeFile}}
 
 
 # Upload the package to the appropriate PyPI index

--- a/devops/pypi-deployment-stages-template.yml
+++ b/devops/pypi-deployment-stages-template.yml
@@ -18,7 +18,7 @@ parameters:
   kvVaultName:
   kvUsername:
   kvPassword:
-  storeFreeze: false
+  storeFreeze: False
   freezeArtifactStem: 
   freezeFile:
 

--- a/devops/pypi-deployment-stages-template.yml
+++ b/devops/pypi-deployment-stages-template.yml
@@ -19,7 +19,7 @@ parameters:
   kvUsername:
   kvPassword:
   freezeArtifactStem: 
-  freezeFile:
+  freezeFileStem:
 
 stages:
 # Create the PyPI package and save as a artifact
@@ -39,7 +39,7 @@ stages:
         versionArtifactName: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
         versionFilename: '${{parameters.versionFileStem}}${{parameters.targetType}}'
         freezeArtifactStem: '${{parameters.freezeArtifactStem}}${{parameters.targetType}}'
-        freezeFile: ${{parameters.freezeFile}}
+        freezeFile: '${{parameters.freezeFileStem}}-${{parameters.targetType}}-create-wheel.txt'
 
 
 # Upload the package to the appropriate PyPI index

--- a/devops/pypi-deployment-stages-template.yml
+++ b/devops/pypi-deployment-stages-template.yml
@@ -18,7 +18,6 @@ parameters:
   kvVaultName:
   kvUsername:
   kvPassword:
-  storeFreeze: False
   freezeArtifactStem: 
   freezeFile:
 
@@ -39,7 +38,6 @@ stages:
         packageArtifactName: '${{parameters.packageArtifactStem}}${{parameters.targetType}}'
         versionArtifactName: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
         versionFilename: '${{parameters.versionFileStem}}${{parameters.targetType}}'
-        storeFreeze: ${{parameters.storeFreeze}}
         freezeArtifactStem: '${{parameters.freezeArtifactStem}}${{parameters.targetType}}'
         freezeFile: ${{parameters.freezeFile}}
 

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -59,8 +59,6 @@ stages:
   - template: notebook-job-template.yml
     parameters:
       pyVersions: [3.6]
-      freezeArtifactStem: "PreDeployment"
-      freezeFile: "requirements-freeze.txt"
 
 
 # =================================================================================================================

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -67,7 +67,7 @@ stages:
     kvVaultName: fairlearndeploy
     kvUsername: 'usernametest'
     kvPassword: 'passwordtest'
-    storeFreeze: true
+    storeFreeze: True
     freezeArtifactStem: 'Freeze'
     freezeFile: 'requirements-freeze.txt'
 
@@ -82,6 +82,6 @@ stages:
     kvVaultName: fairlearndeploy
     kvUsername: 'usernameprod'
     kvPassword: 'passwordprod'
-    storeFreeze: true
+    storeFreeze: True
     freezeArtifactStem: 'Freeze'
     freezeFile: 'requirements-freeze.txt'

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -37,22 +37,30 @@ stages:
       name: Linux
       vmImage: 'ubuntu-16.04'
       pyVersions: [3.6,3.7]
+      freezeArtifactStem: "PreDeployment"
+      freezeFile: "requirements.txt"
 
   - template: all-tests-job-template.yml
     parameters:
       name: Windows
       vmImage:  'vs2017-win2016'
       pyVersions: [3.5, 3.6, 3.7]
+      freezeArtifactStem: "PreDeployment"
+      freezeFile: "requirements.txt"
       
   - template: all-tests-job-template.yml
     parameters:
       name: MacOS
       vmImage:  'macos-latest'
       pyVersions: [3.6, 3.7] 
+      freezeArtifactStem: "PreDeployment"
+      freezeFile: "requirements.txt"
 
   - template: notebook-job-template.yml
     parameters:
       pyVersions: [3.6]
+      freezeArtifactStem: "PreDeployment"
+      freezeFile: "requirements.txt"
 
 
 # =================================================================================================================

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -20,7 +20,7 @@
 variables:
   poolImage: "ubuntu-latest"
   poolPythonVersion: 3.6
-  FreezeFileStem: 'requirements-freeze'
+  FreezeFileStem: 'requirements-freeze-predeploy'
 
 trigger: none # No CI build
 
@@ -75,7 +75,7 @@ stages:
     kvUsername: 'usernametest'
     kvPassword: 'passwordtest'
     freezeArtifactStem: 'Freeze'
-    freezeFileStem: $(FreezeFileStem)
+    freezeFileStem: 'requirements-freeze'
 
 # =================================================================================================================
 
@@ -89,4 +89,4 @@ stages:
     kvUsername: 'usernameprod'
     kvPassword: 'passwordprod'
     freezeArtifactStem: 'Freeze'
-    freezeFileStem: $(FreezeFileStem)
+    freezeFileStem: 'requirements-freeze'

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -67,6 +67,9 @@ stages:
     kvVaultName: fairlearndeploy
     kvUsername: 'usernametest'
     kvPassword: 'passwordtest'
+    storeFreeze: true
+    freezeArtifactStem: 'Freeze'
+    freezeFile: 'requirements-freeze.txt'
 
 # =================================================================================================================
 
@@ -79,3 +82,6 @@ stages:
     kvVaultName: fairlearndeploy
     kvUsername: 'usernameprod'
     kvPassword: 'passwordprod'
+    storeFreeze: true
+    freezeArtifactStem: 'Freeze'
+    freezeFile: 'requirements-freeze.txt'

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -38,7 +38,7 @@ stages:
       vmImage: 'ubuntu-16.04'
       pyVersions: [3.6,3.7]
       freezeArtifactStem: "PreDeployment"
-      freezeFile: "requirements.txt"
+      freezeFile: "requirements-freeze.txt"
 
   - template: all-tests-job-template.yml
     parameters:
@@ -46,7 +46,7 @@ stages:
       vmImage:  'vs2017-win2016'
       pyVersions: [3.5, 3.6, 3.7]
       freezeArtifactStem: "PreDeployment"
-      freezeFile: "requirements.txt"
+      freezeFile: "requirements-freeze.txt"
       
   - template: all-tests-job-template.yml
     parameters:
@@ -54,13 +54,13 @@ stages:
       vmImage:  'macos-latest'
       pyVersions: [3.6, 3.7] 
       freezeArtifactStem: "PreDeployment"
-      freezeFile: "requirements.txt"
+      freezeFile: "requirements-freeze.txt"
 
   - template: notebook-job-template.yml
     parameters:
       pyVersions: [3.6]
       freezeArtifactStem: "PreDeployment"
-      freezeFile: "requirements.txt"
+      freezeFile: "requirements-freeze.txt"
 
 
 # =================================================================================================================

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -67,7 +67,6 @@ stages:
     kvVaultName: fairlearndeploy
     kvUsername: 'usernametest'
     kvPassword: 'passwordtest'
-    storeFreeze: True
     freezeArtifactStem: 'Freeze'
     freezeFile: 'requirements-freeze.txt'
 
@@ -82,6 +81,5 @@ stages:
     kvVaultName: fairlearndeploy
     kvUsername: 'usernameprod'
     kvPassword: 'passwordprod'
-    storeFreeze: True
     freezeArtifactStem: 'Freeze'
     freezeFile: 'requirements-freeze.txt'

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -20,6 +20,7 @@
 variables:
   poolImage: "ubuntu-latest"
   poolPythonVersion: 3.6
+  FreezeFileStem: 'requirements-freeze'
 
 trigger: none # No CI build
 
@@ -38,7 +39,7 @@ stages:
       vmImage: 'ubuntu-16.04'
       pyVersions: [3.6,3.7]
       freezeArtifactStem: "PreDeployment"
-      freezeFile: "requirements-freeze.txt"
+      freezeFileStem: $(FreezeFileStem)
 
   - template: all-tests-job-template.yml
     parameters:
@@ -46,7 +47,7 @@ stages:
       vmImage:  'vs2017-win2016'
       pyVersions: [3.5, 3.6, 3.7]
       freezeArtifactStem: "PreDeployment"
-      freezeFile: "requirements-freeze.txt"
+      freezeFileStem: $(FreezeFileStem)
       
   - template: all-tests-job-template.yml
     parameters:
@@ -54,7 +55,7 @@ stages:
       vmImage:  'macos-latest'
       pyVersions: [3.6, 3.7] 
       freezeArtifactStem: "PreDeployment"
-      freezeFile: "requirements-freeze.txt"
+      freezeFileStem: $(FreezeFileStem)
 
   - template: notebook-job-template.yml
     parameters:
@@ -74,7 +75,7 @@ stages:
     kvUsername: 'usernametest'
     kvPassword: 'passwordtest'
     freezeArtifactStem: 'Freeze'
-    freezeFile: 'requirements-freeze.txt'
+    freezeFileStem: $(FreezeFileStem)
 
 # =================================================================================================================
 
@@ -88,4 +89,4 @@ stages:
     kvUsername: 'usernameprod'
     kvPassword: 'passwordprod'
     freezeArtifactStem: 'Freeze'
-    freezeFile: 'requirements-freeze.txt'
+    freezeFileStem: $(FreezeFileStem)


### PR DESCRIPTION
We've had trouble with our dependencies updating and breaking our builds

Augment the build pipelines so that they publish the output of `pip freeze` to an artifact. This will aid debugging these issues.