### PR TITLE
Remove some flake8 global suppressions

### DIFF
--- a/fairlearn/metrics/_balanced_root_mean_squared_error.py
+++ b/fairlearn/metrics/_balanced_root_mean_squared_error.py
@@ -11,7 +11,7 @@ _Y_TRUE_NOT_0_1 = "Only 0 and 1 are allowed in y_true and both must be present"
 
 
 def balanced_root_mean_squared_error(y_true, y_pred, sample_weight=None):
-    r"""The mean of the root mean squared error (RMSE) for the positive and negative cases.
+    r"""Calculate the mean of the root mean squared error (RMSE) for the positive and negative cases.
 
     Used for binary logistic regression, this computes the error as
 

--- a/fairlearn/metrics/_extra_metrics.py
+++ b/fairlearn/metrics/_extra_metrics.py
@@ -14,7 +14,7 @@ from ._selection_rate import selection_rate  # noqa: F401,E501
 
 
 def specificity_score(y_true, y_pred, sample_weight=None):
-    r"""The specificity score is also known as the True Negative Rate.
+    r"""Calculate the specificity score (also called the True Negative Rate).
 
     At the present time, this routine only supports binary
     classifiers with labels :math:`\in {0, 1}`.
@@ -29,7 +29,7 @@ def specificity_score(y_true, y_pred, sample_weight=None):
 
 
 def miss_rate(y_true, y_pred, sample_weight=None):
-    r"""The miss rate is also known as the False Negative Rate.
+    r"""Calculate the miss rate (also called the False Negative Rate).
 
     At the present time, this routine only supports binary
     classifiers with labels :math:`\in {0, 1}`.
@@ -45,7 +45,7 @@ def miss_rate(y_true, y_pred, sample_weight=None):
 
 
 def fallout_rate(y_true, y_pred, sample_weight=None):
-    r"""The fallout rate is also known as the False Positive Rate.
+    r"""Calculate the fallout rate (also called the False Positive Rate).
 
     At the present time, this routine only supports binary
     classifiers with labels :math:`\in {0, 1}`.

--- a/fairlearn/metrics/_group_metric_result.py
+++ b/fairlearn/metrics/_group_metric_result.py
@@ -1,6 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+# Class is just for holding results so 'imperative mode' makes
+# little sense
+# flake8: noqa: D401
 
 class GroupMetricResult:
     """Class to hold the result of a grouped metric.

--- a/fairlearn/metrics/_input_manipulations.py
+++ b/fairlearn/metrics/_input_manipulations.py
@@ -5,7 +5,7 @@ import numpy as np
 
 
 def _convert_to_ndarray_and_squeeze(target):
-    """Converts to a `numpy.ndarray` and calls squeeze (to dispose of unit length dimensions).
+    """Convert input to a `numpy.ndarray` and calls squeeze (to dispose of unit length dimensions).
 
     There is a special case to stop single element arrays being converted to scalars.
     """

--- a/fairlearn/metrics/_mean_predictions.py
+++ b/fairlearn/metrics/_mean_predictions.py
@@ -7,7 +7,7 @@ from ._input_manipulations import _convert_to_ndarray_and_squeeze
 
 
 def mean_prediction(y_true, y_pred, sample_weight=None):
-    """Returns the (weighted) mean prediction.
+    """Calculate the (weighted) mean prediction.
 
     The true values are ignored, but required as an argument in order
     to maintain a consistent interface
@@ -21,7 +21,7 @@ def mean_prediction(y_true, y_pred, sample_weight=None):
 
 
 def mean_overprediction(y_true, y_pred, sample_weight=None):
-    """Returns the (weighted) mean overprediction.
+    """Calculate the (weighted) mean overprediction.
 
     This is the (weighted) mean of the error where any negative
     errors (i.e. underpredictions) are set to zero
@@ -39,7 +39,7 @@ def mean_overprediction(y_true, y_pred, sample_weight=None):
 
 
 def mean_underprediction(y_true, y_pred, sample_weight=None):
-    """Returns the (weighted) mean underprediction.
+    """Calculate the (weighted) mean underprediction.
 
     This is the (weighted) mean of the error where any
     positive errors (i.e. overpredictions) are set to zero.

--- a/fairlearn/metrics/_metrics_engine.py
+++ b/fairlearn/metrics/_metrics_engine.py
@@ -10,7 +10,7 @@ _MESSAGE_SIZE_MISMATCH = "Array {0} is not the same size as {1}"
 
 
 def metric_by_group(metric_function, y_true, y_pred, group_membership, sample_weight=None):
-    """Applies a metric to each subgroup of a set of data.
+    """Apply a metric to each subgroup of a set of data.
 
     :param metric_function: Function with signature ``(y_true, y_pred, sample_weight=None)``
      which returns a scalar
@@ -91,7 +91,7 @@ def metric_by_group(metric_function, y_true, y_pred, group_membership, sample_we
 
 
 def make_group_metric(metric_function):
-    """Function to turn a regular metric into a grouped metric.
+    """Turn a regular metric into a grouped metric.
 
     :param metric_function: The function to be wrapped. This must have signature
         ``(y_true, y_pred, sample_weight)``

--- a/fairlearn/metrics/_selection_rate.py
+++ b/fairlearn/metrics/_selection_rate.py
@@ -7,7 +7,7 @@ from ._metrics_engine import metric_by_group
 
 
 def selection_rate(y_true, y_pred, *, pos_label=1, sample_weight=None):
-    """The fraction of predicted labels matching the 'good' outcome.
+    """Calculate the fraction of predicted labels matching the 'good' outcome.
 
     The argument `pos_label` specifies the 'good' outcome.
     """
@@ -21,7 +21,7 @@ def selection_rate(y_true, y_pred, *, pos_label=1, sample_weight=None):
 
 def group_selection_rate(y_true, y_pred, group_membership,
                          *, pos_label=1, sample_weight=None):
-    """This is the grouped version of :func:`selection_rate`.
+    """Wrap :func:`selection_rate` as a group metric.
 
     The arguments are the same, with the addition of the
     `group_membership` array.

--- a/fairlearn/metrics/_skm_wrappers.py
+++ b/fairlearn/metrics/_skm_wrappers.py
@@ -9,7 +9,7 @@ from ._metrics_engine import metric_by_group
 def group_accuracy_score(y_true, y_pred, group_membership, *,
                          normalize=True,
                          sample_weight=None):
-    """A wrapper around the :any:`sklearn.metrics.accuracy_score` routine.
+    """Wrap the :any:`sklearn.metrics.accuracy_score` routine.
 
     The arguments remain the same, with `group_membership` added.
     However, the only positional arguments supported are `y_true`,
@@ -27,7 +27,7 @@ def group_accuracy_score(y_true, y_pred, group_membership, *,
 def group_confusion_matrix(y_true, y_pred, group_membership, *,
                            labels=None,
                            sample_weight=None):
-    """A wrapper around the :any:`sklearn.metrics.confusion_matrix` routine.
+    """Wrap the :any:`sklearn.metrics.confusion_matrix` routine.
 
     The arguments remain the same, with `group_membership` added.
     However, the only positional arguments supported are `y_true`,
@@ -45,7 +45,7 @@ def group_confusion_matrix(y_true, y_pred, group_membership, *,
 def group_precision_score(y_true, y_pred, group_membership, *,
                           labels=None, pos_label=1, average='binary',
                           sample_weight=None):
-    """A wrapper around the :any:`sklearn.metrics.precision_score` routine.
+    """Wrap the :any:`sklearn.metrics.precision_score` routine.
 
     The arguments remain the same, with `group_membership` added.
     However, the only positional arguments supported are `y_true`,
@@ -63,7 +63,7 @@ def group_precision_score(y_true, y_pred, group_membership, *,
 def group_recall_score(y_true, y_pred, group_membership, *,
                        labels=None, pos_label=1, average='binary',
                        sample_weight=None):
-    """A wrapper around the :any:`sklearn.metrics.recall_score` routine.
+    """Wrap the :any:`sklearn.metrics.recall_score` routine.
 
     The arguments remain the same, with `group_membership` added.
     However, the only positional arguments supported are `y_true`,
@@ -82,7 +82,7 @@ def group_recall_score(y_true, y_pred, group_membership, *,
 def group_roc_auc_score(y_true, y_pred, group_membership, *,
                         average='macro', max_fpr=None,
                         sample_weight=None):
-    """A wrapper around the :any:`sklearn.metrics.roc_auc_score` routine.
+    """Wrap the :any:`sklearn.metrics.roc_auc_score` routine.
 
     The arguments remain the same, with `group_membership` added.
     However, the only positional arguments supported are `y_true`,
@@ -101,7 +101,7 @@ def group_roc_auc_score(y_true, y_pred, group_membership, *,
 def group_zero_one_loss(y_true, y_pred, group_membership, *,
                         normalize=True,
                         sample_weight=None):
-    """A wrapper around the :any:`sklearn.metrics.zero_one_loss` routine.
+    """Wrap the :any:`sklearn.metrics.zero_one_loss` routine.
 
     The arguments remain the same, with `group_membership` added.
     However, the only positional arguments supported are `y_true`,
@@ -121,7 +121,7 @@ def group_zero_one_loss(y_true, y_pred, group_membership, *,
 def group_mean_squared_error(y_true, y_pred, group_membership, *,
                              multioutput='uniform_average',
                              sample_weight=None):
-    """A wrapper around the :any:`sklearn.metrics.mean_squared_error` routine.
+    """Wrap the :any:`sklearn.metrics.mean_squared_error` routine.
 
     The arguments remain the same, with `group_membership` added.
     However, the only positional arguments supported are `y_true`,
@@ -140,7 +140,7 @@ def group_mean_squared_error(y_true, y_pred, group_membership, *,
 def group_root_mean_squared_error(y_true, y_pred, group_membership, *,
                                   multioutput='uniform_average',
                                   sample_weight=None):
-    """A wrapper around the :any:`sklearn.metrics.mean_squared_error` routine.
+    """Wrap the :any:`sklearn.metrics.mean_squared_error` routine.
 
     The arguments remain the same, with `group_membership` added.
     The result is then square rooted.
@@ -160,7 +160,7 @@ def group_root_mean_squared_error(y_true, y_pred, group_membership, *,
 def group_r2_score(y_true, y_pred, group_membership, *,
                    multioutput='uniform_average',
                    sample_weight=None):
-    """A wrapper around the :any:`sklearn.metrics.r2_score` routine.
+    """Wrap the :any:`sklearn.metrics.r2_score` routine.
 
     The arguments remain the same, with `group_membership` added.
     However, the only positional arguments supported are `y_true`,

--- a/fairlearn/postprocessing/_curve_plotting_utilities.py
+++ b/fairlearn/postprocessing/_curve_plotting_utilities.py
@@ -24,6 +24,7 @@ def _get_debug_color(key):
 
 
 def plot_solution_and_show_plot(x_best, y_best, solution_label, xlabel, ylabel):
+    """Plot the given solution with appropriate labels."""
     if y_best is None:
         plt.axvline(x=x_best, label=solution_label, ls='--')
     else:
@@ -35,11 +36,13 @@ def plot_solution_and_show_plot(x_best, y_best, solution_label, xlabel, ylabel):
 
 
 def plot_overlap(x_grid, y_min):
+    """Plot the overlap region."""
     line, = plt.plot(x_grid, y_min, color=highlight_color, lw=8, label='overlap')
     line.zorder -= 1
 
 
 def plot_curve(sensitive_feature, x_col, y_col, points):
+    """Plot the given curve with labels."""
     color = _get_debug_color(sensitive_feature)
     plt.plot(points[x_col], points[y_col], c=color, ls='-', lw=2.0,
              label='sensitive feature value ' + str(sensitive_feature))

--- a/fairlearn/postprocessing/_interpolated_prediction.py
+++ b/fairlearn/postprocessing/_interpolated_prediction.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 class InterpolatedPredictor:
     def __init__(self, p_ignore, prediction_constant, p0, operation0, p1, operation1):
-        """Creates the interpolated prediction between two predictions.
+        """Create the interpolated prediction between two predictions.
 
         The predictions are represented through the threshold rules operation0 and operation1.
 
@@ -47,7 +47,7 @@ class InterpolatedPredictor:
                     self._p1, self._operation1)
 
     def predict(self, scores):
-        """Creates the interpolated prediction.
+        """Create the interpolated prediction.
 
         The interpolation is based on two threshold operations and the
         transformation adjustment.

--- a/fairlearn/postprocessing/_roc_curve_utilities.py
+++ b/fairlearn/postprocessing/_roc_curve_utilities.py
@@ -32,7 +32,7 @@ def _get_roc(data, sensitive_feature_value, flip=True):
 
 
 def _filter_points_to_get_convex_hull(roc_sorted):
-    """Finds the convex hull.
+    """Find the convex hull.
 
     Uses a simplified version of Andrew's monotone chain convex hull algorithm
     https://en.wikibooks.org/wiki/Algorithm_Implementation/Geometry/Convex_hull/Monotone_chain
@@ -124,7 +124,7 @@ def _interpolate_curve(data, x_col, y_col, content_col, x_grid):
 
 
 def _calculate_roc_points(data, sensitive_feature_value, flip=True):
-    """Calculates the ROC points from the scores and labels.
+    """Calculate the ROC points from the scores and labels.
 
     This is done by iterating through all possible
     thresholds that could be set based on the available scores.
@@ -203,7 +203,7 @@ def _get_scores_labels_and_counts(data):
 
 
 def _get_counts(labels):
-    """Returns the overall, positive, and negative counts of the labels.
+    """Return the overall, positive, and negative counts of the labels.
 
     :param labels: the labels of the samples
     :type labels: list

--- a/fairlearn/postprocessing/_threshold_operation.py
+++ b/fairlearn/postprocessing/_threshold_operation.py
@@ -30,7 +30,7 @@ class ThresholdOperation():
         return self._operator
 
     def get_predictor_from_operation(self):
-        """Encodes the threshold rule `Y_hat > t` or `Y_hat < t`.
+        """Encode the threshold rule `Y_hat > t` or `Y_hat < t`.
 
         :return: a function that takes a single argument to evaluate it against the threshold rule
         :rtype: lambda

--- a/fairlearn/postprocessing/_threshold_operation.py
+++ b/fairlearn/postprocessing/_threshold_operation.py
@@ -23,10 +23,12 @@ class ThresholdOperation():
 
     @property
     def threshold(self):
+        """Return the stored threshold"""
         return self._threshold
 
     @property
     def operator(self):
+        """Return the stored threshold operator."""
         return self._operator
 
     def get_predictor_from_operation(self):

--- a/fairlearn/postprocessing/_threshold_operation.py
+++ b/fairlearn/postprocessing/_threshold_operation.py
@@ -23,7 +23,7 @@ class ThresholdOperation():
 
     @property
     def threshold(self):
-        """Return the stored threshold"""
+        """Return the stored threshold."""
         return self._threshold
 
     @property

--- a/fairlearn/postprocessing/_threshold_optimizer.py
+++ b/fairlearn/postprocessing/_threshold_optimizer.py
@@ -206,7 +206,7 @@ class ThresholdOptimizer(PostProcessing):
 
 def _threshold_optimization_demographic_parity(sensitive_features, labels, scores, grid_size=1000,
                                                flip=True, plot=False):
-    """Calculates selection and error rates for every sensitive feature value.
+    """Calculate the selection and error rates for every sensitive feature value.
 
     These calculations are made at different
     thresholds over the scores. Subsequently weighs each sensitive feature value's error by the
@@ -318,7 +318,7 @@ def _threshold_optimization_demographic_parity(sensitive_features, labels, score
 
 def _threshold_optimization_equalized_odds(sensitive_features, labels, scores, grid_size=1000,
                                            flip=True, plot=False):
-    """Calculates the ROC curve of every sensitive feature value at different thresholds.
+    """Calculate the ROC curve of every sensitive feature value at different thresholds.
 
     Subsequently takes the overlapping region of the ROC curves, and finds the best
     solution by selecting the point on the curve with minimal error.
@@ -449,7 +449,7 @@ def _vectorized_prediction(function_dict, sensitive_features, scores):
 
 
 def _convert_to_ndarray(data, dataframe_multiple_columns_error_message):
-    """Converts input data from list, pandas.Series, or pandas.DataFrame to numpy.ndarray.
+    """Convert the input data from list, pandas.Series, or pandas.DataFrame to numpy.ndarray.
 
     :param data: the data to be converted into a numpy.ndarray
     :type data: numpy.ndarray, pandas.Series, pandas.DataFrame, or list

--- a/fairlearn/reductions/_exponentiated_gradient/__init__.py
+++ b/fairlearn/reductions/_exponentiated_gradient/__init__.py
@@ -4,7 +4,7 @@
 """Package for Exponentiated Gradient."""
 
 from .exponentiated_gradient import ExponentiatedGradient  # noqa: F401
-from .exponentiated_gradient import ExponentiatedGradientResult  # noqa: F401
+from ._exponentiated_gradient_result import ExponentiatedGradientResult  # noqa: F401
 
 __all__ = [
     "ExponentiatedGradient",

--- a/fairlearn/reductions/_exponentiated_gradient/_exponentiated_gradient_result.py
+++ b/fairlearn/reductions/_exponentiated_gradient/_exponentiated_gradient_result.py
@@ -1,0 +1,77 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+
+# Class is just for holding results so 'imperative mode' makes
+# little sense
+# flake8: noqa: D401
+
+class ExponentiatedGradientResult:
+    """Class to hold the result of an `ExponentiatedGradient` estimator."""
+
+    def __init__(self, best_classifier, best_gap, classifiers, weights, last_t, best_t,
+                 n_oracle_calls):
+        """Result object for the exponentiated gradient reduction operation."""
+        self._best_classifier = best_classifier
+        self._best_gap = best_gap
+        self._classifiers = classifiers
+        self._weights = weights
+        self._last_t = last_t
+        self._best_t = best_t
+        self._n_oracle_calls = n_oracle_calls
+
+    @property
+    def best_classifier(self):
+        """The best classifier found by the algorithm.
+
+        A function that maps a DataFrame `X` containing covariates to a Series containing the
+        corresponding probabilistic decisions in :math:`[0,1]`
+        """
+        return self._best_classifier
+
+    @property
+    def best_gap(self):
+        """The quality of `best_classifier`.
+
+        If the algorithm has converged then :code:`best_gap <= nu`;
+        the solution `best_classifier` is guaranteed to have the classification error within
+        :code:`2*best_gap` of the best error under constraint `eps`; the constraint violation
+        is at most :code:`2*(eps+best_gap)`
+        """
+        return self._best_gap
+
+    @property
+    def classifiers(self):
+        """The base classifiers generated (instances of estimator)."""
+        return self._classifiers
+
+    @property
+    def weights(self):
+        """The weights of those classifiers within `best_classifier`."""
+        return self._weights
+
+    @property
+    def last_t(self):
+        """The last executed iteration; always :code:`last_t < T`."""
+        return self._last_t
+
+    @property
+    def best_t(self):
+        """The iteration in which best_classifier was obtained."""
+        return self._best_t
+
+    @property
+    def n_oracle_calls(self):
+        """The number of times the estimator was called."""
+        return self._n_oracle_calls
+
+    def _as_dict(self):
+        return {
+            "best_classifier": self._best_classifier,
+            "best_gap": self._best_gap,
+            "classifiers": self._classifiers,
+            "weights": self._weights,
+            "last_t": self._last_t,
+            "best_t": self._best_t,
+            "n_oracle_calls": self._n_oracle_calls
+        }

--- a/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
+++ b/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
@@ -49,7 +49,7 @@ class ExponentiatedGradient(Reduction):
     :type eta_mul: float
     """
 
-    def __init__(self, estimator, constraints, eps=0.01, T=50, nu=None, eta_mul=2.0):
+    def __init__(self, estimator, constraints, eps=0.01, T=50, nu=None, eta_mul=2.0):  # noqa: D103
         self._estimator = estimator
         self._constraints = constraints
         self._eps = eps

--- a/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
+++ b/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
@@ -8,6 +8,7 @@ from fairlearn.reductions import Reduction
 from ._constants import _ACCURACY_MUL, _REGRET_CHECK_START_T, _REGRET_CHECK_INCREASE_T, \
     _SHRINK_REGRET, _SHRINK_ETA, _MIN_T, _RUN_LP_STEP, _PRECISION, _INDENTATION
 from ._lagrangian import _Lagrangian
+from ._exponentiated_gradient_result import ExponentiatedGradientResult
 from fairlearn._input_validation import _validate_and_reformat_reductions_input
 
 logger = logging.getLogger(__name__)
@@ -19,77 +20,6 @@ def _mean_pred(X, hs, weights):
     for t in range(len(hs)):
         pred[t] = hs[t](X)
     return pred[weights.index].dot(weights)
-
-
-class ExponentiatedGradientResult:
-    """Class to hold the result of an `ExponentiatedGradient` estimator."""
-
-    def __init__(self, best_classifier, best_gap, classifiers, weights, last_t, best_t,
-                 n_oracle_calls):
-        """Result object for the exponentiated gradient reduction operation."""
-        self._best_classifier = best_classifier
-        self._best_gap = best_gap
-        self._classifiers = classifiers
-        self._weights = weights
-        self._last_t = last_t
-        self._best_t = best_t
-        self._n_oracle_calls = n_oracle_calls
-
-    @property
-    def best_classifier(self):
-        """The best classifier found by the algorithm.
-
-        A function that maps a DataFrame `X` containing covariates to a Series containing the
-        corresponding probabilistic decisions in :math:`[0,1]`
-        """
-        return self._best_classifier
-
-    @property
-    def best_gap(self):
-        """The quality of `best_classifier`.
-
-        If the algorithm has converged then :code:`best_gap <= nu`;
-        the solution `best_classifier` is guaranteed to have the classification error within
-        :code:`2*best_gap` of the best error under constraint `eps`; the constraint violation
-        is at most :code:`2*(eps+best_gap)`
-        """
-        return self._best_gap
-
-    @property
-    def classifiers(self):
-        """The base classifiers generated (instances of estimator)."""
-        return self._classifiers
-
-    @property
-    def weights(self):
-        """The weights of those classifiers within `best_classifier`."""
-        return self._weights
-
-    @property
-    def last_t(self):
-        """The last executed iteration; always :code:`last_t < T`."""
-        return self._last_t
-
-    @property
-    def best_t(self):
-        """The iteration in which best_classifier was obtained."""
-        return self._best_t
-
-    @property
-    def n_oracle_calls(self):
-        """The number of times the estimator was called."""
-        return self._n_oracle_calls
-
-    def _as_dict(self):
-        return {
-            "best_classifier": self._best_classifier,
-            "best_gap": self._best_gap,
-            "classifiers": self._classifiers,
-            "weights": self._weights,
-            "last_t": self._last_t,
-            "best_t": self._best_t,
-            "n_oracle_calls": self._n_oracle_calls
-        }
 
 
 class ExponentiatedGradient(Reduction):

--- a/fairlearn/reductions/_grid_search/grid_search.py
+++ b/fairlearn/reductions/_grid_search/grid_search.py
@@ -122,7 +122,7 @@ class GridSearch(Reduction):
                  grid_size=10,
                  grid_limit=2.0,
                  grid=None):
-        """Constructor for a GridSearch object."""
+        """Construct a GridSearch object."""
         self.estimator = estimator
         if not isinstance(constraints, Moment):
             raise RuntimeError("Unsupported disparity metric")
@@ -146,12 +146,12 @@ class GridSearch(Reduction):
 
     @property
     def all_results(self):
-        """A list of :class:`GridSearchResult` from each point in the grid."""
+        """Return a list of :class:`GridSearchResult` from each point in the grid."""
         return self._all_results
 
     @property
     def best_result(self):
-        """The best result found from the grid search.
+        """Return the best result found from the grid search.
 
         The predictor contained in this instance of
         :class:`GridSearchResult` is used in calls to
@@ -160,7 +160,7 @@ class GridSearch(Reduction):
         return self._best_result
 
     def fit(self, X, y, **kwargs):
-        """Runs the grid search.
+        """Run the grid search.
 
         This will result in multiple copies of the
         estimator being made, and the :code:`fit` method
@@ -255,7 +255,7 @@ class GridSearch(Reduction):
         return
 
     def predict(self, X):
-        """Provides a prediction for the given input data based on the best model found by the grid search.
+        """Provide a prediction for the given input data based on the best model found by the grid search.
 
         :param X: The data for which predictions are required
         :type X: Array
@@ -269,7 +269,7 @@ class GridSearch(Reduction):
         return self.best_result.predictor.predict(X)
 
     def predict_proba(self, X):
-        """Provides the result of :code:`predict_proba` from the best model found by the grid search.
+        """Provide the result of :code:`predict_proba` from the best model found by the grid search.
 
         The underlying estimator must support :code:`predict_proba` for this
         to work.

--- a/fairlearn/reductions/_grid_search/grid_search_result.py
+++ b/fairlearn/reductions/_grid_search/grid_search_result.py
@@ -1,6 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+# Class is just for holding results so 'imperative mode' makes
+# little sense
+# flake8: noqa: D401
 
 class GridSearchResult:
     """Class to hold a single result from the :class:`GridSearch` class."""

--- a/fairlearn/reductions/_moments/bounded_group_loss.py
+++ b/fairlearn/reductions/_moments/bounded_group_loss.py
@@ -42,7 +42,7 @@ class ConditionalLossMoment(LossMoment):
             i += 1
 
     def gamma(self, predictor):
-        """Calculates degree to which constraints are currently violated by the predictor."""
+        """Calculate the degree to which constraints are currently violated by the predictor."""
         self.tags[_PREDICTION] = predictor(self.X)
         self.tags[_LOSS] = self.reduction_loss.eval(self.tags[_LABEL], self.tags[_PREDICTION])
         expect_attr = self.tags.groupby(_GROUP_ID).mean()

--- a/fairlearn/reductions/_moments/bounded_group_loss.py
+++ b/fairlearn/reductions/_moments/bounded_group_loss.py
@@ -16,9 +16,11 @@ class ConditionalLossMoment(LossMoment):
         self.no_groups = no_groups
 
     def default_objective(self):
+        """Return a default objective."""
         return AverageLossMoment(self.reduction_loss)
 
     def load_data(self, X, y, **kwargs):
+        """Load data into the moment object."""
         kwargs_mod = kwargs.copy()
         if self.no_groups:
             kwargs_mod[_KW_SENSITIVE_FEATURES] = pd.Series(y).apply(lambda y: _ALL)
@@ -50,9 +52,11 @@ class ConditionalLossMoment(LossMoment):
         return expect_attr[_LOSS]
 
     def project_lambda(self, lambda_vec):
+        """Return the lambda values."""
         return lambda_vec
 
     def signed_weights(self, lambda_vec):
+        """Return the signed weights."""
         adjust = lambda_vec / self.prob_attr
         signed_weights = self.tags.apply(
             lambda row: adjust[row[_GROUP_ID]], axis=1
@@ -86,6 +90,7 @@ class SquareLoss:
         self.max = (max_val-min_val) ** 2
 
     def eval(self, y_true, y_pred):  # noqa: A003
+        """Evaluate the square loss for the given set of true and predicted values."""
         return (np.clip(y_true, self.min_val, self.max_val)
                 - np.clip(y_pred, self.min_val, self.max_val)) ** 2
 
@@ -99,6 +104,7 @@ class AbsoluteLoss:
         self.max = np.abs(max_val-min_val)
 
     def eval(self, y_true, y_pred):  # noqa: A003
+        """Evaluate the absolute loss for the given set of true and predicted values."""
         return np.abs(np.clip(y_true, self.min_val, self.max_val)
                       - np.clip(y_pred, self.min_val, self.max_val))
 

--- a/fairlearn/reductions/_moments/conditional_selection_rate.py
+++ b/fairlearn/reductions/_moments/conditional_selection_rate.py
@@ -45,7 +45,7 @@ class ConditionalSelectionRate(ClassificationMoment):
                 i += 1
 
     def gamma(self, predictor):
-        """Calculates degree to which constraints are currently violated by the predictor."""
+        """Calculate the degree to which constraints are currently violated by the predictor."""
         pred = predictor(self.X)
         self.tags[_PREDICTION] = pred
         expect_event = self.tags.groupby(_EVENT).mean()

--- a/fairlearn/reductions/_moments/conditional_selection_rate.py
+++ b/fairlearn/reductions/_moments/conditional_selection_rate.py
@@ -13,9 +13,11 @@ class ConditionalSelectionRate(ClassificationMoment):
     """Generic fairness metric including :class:`DemographicParity` and :class:`EqualizedOdds`."""
 
     def default_objective(self):
+        """Return the default objective for moments of this kind."""
         return ErrorRate()
 
     def load_data(self, X, y, event=None, **kwargs):
+        """Load the specified data into this object."""
         super().load_data(X, y, **kwargs)
         self.tags[_EVENT] = event
         self.prob_event = self.tags.groupby(_EVENT).size() / self.n
@@ -61,6 +63,7 @@ class ConditionalSelectionRate(ClassificationMoment):
 
     # TODO: this can be further improved using the overcompleteness in group membership
     def project_lambda(self, lambda_vec):
+        """Return the projected lambda values."""
         lambda_pos = lambda_vec["+"] - lambda_vec["-"]
         lambda_neg = -lambda_pos
         lambda_pos[lambda_pos < 0.0] = 0.0
@@ -71,6 +74,7 @@ class ConditionalSelectionRate(ClassificationMoment):
         return lambda_projected
 
     def signed_weights(self, lambda_vec):
+        """Return the signed weights."""
         lambda_signed = lambda_vec["+"] - lambda_vec["-"]
         adjust = lambda_signed.sum(level=_EVENT) / self.prob_event \
             - lambda_signed / self.prob_group_event
@@ -97,6 +101,7 @@ class DemographicParity(ConditionalSelectionRate):
     short_name = "DemographicParity"
 
     def load_data(self, X, y, **kwargs):
+        """Load the specified data into the object."""
         super().load_data(X, y, event=_ALL, **kwargs)
 
 
@@ -112,6 +117,7 @@ class EqualizedOdds(ConditionalSelectionRate):
     short_name = "EqualizedOdds"
 
     def load_data(self, X, y, **kwargs):
+        """Load the specified data into the object."""
         super().load_data(X, y,
                           event=pd.Series(y).apply(lambda y: _LABEL + "=" + str(y)),
                           **kwargs)

--- a/fairlearn/reductions/_moments/error_rate.py
+++ b/fairlearn/reductions/_moments/error_rate.py
@@ -12,10 +12,12 @@ class ErrorRate(ClassificationMoment):
     short_name = "Err"
 
     def load_data(self, X, y, **kwargs):
+        """Load the specified data into the object."""
         super().load_data(X, y, **kwargs)
         self.index = [_ALL]
 
     def gamma(self, predictor):
+        """Return the gamma values for the given predictor."""
         pred = predictor(self.X)
         error = pd.Series(data=(self.tags[_LABEL] - pred).abs().mean(),
                           index=self.index)
@@ -23,9 +25,11 @@ class ErrorRate(ClassificationMoment):
         return error
 
     def project_lambda(self, lambda_vec):
+        """Return the lambda values."""
         return lambda_vec
 
     def signed_weights(self, lambda_vec=None):
+        """Return the signed weights."""
         if lambda_vec is None:
             return 2 * self.tags[_LABEL] - 1
         else:

--- a/fairlearn/reductions/_moments/moment.py
+++ b/fairlearn/reductions/_moments/moment.py
@@ -40,13 +40,13 @@ class Moment:
         self.data_loaded = True
         self._gamma_descr = None
 
-    def gamma(self, predictor):
+    def gamma(self, predictor):  # noqa: D102
         raise NotImplementedError()
 
-    def project_lambda(self, lambda_vec):
+    def project_lambda(self, lambda_vec):  # noqa: D102
         raise NotImplementedError()
 
-    def signed_weights(self, lambda_vec):
+    def signed_weights(self, lambda_vec):  # noqa: D102
         raise NotImplementedError()
 
 

--- a/fairlearn/reductions/_reduction.py
+++ b/fairlearn/reductions/_reduction.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+# flake8: noqa: D102
 
 class Reduction:
     """Base class for our reduction-implementing estimators."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ per-file-ignores =
     setup.py:D100
     docs/*.py:D100,A001
     fairlearn/*.py:D100
-    fairlearn/*/*.py:D100,D101,D103,D107,RST304
+    fairlearn/*/*.py:D100,D101,D107,RST304
     fairlearn/metrics/__init__.py: RST902
     scripts/*.py:D100,D101,D102,D103,D104,D107,D205,D400,D401,RST201,RST205,RST301
     test/*.py:D104

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ per-file-ignores =
     setup.py:D100
     docs/*.py:D100,A001
     fairlearn/*.py:D100
-    fairlearn/*/*.py:D100,D101,D102,D107,RST304
+    fairlearn/*/*.py:D100,D101,D103,D107,RST304
     fairlearn/metrics/__init__.py: RST902
     scripts/*.py:D100,D101,D102,D103,D104,D107,D205,D400,D401,RST201,RST205,RST301
     test/*.py:D104

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ per-file-ignores =
     setup.py:D100
     docs/*.py:D100,A001
     fairlearn/*.py:D100
-    fairlearn/*/*.py:D100,D101,D102,D103,D107,RST304
+    fairlearn/*/*.py:D100,D101,D102,D103,RST304
     fairlearn/metrics/__init__.py: RST902
     scripts/*.py:D100,D101,D102,D103,D104,D107,D205,D400,D401,RST201,RST205,RST301
     test/*.py:D104

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ per-file-ignores =
     setup.py:D100
     docs/*.py:D100,A001
     fairlearn/*.py:D100
-    fairlearn/*/*.py:D100,D101,D102,D103,D107,D401,RST304
+    fairlearn/*/*.py:D100,D101,D102,D103,D107,RST304
     fairlearn/metrics/__init__.py: RST902
     scripts/*.py:D100,D101,D102,D103,D104,D107,D205,D400,D401,RST201,RST205,RST301
     test/*.py:D104

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ per-file-ignores =
     setup.py:D100
     docs/*.py:D100,A001
     fairlearn/*.py:D100
-    fairlearn/*/*.py:D100,D101,D102,D103,RST304
+    fairlearn/*/*.py:D100,D101,D102,D107,RST304
     fairlearn/metrics/__init__.py: RST902
     scripts/*.py:D100,D101,D102,D103,D104,D107,D205,D400,D401,RST201,RST205,RST301
     test/*.py:D104


### PR DESCRIPTION
After adding more `flake8` analysers, we were obliged to put in some global suppressions to keep the number of issues manageable. Start the process of removing these with D102, D103 and D401. Some of these just move the suppression to file-level, while others tweak documentation blocks to suit.