### PR TITLE
Re-enable Linux 3.5

### DIFF
--- a/devops/all-tests-job-template.yml
+++ b/devops/all-tests-job-template.yml
@@ -26,11 +26,7 @@ jobs:
       versionSpec: '$(PyVer)' 
       addToPath: true
 
-  - script: pip install --upgrade pip
-    displayName: 'Upgrade pip to latest version'
-
-  - script: pip install --upgrade setuptools
-    displayName: 'Upgrade setuptools'
+  - template: python-infra-upgrade-steps-template.yml
 
   - script: pip install -r ${{ parameters.requirementsFile }}
     displayName: 'Install required packages specified in ${{ parameters.requirementsFile }}'

--- a/devops/all-tests-job-template.yml
+++ b/devops/all-tests-job-template.yml
@@ -26,6 +26,12 @@ jobs:
       versionSpec: '$(PyVer)' 
       addToPath: true
 
+  - script: pip install --upgrade pip
+    displayName: 'Upgrade pip to latest version'
+
+  - script: pip install --upgrade setuptools
+    displayName: 'Upgrade setuptools'
+
   - script: pip install -r ${{ parameters.requirementsFile }}
     displayName: 'Install required packages specified in ${{ parameters.requirementsFile }}'
 

--- a/devops/code-coverage-job-template.yml
+++ b/devops/code-coverage-job-template.yml
@@ -15,6 +15,8 @@ jobs:
       versionSpec: ${{ parameters.pyVersion }} 
       addToPath: true
 
+  - template: python-infra-upgrade-steps-template.yml
+
   - script: pip install -r requirements.txt
     displayName: 'Install required packages'
 

--- a/devops/create-wheel-step-template.yml
+++ b/devops/create-wheel-step-template.yml
@@ -17,6 +17,8 @@ steps:
     versionSpec: ${{parameters.pyVer}}
     addToPath: true
 
+- template: python-infra-upgrade-steps-template.yml
+
 - script: pip install setuptools wheel 
   displayName: 'Install setuptools'
 

--- a/devops/nightly-requirements-fixed.yml
+++ b/devops/nightly-requirements-fixed.yml
@@ -26,7 +26,7 @@ jobs:
     name: Linux
     vmImage: 'ubuntu-16.04'
     requirementsFile: 'requirements-fixed.txt'
-    pyVersions: [3.6, 3.7]
+    pyVersions: [3.5, 3.6, 3.7]
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFileStem: $(FreezeFileStem)
 
@@ -43,6 +43,6 @@ jobs:
     name: LinuxNotebooks
     vmImage: 'ubuntu-16.04'
     requirementsFile: 'requirements-fixed.txt'
-    pyVersions: [3.6, 3.7]
+    pyVersions: [3.5, 3.6, 3.7]
 
 - template: build-widget-job-template.yml

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -24,7 +24,7 @@ jobs:
   parameters:
     name: Linux
     vmImage: 'ubuntu-16.04'
-    pyVersions: [3.6, 3.7]
+    pyVersions: [3.5, 3.6, 3.7]
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFileStem: $(FreezeFileStem)
 

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -39,7 +39,7 @@ jobs:
   parameters:
     name: MacOS
     vmImage:  'macos-latest'
-    pyVersions: [3.6, 3.7]
+    pyVersions: [3.5, 3.6, 3.7]
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFileStem: $(FreezeFileStem)
 

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -47,6 +47,6 @@ jobs:
   parameters:
     name: LinuxNotebooks
     vmImage: 'ubuntu-16.04'
-    pyVersions: [3.6, 3.7] 
+    pyVersions: [3.5, 3.6, 3.7] 
 
 - template: build-widget-job-template.yml

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -39,7 +39,7 @@ jobs:
   parameters:
     name: MacOS
     vmImage:  'macos-latest'
-    pyVersions: [3.5, 3.6, 3.7]
+    pyVersions: [3.6, 3.7]
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFileStem: $(FreezeFileStem)
 

--- a/devops/notebook-job-template.yml
+++ b/devops/notebook-job-template.yml
@@ -21,6 +21,8 @@ jobs:
     inputs:
       versionSpec: '$(PyVer)' 
       addToPath: true
+  
+  - template: python-infra-upgrade-steps-template.yml
 
   - script: pip install -r ${{ parameters.requirementsFile }}
     displayName: 'Install required packages specified in ${{ parameters.requirementsFile }}'

--- a/devops/notebook-pypi-job-template.yml
+++ b/devops/notebook-pypi-job-template.yml
@@ -52,6 +52,9 @@ jobs:
       versionSpec: '$(PyVer)' 
       addToPath: true
 
+  # Ensure tools such as pip are up-to-date
+  - template: python-infra-upgrade-steps-template.yml
+
   # Install our requirements from regular PyPI
   - script: pip install -r ${{ parameters.requirementsFile }}
     displayName: 'Install required packages specified in ${{ parameters.requirementsFile }}'

--- a/devops/pypi-deployment-stages-template.yml
+++ b/devops/pypi-deployment-stages-template.yml
@@ -101,7 +101,7 @@ stages:
     parameters:
       name: Linux
       vmImage: 'ubuntu-16.04'
-      pyVersions: [3.6, 3.7]
+      pyVersions: [3.5, 3.6, 3.7]
       targetType: ${{parameters.targetType}}
       versionFileArtifact: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
       versionFileName: '${{parameters.versionFileStem}}${{parameters.targetType}}'

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -37,7 +37,7 @@ stages:
     parameters:
       name: Linux
       vmImage: 'ubuntu-16.04'
-      pyVersions: [3.6,3.7]
+      pyVersions: [3.5, 3.6, 3.7]
       freezeArtifactStem: "PreDeployment"
       freezeFileStem: $(FreezeFileStem)
 
@@ -59,7 +59,7 @@ stages:
 
   - template: notebook-job-template.yml
     parameters:
-      pyVersions: [3.6]
+      pyVersions: [3.5, 3.6]
 
 
 # =================================================================================================================

--- a/devops/python-infra-upgrade-steps-template.yml
+++ b/devops/python-infra-upgrade-steps-template.yml
@@ -1,0 +1,5 @@
+- script: pip install --upgrade pip
+  displayName: 'Upgrade pip to latest version'
+
+- script: pip install --upgrade setuptools
+  displayName: 'Upgrade setuptools'

--- a/devops/python-infra-upgrade-steps-template.yml
+++ b/devops/python-infra-upgrade-steps-template.yml
@@ -1,5 +1,6 @@
-- script: pip install --upgrade pip
-  displayName: 'Upgrade pip to latest version'
+steps:
+  - script: pip install --upgrade pip
+    displayName: 'Upgrade pip to latest version'
 
-- script: pip install --upgrade setuptools
-  displayName: 'Upgrade setuptools'
+  - script: pip install --upgrade setuptools
+    displayName: 'Upgrade setuptools'

--- a/devops/unit-tests-pypi-job-template.yml
+++ b/devops/unit-tests-pypi-job-template.yml
@@ -52,6 +52,9 @@ jobs:
       versionSpec: '$(PyVer)' 
       addToPath: true
 
+  # Ensure infrastructure such as pip are up-to-date
+  - template: python-infra-upgrade-steps-template.yml
+
   # Install our requirements from regular PyPI
   - script: pip install -r ${{ parameters.requirementsFile }}
     displayName: 'Install required packages specified in ${{ parameters.requirementsFile }}'


### PR DESCRIPTION
Roman figured out a workaround for getting `shap` installed with Linux and Python 3.5. Put this into `fairlearn`