### PR TITLE
Expand Notebook testing

### DIFF
--- a/devops/PR-Gate.yml
+++ b/devops/PR-Gate.yml
@@ -38,6 +38,19 @@ jobs:
 
 - template: notebook-job-template.yml
   parameters:
-    pyVersions: [3.6]
+    name: LinuxNotebooks
+    pyVersions: [3.5]
+
+- template: notebook-job-template.yml
+  parameters:
+    name: WindowsNotebooks
+    vmImage: 'vs2017-win2016'
+    pyVersions: [3.6] 
+
+- template: notebook-job-template.yml
+  parameters:
+    name: MacOSNotebooks
+    vmImage: 'macos-latest'
+    pyVersions: [3.7] 
 
 - template: build-widget-job-template.yml

--- a/devops/PR-Gate.yml
+++ b/devops/PR-Gate.yml
@@ -45,12 +45,6 @@ jobs:
   parameters:
     name: WindowsNotebooks
     vmImage: 'vs2017-win2016'
-    pyVersions: [3.6] 
-
-- template: notebook-job-template.yml
-  parameters:
-    name: MacOSNotebooks
-    vmImage: 'macos-latest'
-    pyVersions: [3.7] 
+    pyVersions: [3.7]
 
 - template: build-widget-job-template.yml

--- a/devops/nightly-requirements-fixed.yml
+++ b/devops/nightly-requirements-fixed.yml
@@ -45,4 +45,10 @@ jobs:
     requirementsFile: 'requirements-fixed.txt'
     pyVersions: [3.5, 3.6, 3.7]
 
+- template: notebook-job-template.yml
+  parameters:
+    name: WindowsNotebooks
+    vmImage: 'vs2017-win2016'
+    pyVersions: [3.5, 3.6, 3.7] 
+
 - template: build-widget-job-template.yml

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -47,6 +47,12 @@ jobs:
   parameters:
     name: LinuxNotebooks
     vmImage: 'ubuntu-16.04'
+    pyVersions: [3.5, 3.6, 3.7]
+
+- template: notebook-job-template.yml
+  parameters:
+    name: WindowsNotebooks
+    vmImage: 'vs2017-win2016'
     pyVersions: [3.5, 3.6, 3.7] 
 
 - template: build-widget-job-template.yml

--- a/devops/pypi-deployment-stages-template.yml
+++ b/devops/pypi-deployment-stages-template.yml
@@ -126,9 +126,18 @@ stages:
 
   - template: notebook-pypi-job-template.yml
     parameters:
-      name: Notebooks_Linux
+      name: LinuxNotebooks
       vmImage: 'ubuntu-16.04'
-      pyVersions: [3.6, 3.7]
+      pyVersions: [3.5, 3.6, 3.7]
+      targetType: ${{parameters.targetType}}
+      versionFileArtifact: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
+      versionFileName: '${{parameters.versionFileStem}}${{parameters.targetType}}'
+
+  - template: notebook-pypi-job-template.yml
+    parameters:
+      name: WindowsNotebooks
+      vmImage: 'vs2017-win2016'
+      pyVersions: [3.5, 3.6, 3.7]
       targetType: ${{parameters.targetType}}
       versionFileArtifact: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
       versionFileName: '${{parameters.versionFileStem}}${{parameters.targetType}}'

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -59,7 +59,15 @@ stages:
 
   - template: notebook-job-template.yml
     parameters:
-      pyVersions: [3.5, 3.6]
+      name: LinuxNotebooks
+      vmImage: 'ubuntu-16.04'
+      pyVersions: [3.5, 3.6, 3.7]
+
+  - template: notebook-job-template.yml
+    parameters:
+      name: WindowsNotebooks
+      vmImage: 'vs2017-win2016'
+      pyVersions: [3.5, 3.6, 3.7] 
 
 
 # =================================================================================================================


### PR DESCRIPTION
Increase the variety of platforms used for testing our Jupyter Notebooks. Unable to test on MacOS at present, due to some problem installing `lightgbm`.