### PR TITLE
Standardise ML argument documentation

### DIFF
--- a/fairlearn/postprocessing/_postprocessing.py
+++ b/fairlearn/postprocessing/_postprocessing.py
@@ -12,14 +12,16 @@ MISSING_PREDICT_ERROR_MESSAGE = "The predictor does not have a callable 'predict
 class PostProcessing:
     """Abstract base class for postprocessing approaches for disparity mitigation.
 
-    :param unconstrained_predictor: a predictor with a `predict` function that has already been
-        trained on the training data; the predictor will subsequently be used in the mitigator
-        for unconstrained predictions; can only be specified if `estimator` is None
+    :param unconstrained_predictor: A predictor with a :code:`predict(X)` method that has already
+        been trained on the training data; the predictor will subsequently be used in the mitigator
+        for unconstrained predictions; can only be specified if `estimator` is `None`
     :type unconstrainted_predictor: predictor
-    :param estimator: an estimator with a `fit` and `predict` function that will be trained on the
-        training data and subsequently used in the mitigator for unconstrained predictions; can
-        only be specified if `unconstrainted_predictor` is None
+
+    :param estimator: An estimator implementing :code:`fit(X, y)` and :code:`predict(X)` methods
+        that will be trained on the training data and subsequently used in the mitigator for
+        unconstrained predictions; can only be specified if `unconstrainted_predictor` is `None`
     :type estimator: estimator
+
     :param constraints: the parity constraints to be enforced represented as a string
     :type constraints: str
     """
@@ -59,7 +61,7 @@ class PostProcessing:
         raise NotImplementedError(self.fit.__name__ + " is not implemented")
 
     def predict(self, X, *, sensitive_features):
-        """Predict label for each sample in X while taking into account sensitive features.
+        """Predict label for each sample in `X` while taking into account sensitive features.
 
         :param X: Feature matrix
         :type X: numpy.ndarray or pandas.DataFrame

--- a/fairlearn/postprocessing/_threshold_optimizer.py
+++ b/fairlearn/postprocessing/_threshold_optimizer.py
@@ -89,9 +89,9 @@ class ThresholdOptimizer(PostProcessing):
         as well as the fairness-unaware predictor or estimator. If an estimator was passed
         in the constructor this fit method will call `fit(X, y, **kwargs)` on said estimator.
 
-        :param X: feature matrix
+        :param X: The feature matrix
         :type X: numpy.ndarray or pandas.DataFrame
-        :param y: label vector
+        :param y: The label vector
         :type y: numpy.ndarray, pandas.DataFrame, pandas.Series, or list
         :param sensitive_features: sensitive features to identify groups by, currently allows
             only a single column

--- a/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
+++ b/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
@@ -29,22 +29,27 @@ class ExponentiatedGradient(Reduction):
     `Agarwal et al. (2018) <https://arxiv.org/abs/1803.02453>`_.
 
     :param estimator: An estimator implementing methods :code:`fit(X, y, sample_weight)` and
-        :code:`predict(X)`, where `X` is the set of features, `y` is the set of labels, and
-        `sample_weight` is a set of weights; labels `y` and predictions returned by
+        :code:`predict(X)`, where `X` is the matrix of features, `y` is the vector of labels, and
+        `sample_weight` is a vector of weights; labels `y` and predictions returned by
         :code:`predict(X)` are either 0 or 1.
-    :type estimator: An estimator
+    :type estimator: estimator
+
     :param constraints: The disparity constraints expressed as moments
     :type constraints: fairlearn.reductions.Moment
+
     :param eps: Allowed fairness constraint violation; the solution best_classifier is
         guaranteed to have the classification error within :code:`2*best_gap` of the best error
         under constraint eps; the constraint violation is at most :code:`2*(eps+best_gap)`
     :type eps: float
+
     :param T: Maximum number of iterations
     :type T: int
+
     :param nu: Convergence threshold for the duality gap, corresponding to a
         conservative automatic setting based on the statistical uncertainty in measuring
         classification error
     :type nu: float
+
     :param eta_mul: Initial setting of the learning rate
     :type eta_mul: float
     """
@@ -62,10 +67,11 @@ class ExponentiatedGradient(Reduction):
     def fit(self, X, y, **kwargs):
         """Return a fair classifier under specified fairness constraints.
 
-        :param X: The array of training features
-        :type X: Array
-        :param y: The array of training labels
-        :type y: 1-dimensional Array
+        :param X: The feature matrix
+        :type X: numpy.ndarray or pandas.DataFrame
+
+        :param y: The label vector
+        :type y: numpy.ndarray, pandas.DataFrame, pandas.Series, or list
         """
         X_train, y_train, A = _validate_and_reformat_reductions_input(X, y, **kwargs)
 
@@ -165,10 +171,12 @@ class ExponentiatedGradient(Reduction):
         Note that this is non-deterministic, due to the nature of the
         exponentiated gradient algorithm.
 
-        :param X: The data for which predictions are required
-        :type X: Array
-        :return: Array of predictions as 0 or 1.
-        :rtype: Array
+        :param X: Feature data
+        :type X: numpy.ndarray or pandas.DataFrame
+
+        :return: The prediction. If `X` represents the data for a single example
+            the result will be a scalar. Otherwise the result will be a vector
+        :rtype: Scalar or vector
         """
         positive_probs = self._best_classifier(X)
         return (positive_probs >= np.random.rand(len(positive_probs))) * 1

--- a/fairlearn/reductions/_grid_search/grid_search.py
+++ b/fairlearn/reductions/_grid_search/grid_search.py
@@ -257,8 +257,9 @@ class GridSearch(Reduction):
         return
 
     def predict(self, X):
-        """Provide a prediction for the given input data based on the best model found by the
-        grid search. This works by dispatching `X` to the :code:`predict(X)` method of the
+        """Provide a prediction using the best model found by the grid search.
+
+        This dispatches `X` to the :code:`predict(X)` method of the
         selected estimator, and hence the return type is dependent on that method.
 
         :param X: Feature data
@@ -272,7 +273,7 @@ class GridSearch(Reduction):
         """Provide the result of :code:`predict_proba` from the best model found by the grid search.
 
         The underlying estimator must support :code:`predict_proba(X)` for this
-        to work. The return type is determined by this method. 
+        to work. The return type is determined by this method.
 
         :param X: Feature data
         :type X: numpy.ndarray or pandas.DataFrame

--- a/fairlearn/reductions/_grid_search/grid_search.py
+++ b/fairlearn/reductions/_grid_search/grid_search.py
@@ -84,11 +84,13 @@ class GridSearch(Reduction):
     The approach used is taken from section 3.4 of
     `Agarwal et al. (2018) <https://arxiv.org/abs/1803.02453>`_.
 
-    :param estimator: The underlying estimator to be used. Must provide a
-        :code:`fit(X, y, sample_weights)` method
+    :param estimator: An estimator implementing methods :code:`fit(X, y, sample_weight)` and
+        :code:`predict(X)`, where `X` is the matrix of features, `y` is the vector of labels, and
+        `sample_weight` is a vector of weights; labels `y` and predictions returned by
+        :code:`predict(X)` are either 0 or 1.
+    :type estimator: estimator
 
-    :param constraints: Object describing the parity constraints. This provides the reweighting
-        and relabelling
+    :param constraints: The disparity constraints expressed as moments.
     :type constraints: fairlearn.reductions.Moment
 
     :param selection_rule: Specifies the procedure for selecting the best model found by the
@@ -163,18 +165,18 @@ class GridSearch(Reduction):
         """Run the grid search.
 
         This will result in multiple copies of the
-        estimator being made, and the :code:`fit` method
+        estimator being made, and the :code:`fit(X)` method
         of each one called.
 
-        :param X: The feature data for the machine learning problem
-        :type X: Array
+        :param X: The feature matrix
+        :type X: numpy.ndarray or pandas.DataFrame
 
-        :param y: The ground truth labels for the machine learning problem
-        :type y: 1-D array
+        :param y: The label vector
+        :type y: numpy.ndarray, pandas.DataFrame, pandas.Series, or list
 
         :param sensitive_features: A (currently) required keyword argument listing the
             feature used by the constraints object
-        :type sensitive_features: 1-D array (for now)
+        :type sensitive_features: numpy.ndarray, pandas.DataFrame, pandas.Series, or list (for now)
         """
         X_train, y_train, _ = _validate_and_reformat_reductions_input(
             X, y, enforce_binary_sensitive_feature=True, **kwargs)
@@ -255,14 +257,12 @@ class GridSearch(Reduction):
         return
 
     def predict(self, X):
-        """Provide a prediction for the given input data based on the best model found by the grid search.
+        """Provide a prediction for the given input data based on the best model found by the
+        grid search. This works by dispatching `X` to the :code:`predict(X)` method of the
+        selected estimator, and hence the return type is dependent on that method.
 
-        :param X: The data for which predictions are required
-        :type X: Array
-
-        :return: The prediction. If X represents the data for a single example
-            the result will be a scalar. Otherwise the result will be an
-        :rtype: Scalar or array
+        :param X: Feature data
+        :type X: numpy.ndarray or pandas.DataFrame
         """
         if self.best_result is None:
             raise NotFittedException(_NO_PREDICT_BEFORE_FIT)
@@ -271,11 +271,11 @@ class GridSearch(Reduction):
     def predict_proba(self, X):
         """Provide the result of :code:`predict_proba` from the best model found by the grid search.
 
-        The underlying estimator must support :code:`predict_proba` for this
-        to work.
+        The underlying estimator must support :code:`predict_proba(X)` for this
+        to work. The return type is determined by this method. 
 
-        :param X: The data for which predictions are required
-        :type X: Array
+        :param X: Feature data
+        :type X: numpy.ndarray or pandas.DataFrame
         """
         if self.best_result is None:
             raise NotFittedException(_NO_PREDICT_BEFORE_FIT)


### PR DESCRIPTION
Make our documentation of `fit()`, `X`, `predict()` etc. more standard between our various submodules.

Signed-off-by: Richard Edgar <riedgar@microsoft.com>