### PR TITLE
Documentation and flake8

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ copyright = '2019, Microsoft Corporation.'
 author = 'Microsoft'
 
 # The full version, including alpha/beta/rc tags
-release = '0.4.0a1'
+release = fairlearn._base_version
 
 
 # -- General configuration ---------------------------------------------------

--- a/fairlearn/exceptions.py
+++ b/fairlearn/exceptions.py
@@ -5,4 +5,4 @@
 
 
 class NotFittedException(ValueError):
-    """Exception to use if predict is called before fit."""
+    """Exception to use if :code:`predict()` is called before :code:`fit()`."""

--- a/fairlearn/exceptions.py
+++ b/fairlearn/exceptions.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+"""Module holding specialised exceptions for fairlearn."""
+
 
 class NotFittedException(ValueError):
     """Exception to use if predict is called before fit."""

--- a/fairlearn/metrics/__init__.py
+++ b/fairlearn/metrics/__init__.py
@@ -130,4 +130,4 @@ _engine = [
 ]
 
 
-__all__ = _engine + _extra_metrics + _group_metrics  # noqa: RST902
+__all__ = _engine + _extra_metrics + _group_metrics

--- a/fairlearn/metrics/__init__.py
+++ b/fairlearn/metrics/__init__.py
@@ -41,15 +41,15 @@ from ._metrics_engine import make_group_metric, metric_by_group  # noqa: F401
 
 # Classification metrics
 group_specificity_score = make_group_metric(specificity_score)
-"""A grouped metric for the :any:`specificity_score`
+"""A grouped metric for the :py:func:`specificity_score`
 """
 
 group_miss_rate = make_group_metric(miss_rate)
-"""A grouped metric for the :any:`miss_rate`
+"""A grouped metric for the :py:func:`miss_rate`
 """
 
 group_fallout_rate = make_group_metric(fallout_rate)
-"""A grouped metric for the :any:`fallout_rate`
+"""A grouped metric for the :py:func:`fallout_rate`
 """
 
 # Regression metrics
@@ -71,19 +71,19 @@ group_median_absolute_error = make_group_metric(skm.median_absolute_error)
 
 group_balanced_root_mean_squared_error = make_group_metric(
     balanced_root_mean_squared_error)
-"""A grouped wrapper around the :any:`balanced_root_mean_squared_error` routine
+"""A grouped wrapper around the :py:func:`balanced_root_mean_squared_error` routine
 """
 
 group_mean_prediction = make_group_metric(mean_prediction)
-"""A grouped wrapper around the :any:`mean_prediction` routine
+"""A grouped wrapper around the :py:func:`mean_prediction` routine
 """
 
 group_mean_overprediction = make_group_metric(mean_overprediction)
-"""A grouped wrapper around the :any:`mean_overprediction` routine
+"""A grouped wrapper around the :py:func:`mean_overprediction` routine
 """
 
 group_mean_underprediction = make_group_metric(mean_underprediction)
-"""A grouped wapper around the :any:`mean_underprediction` routine
+"""A grouped wapper around the :py:func:`mean_underprediction` routine
 """
 
 # -------------------------------------------

--- a/fairlearn/metrics/__init__.py
+++ b/fairlearn/metrics/__init__.py
@@ -54,19 +54,19 @@ group_fallout_rate = make_group_metric(fallout_rate)
 
 # Regression metrics
 group_max_error = make_group_metric(skm.max_error)
-"""A grouped wrapper around the :any:`sklearn.metrics.max_error` routine
+"""A grouped wrapper around the :py:func:`sklearn.metrics.max_error` routine
 """
 
 group_mean_absolute_error = make_group_metric(skm.mean_absolute_error)
-"""A grouped wrapper around the :any:`sklearn.metrics.mean_absolute_error` routine
+"""A grouped wrapper around the :py:func:`sklearn.metrics.mean_absolute_error` routine
 """
 
 group_mean_squared_log_error = make_group_metric(skm.mean_squared_log_error)
-"""A grouped wrapper around the :any:`sklearn.metrics.mean_squared_log_error` routine
+"""A grouped wrapper around the :py:func:`sklearn.metrics.mean_squared_log_error` routine
 """
 
 group_median_absolute_error = make_group_metric(skm.median_absolute_error)
-"""A grouped wrapper around the :any:`sklearn.metrics.median_absolute_error` routine
+"""A grouped wrapper around the :py:func:`sklearn.metrics.median_absolute_error` routine
 """
 
 group_balanced_root_mean_squared_error = make_group_metric(

--- a/fairlearn/metrics/__init__.py
+++ b/fairlearn/metrics/__init__.py
@@ -130,4 +130,4 @@ _engine = [
 ]
 
 
-__all__ = _engine + _extra_metrics + _group_metrics
+__all__ = _engine + _extra_metrics + _group_metrics  # noqa: RST902

--- a/fairlearn/metrics/_balanced_root_mean_squared_error.py
+++ b/fairlearn/metrics/_balanced_root_mean_squared_error.py
@@ -23,7 +23,7 @@ def balanced_root_mean_squared_error(y_true, y_pred, sample_weight=None):
     (which could be thresholded to get a predicted class).
 
     Internally, this builds on the
-    :any:`sklearn.metrics.mean_squared_error` routine.
+    :py:func:`sklearn.metrics.mean_squared_error` routine.
     """
     y_ta = _convert_to_ndarray_and_squeeze(y_true)
     y_pa = _convert_to_ndarray_and_squeeze(y_pred)

--- a/fairlearn/metrics/_extra_metrics.py
+++ b/fairlearn/metrics/_extra_metrics.py
@@ -18,7 +18,7 @@ def specificity_score(y_true, y_pred, sample_weight=None):
 
     At the present time, this routine only supports binary
     classifiers with labels :math:`\in {0, 1}`.
-    The calculation uses the :sklearn:`sklearn.metrics.confusion_matrix` routine.
+    The calculation uses the :py:`sklearn.metrics.confusion_matrix` routine.
     """
     cm = skm.confusion_matrix(y_true, y_pred, sample_weight=sample_weight)
     # Taken from

--- a/fairlearn/metrics/_extra_metrics.py
+++ b/fairlearn/metrics/_extra_metrics.py
@@ -18,7 +18,7 @@ def specificity_score(y_true, y_pred, sample_weight=None):
 
     At the present time, this routine only supports binary
     classifiers with labels :math:`\in {0, 1}`.
-    The calculation uses the :any:`sklearn.metrics.confusion_matrix` routine.
+    The calculation uses the :py:func:`sklearn.metrics.confusion_matrix` routine.
     """
     cm = skm.confusion_matrix(y_true, y_pred, sample_weight=sample_weight)
     # Taken from
@@ -35,7 +35,7 @@ def miss_rate(y_true, y_pred, sample_weight=None):
     classifiers with labels :math:`\in {0, 1}`.
     By definition, this is the complement of the True Positive
     Rate, so this routine uses the
-    :any:`sklearn.metrics.recall_score` routine.
+    :py:func:`sklearn.metrics.recall_score` routine.
     """
     # aka False Negative Rate
     tpr = skm.recall_score(y_true, y_pred, sample_weight=sample_weight)

--- a/fairlearn/metrics/_extra_metrics.py
+++ b/fairlearn/metrics/_extra_metrics.py
@@ -18,7 +18,7 @@ def specificity_score(y_true, y_pred, sample_weight=None):
 
     At the present time, this routine only supports binary
     classifiers with labels :math:`\in {0, 1}`.
-    The calculation uses the :any:`sklearn.metrics.confusion_matrix` routine.
+    The calculation uses the :sklearn:`sklearn.metrics.confusion_matrix` routine.
     """
     cm = skm.confusion_matrix(y_true, y_pred, sample_weight=sample_weight)
     # Taken from

--- a/fairlearn/metrics/_extra_metrics.py
+++ b/fairlearn/metrics/_extra_metrics.py
@@ -18,7 +18,7 @@ def specificity_score(y_true, y_pred, sample_weight=None):
 
     At the present time, this routine only supports binary
     classifiers with labels :math:`\in {0, 1}`.
-    The calculation uses the :sphinx:py:function:`sklearn.metrics.confusion_matrix` routine.
+    The calculation uses the :sklearn:py:function:`sklearn.metrics.confusion_matrix` routine.
     """
     cm = skm.confusion_matrix(y_true, y_pred, sample_weight=sample_weight)
     # Taken from

--- a/fairlearn/metrics/_extra_metrics.py
+++ b/fairlearn/metrics/_extra_metrics.py
@@ -18,7 +18,7 @@ def specificity_score(y_true, y_pred, sample_weight=None):
 
     At the present time, this routine only supports binary
     classifiers with labels :math:`\in {0, 1}`.
-    The calculation uses the :sklearn:py:function:`sklearn.metrics.confusion_matrix` routine.
+    The calculation uses the :any:`sklearn.metrics.confusion_matrix` routine.
     """
     cm = skm.confusion_matrix(y_true, y_pred, sample_weight=sample_weight)
     # Taken from
@@ -50,7 +50,7 @@ def fallout_rate(y_true, y_pred, sample_weight=None):
     At the present time, this routine only supports binary
     classifiers with labels :math:`\in {0, 1}`.
     By definition, this is the complement of the
-    Specificity, and so uses :any:`specificity_score` in its
+    Specificity, and so uses :py:func:`specificity_score` in its
     calculation.
     """
     # aka False Positive Rate

--- a/fairlearn/metrics/_extra_metrics.py
+++ b/fairlearn/metrics/_extra_metrics.py
@@ -18,7 +18,7 @@ def specificity_score(y_true, y_pred, sample_weight=None):
 
     At the present time, this routine only supports binary
     classifiers with labels :math:`\in {0, 1}`.
-    The calculation uses the :function:`sklearn.metrics.confusion_matrix` routine.
+    The calculation uses the :sphinx:py:function:`sklearn.metrics.confusion_matrix` routine.
     """
     cm = skm.confusion_matrix(y_true, y_pred, sample_weight=sample_weight)
     # Taken from

--- a/fairlearn/metrics/_extra_metrics.py
+++ b/fairlearn/metrics/_extra_metrics.py
@@ -18,7 +18,7 @@ def specificity_score(y_true, y_pred, sample_weight=None):
 
     At the present time, this routine only supports binary
     classifiers with labels :math:`\in {0, 1}`.
-    The calculation uses the :py:`sklearn.metrics.confusion_matrix` routine.
+    The calculation uses the :function:`sklearn.metrics.confusion_matrix` routine.
     """
     cm = skm.confusion_matrix(y_true, y_pred, sample_weight=sample_weight)
     # Taken from

--- a/fairlearn/metrics/_group_metric_result.py
+++ b/fairlearn/metrics/_group_metric_result.py
@@ -1,9 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-# Class is just for holding results so 'imperative mode' makes
-# little sense
-# flake8: noqa: D401
 
 class GroupMetricResult:
     """Class to hold the result of a grouped metric.
@@ -33,7 +30,7 @@ class GroupMetricResult:
 
     @property
     def overall(self):
-        """The metric calculated over the entire dataset."""
+        """Return the metric calculated over the entire dataset."""
         return self._overall
 
     @overall.setter
@@ -42,7 +39,7 @@ class GroupMetricResult:
 
     @property
     def by_group(self):
-        """The metric calculated for each sub-group in the dataset.
+        """Return the metric calculated for each sub-group in the dataset.
 
         This is a dictionary whose keys are the unique members of
         the ``group_membership`` data. The corresponding values are
@@ -57,7 +54,7 @@ class GroupMetricResult:
 
     @property
     def minimum(self):
-        """The minimum value of the metric in the ``by_group`` dictionary.
+        """Return the minimum value of the metric in the ``by_group`` dictionary.
 
         This is only set if the metric is a scalar.
         """
@@ -69,7 +66,7 @@ class GroupMetricResult:
 
     @property
     def maximum(self):
-        """The maximum value of the metric in the ``by_group`` dictionary.
+        """Return the maximum value of the metric in the ``by_group`` dictionary.
 
         This is only set if the metric is a scalar.
         """
@@ -81,7 +78,7 @@ class GroupMetricResult:
 
     @property
     def argmin_set(self):
-        """The set of groups corresponding to the ``minimum``.
+        """Return the set of groups corresponding to the ``minimum``.
 
         This is only set if the metric is a scalar, and will be
         a set of keys to tbe ``by_group`` dictionary.
@@ -94,7 +91,7 @@ class GroupMetricResult:
 
     @property
     def argmax_set(self):
-        """The set of groups corresponding to the ``minimum``.
+        """Return the set of groups corresponding to the ``minimum``.
 
         This is only set if the metric is a scalar, and will be
         a set of keys to tbe ``by_group`` dictionary.
@@ -107,7 +104,7 @@ class GroupMetricResult:
 
     @property  # noqa: A003
     def range(self):
-        """The value of :code:`maximum-minimum`.
+        """Return the value of :code:`maximum-minimum`.
 
         This is only set if the metric is a scalar.
         """
@@ -119,7 +116,7 @@ class GroupMetricResult:
 
     @property
     def range_ratio(self):
-        """The value of :code:`minimum/maximum`.
+        """Return the value of :code:`minimum/maximum`.
 
         This is only set if the metric is a scalar.
         """

--- a/fairlearn/metrics/_skm_wrappers.py
+++ b/fairlearn/metrics/_skm_wrappers.py
@@ -9,7 +9,7 @@ from ._metrics_engine import metric_by_group
 def group_accuracy_score(y_true, y_pred, group_membership, *,
                          normalize=True,
                          sample_weight=None):
-    """Wrap the :any:`sklearn.metrics.accuracy_score` routine.
+    """Wrap the :py:func:`sklearn.metrics.accuracy_score` routine.
 
     The arguments remain the same, with `group_membership` added.
     However, the only positional arguments supported are `y_true`,
@@ -27,7 +27,7 @@ def group_accuracy_score(y_true, y_pred, group_membership, *,
 def group_confusion_matrix(y_true, y_pred, group_membership, *,
                            labels=None,
                            sample_weight=None):
-    """Wrap the :any:`sklearn.metrics.confusion_matrix` routine.
+    """Wrap the :py:func:`sklearn.metrics.confusion_matrix` routine.
 
     The arguments remain the same, with `group_membership` added.
     However, the only positional arguments supported are `y_true`,
@@ -45,7 +45,7 @@ def group_confusion_matrix(y_true, y_pred, group_membership, *,
 def group_precision_score(y_true, y_pred, group_membership, *,
                           labels=None, pos_label=1, average='binary',
                           sample_weight=None):
-    """Wrap the :any:`sklearn.metrics.precision_score` routine.
+    """Wrap the :py:func:`sklearn.metrics.precision_score` routine.
 
     The arguments remain the same, with `group_membership` added.
     However, the only positional arguments supported are `y_true`,
@@ -63,7 +63,7 @@ def group_precision_score(y_true, y_pred, group_membership, *,
 def group_recall_score(y_true, y_pred, group_membership, *,
                        labels=None, pos_label=1, average='binary',
                        sample_weight=None):
-    """Wrap the :any:`sklearn.metrics.recall_score` routine.
+    """Wrap the :py:func:`sklearn.metrics.recall_score` routine.
 
     The arguments remain the same, with `group_membership` added.
     However, the only positional arguments supported are `y_true`,
@@ -82,7 +82,7 @@ def group_recall_score(y_true, y_pred, group_membership, *,
 def group_roc_auc_score(y_true, y_pred, group_membership, *,
                         average='macro', max_fpr=None,
                         sample_weight=None):
-    """Wrap the :any:`sklearn.metrics.roc_auc_score` routine.
+    """Wrap the :py:func:`sklearn.metrics.roc_auc_score` routine.
 
     The arguments remain the same, with `group_membership` added.
     However, the only positional arguments supported are `y_true`,
@@ -101,7 +101,7 @@ def group_roc_auc_score(y_true, y_pred, group_membership, *,
 def group_zero_one_loss(y_true, y_pred, group_membership, *,
                         normalize=True,
                         sample_weight=None):
-    """Wrap the :any:`sklearn.metrics.zero_one_loss` routine.
+    """Wrap the :py:func:`sklearn.metrics.zero_one_loss` routine.
 
     The arguments remain the same, with `group_membership` added.
     However, the only positional arguments supported are `y_true`,
@@ -121,7 +121,7 @@ def group_zero_one_loss(y_true, y_pred, group_membership, *,
 def group_mean_squared_error(y_true, y_pred, group_membership, *,
                              multioutput='uniform_average',
                              sample_weight=None):
-    """Wrap the :any:`sklearn.metrics.mean_squared_error` routine.
+    """Wrap the :py:func:`sklearn.metrics.mean_squared_error` routine.
 
     The arguments remain the same, with `group_membership` added.
     However, the only positional arguments supported are `y_true`,
@@ -140,7 +140,7 @@ def group_mean_squared_error(y_true, y_pred, group_membership, *,
 def group_root_mean_squared_error(y_true, y_pred, group_membership, *,
                                   multioutput='uniform_average',
                                   sample_weight=None):
-    """Wrap the :any:`sklearn.metrics.mean_squared_error` routine.
+    """Wrap the :py:func:`sklearn.metrics.mean_squared_error` routine.
 
     The arguments remain the same, with `group_membership` added.
     The result is then square rooted.
@@ -160,7 +160,7 @@ def group_root_mean_squared_error(y_true, y_pred, group_membership, *,
 def group_r2_score(y_true, y_pred, group_membership, *,
                    multioutput='uniform_average',
                    sample_weight=None):
-    """Wrap the :any:`sklearn.metrics.r2_score` routine.
+    """Wrap the :py:func:`sklearn.metrics.r2_score` routine.
 
     The arguments remain the same, with `group_membership` added.
     However, the only positional arguments supported are `y_true`,

--- a/fairlearn/postprocessing/_interpolated_prediction.py
+++ b/fairlearn/postprocessing/_interpolated_prediction.py
@@ -8,22 +8,23 @@ logger = logging.getLogger(__name__)
 
 
 class InterpolatedPredictor:
+    """Predictor for computing predictions between two actual predictions.
+
+    The predictions are represented through the threshold rules operation0 and operation1.
+
+    :param p_ignore: p_ignore changes the interpolated prediction P to the desired
+        solution using the transformation p_ignore * prediction_constant + (1 - p_ignore) * P
+    :param prediction_constant: 0 if not required, otherwise the x value of the best
+        solution should be passed
+    :param p0: interpolation multiplier for prediction from the first predictor
+    :param operation0: threshold rule for the first predictor
+    :param p1: interpolation multiplier for prediction from the second predictor
+    :param operation1: threshold rule for the second predictor
+    :return: an anonymous function that scales the original prediction to the desired one
+    :rtype: lambda
+    """
+
     def __init__(self, p_ignore, prediction_constant, p0, operation0, p1, operation1):
-        """Create the interpolated prediction between two predictions.
-
-        The predictions are represented through the threshold rules operation0 and operation1.
-
-        :param p_ignore: p_ignore changes the interpolated prediction P to the desired
-            solution using the transformation p_ignore * prediction_constant + (1 - p_ignore) * P
-        :param prediction_constant: 0 if not required, otherwise the x value of the best
-            solution should be passed
-        :param p0: interpolation multiplier for prediction from the first predictor
-        :param operation0: threshold rule for the first predictor
-        :param p1: interpolation multiplier for prediction from the second predictor
-        :param operation1: threshold rule for the second predictor
-        :return: an anonymous function that scales the original prediction to the desired one
-        :rtype: lambda
-        """
         self._operation0 = operation0
         self._operation1 = operation1
         self._p_ignore = p_ignore

--- a/fairlearn/postprocessing/_threshold_optimizer.py
+++ b/fairlearn/postprocessing/_threshold_optimizer.py
@@ -68,7 +68,6 @@ class ThresholdOptimizer(PostProcessing):
 
     def __init__(self, *, unconstrained_predictor=None, estimator=None,
                  constraints=DEMOGRAPHIC_PARITY, grid_size=1000, flip=True, plot=False):
-        """Construct a ThresholdOptimizer"""
         super(ThresholdOptimizer, self).__init__(
             unconstrained_predictor=unconstrained_predictor,
             estimator=estimator,

--- a/fairlearn/postprocessing/_threshold_optimizer.py
+++ b/fairlearn/postprocessing/_threshold_optimizer.py
@@ -68,6 +68,7 @@ class ThresholdOptimizer(PostProcessing):
 
     def __init__(self, *, unconstrained_predictor=None, estimator=None,
                  constraints=DEMOGRAPHIC_PARITY, grid_size=1000, flip=True, plot=False):
+        """Construct a ThresholdOptimizer"""
         super(ThresholdOptimizer, self).__init__(
             unconstrained_predictor=unconstrained_predictor,
             estimator=estimator,

--- a/fairlearn/reductions/_exponentiated_gradient/_exponentiated_gradient_result.py
+++ b/fairlearn/reductions/_exponentiated_gradient/_exponentiated_gradient_result.py
@@ -2,16 +2,11 @@
 # Licensed under the MIT License.
 
 
-# Class is just for holding results so 'imperative mode' makes
-# little sense
-# flake8: noqa: D401
-
 class ExponentiatedGradientResult:
     """Class to hold the result of an `ExponentiatedGradient` estimator."""
 
     def __init__(self, best_classifier, best_gap, classifiers, weights, last_t, best_t,
                  n_oracle_calls):
-        """Result object for the exponentiated gradient reduction operation."""
         self._best_classifier = best_classifier
         self._best_gap = best_gap
         self._classifiers = classifiers
@@ -22,7 +17,7 @@ class ExponentiatedGradientResult:
 
     @property
     def best_classifier(self):
-        """The best classifier found by the algorithm.
+        """Return the best classifier found by the algorithm.
 
         A function that maps a DataFrame `X` containing covariates to a Series containing the
         corresponding probabilistic decisions in :math:`[0,1]`
@@ -31,7 +26,7 @@ class ExponentiatedGradientResult:
 
     @property
     def best_gap(self):
-        """The quality of `best_classifier`.
+        """Return the quality of `best_classifier`.
 
         If the algorithm has converged then :code:`best_gap <= nu`;
         the solution `best_classifier` is guaranteed to have the classification error within
@@ -42,27 +37,27 @@ class ExponentiatedGradientResult:
 
     @property
     def classifiers(self):
-        """The base classifiers generated (instances of estimator)."""
+        """Return the base classifiers generated (instances of estimator)."""
         return self._classifiers
 
     @property
     def weights(self):
-        """The weights of those classifiers within `best_classifier`."""
+        """Return the weights of those classifiers within `best_classifier`."""
         return self._weights
 
     @property
     def last_t(self):
-        """The last executed iteration; always :code:`last_t < T`."""
+        """Return the last executed iteration; always :code:`last_t < T`."""
         return self._last_t
 
     @property
     def best_t(self):
-        """The iteration in which best_classifier was obtained."""
+        """Return the iteration in which best_classifier was obtained."""
         return self._best_t
 
     @property
     def n_oracle_calls(self):
-        """The number of times the estimator was called."""
+        """Return the number of times the estimator was called."""
         return self._n_oracle_calls
 
     def _as_dict(self):

--- a/fairlearn/reductions/_grid_search/grid_search_result.py
+++ b/fairlearn/reductions/_grid_search/grid_search_result.py
@@ -1,9 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-# Class is just for holding results so 'imperative mode' makes
-# little sense
-# flake8: noqa: D401
 
 class GridSearchResult:
     """Class to hold a single result from the :class:`GridSearch` class."""
@@ -16,12 +13,12 @@ class GridSearchResult:
 
     @property
     def predictor(self):
-        """The predictor trained for this particular result from :class:`GridSearch`."""
+        """Return the predictor trained for this particular result from :class:`GridSearch`."""
         return self._predictor
 
     @property
     def lambda_vec(self):
-        """The Lagrange multiplier corresponding to this result.
+        """Return the Lagrange multiplier corresponding to this result.
 
         The exact contents of this are defined by the `constraints`
         argument passed to :class:`GridSearch`
@@ -30,10 +27,10 @@ class GridSearchResult:
 
     @property
     def objective(self):
-        """Description goes here."""
+        """Description goes here."""  # noqa: D401
         return self._objective
 
     @property
     def gamma(self):
-        """Description goes here."""
+        """Description goes here."""  # noqa: D401
         return self._gamma

--- a/fairlearn/reductions/_moments/bounded_group_loss.py
+++ b/fairlearn/reductions/_moments/bounded_group_loss.py
@@ -70,18 +70,21 @@ ConditionalLossMoment.__module__ = "fairlearn.reductions"
 
 
 class AverageLossMoment(ConditionalLossMoment):
+    """Moment for Average Loss."""
 
     def __init__(self, loss):
         super().__init__(loss, no_groups=True)
 
 
 class GroupLossMoment(ConditionalLossMoment):
+    """Moment for Group Loss."""
 
     def __init__(self, loss):
         super().__init__(loss, no_groups=False)
 
 
 class SquareLoss:
+    """Class to evaluate the square loss."""
 
     def __init__(self, min_val, max_val):
         self.min_val = min_val
@@ -96,6 +99,7 @@ class SquareLoss:
 
 
 class AbsoluteLoss:
+    """Class to evaluate absolute loss."""
 
     def __init__(self, min_val, max_val):
         self.min_val = min_val
@@ -115,6 +119,7 @@ AbsoluteLoss.__module__ = "fairlearn.reductions"
 
 
 class ZeroOneLoss(AbsoluteLoss):
+    """Class to evaluate a zero-one loss."""
 
     def __init__(self):
         super().__init__(0, 1)

--- a/fairlearn/reductions/_moments/conditional_selection_rate.py
+++ b/fairlearn/reductions/_moments/conditional_selection_rate.py
@@ -10,7 +10,11 @@ _DIFF = "diff"
 
 
 class ConditionalSelectionRate(ClassificationMoment):
-    """Generic fairness metric including :class:`DemographicParity` and :class:`EqualizedOdds`."""
+    """Generic fairness moment for selection rates.
+
+    This serves as the base class for both :class:`DemographicParity`
+    and :class:`EqualizedOdds`.
+    """
 
     def default_objective(self):
         """Return the default objective for moments of this kind."""

--- a/fairlearn/reductions/_reduction.py
+++ b/fairlearn/reductions/_reduction.py
@@ -1,18 +1,17 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-# flake8: noqa: D102
 
 class Reduction:
     """Base class for our reduction-implementing estimators."""
 
-    def fit(self, X, y, **kwargs):
+    def fit(self, X, y, **kwargs):  # noqa: D102
         raise NotImplementedError()
 
-    def predict(self, X):
+    def predict(self, X):  # noqa: D102
         raise NotImplementedError()
 
-    def predict_proba(self, X):
+    def predict_proba(self, X):  # noqa: D102
         raise NotImplementedError()
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,9 +8,9 @@ enable-extensions = G
 per-file-ignores = 
     setup.py:D100
     docs/*.py:D100,A001
-    fairlearn/_*.py:D100
-    fairlearn/*/_*.py:D100
-    fairlearn/*/*.py:D107
+    fairlearn/*.py:D100
+    fairlearn/*/*.py:D100,D101,D107,RST304
+    fairlearn/metrics/__init__.py: RST902
     scripts/*.py:D100,D101,D102,D103,D104,D107,D205,D400,D401,RST201,RST205,RST301
     test/*.py:D104
     test/*/*.py:D100,D101,D102,D103,D104,D105,D107

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ enable-extensions = G
 
 # Suppress particular flake8 warnings
 # Ideally for the fairlearn directory (which becomes the wheel) we would have no
-# suppressions. For the following reasons, we still have the 
+# suppressions. For the following reasons, we still have some demaining:
 # D100 requires docstrings on public modules but there is some issue with '_' prefixes on filenames
 # D107 requires docstrings on __init__ but these are ignored in our current sphinx configuration
 # RST902 is from trouble parsing the __all__ entry. This only happens in a single file
@@ -12,7 +12,7 @@ per-file-ignores =
     setup.py:D100
     docs/*.py:D100,A001
     fairlearn/*.py:D100
-    fairlearn/*/*.py:D100,D107,RST304
+    fairlearn/*/*.py:D100,D107
     fairlearn/metrics/__init__.py: RST902
     scripts/*.py:D100,D101,D102,D103,D104,D107,D205,D400,D401,RST201,RST205,RST301
     test/*.py:D104

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,8 @@ max-line-length = 99
 enable-extensions = G
 
 # Suppress particular flake8 warnings
-# Ideally for the fairlearn directory (which becomes the wheel) we would have no
-# suppressions. For the following reasons, we still have some demaining:
+# Ideally for the fairlearn directory (which becomes the published wheel) we would have no
+# suppressions. For the following reasons, we still have some remaining:
 # D100 requires docstrings on public modules but there is some issue with '_' prefixes on filenames
 # D107 requires docstrings on __init__ but these are ignored in our current sphinx configuration
 # RST304 is about "unknown text roles" in sphinx. Unfortunately, things like :class: appear to be unknown

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ enable-extensions = G
 
 # Some explanations for suppressions:
 # D100 requires docstrings on public modules but there is some issue with '_' prefixes
-# D107 requires docstrings on __init__ but these are ignored
+# D107 requires docstrings on __init__ but these are ignored in our current sphinx configuration
 per-file-ignores = 
     setup.py:D100
     docs/*.py:D100,A001

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,9 +7,6 @@ enable-extensions = G
 per-file-ignores = 
     setup.py:D100
     docs/*.py:D100,A001
-    fairlearn/*.py:D100
-    fairlearn/*/*.py:D100,D101,D107,RST304
-    fairlearn/metrics/__init__.py: RST902
     scripts/*.py:D100,D101,D102,D103,D104,D107,D205,D400,D401,RST201,RST205,RST301
     test/*.py:D104
     test/*/*.py:D100,D101,D102,D103,D104,D105,D107

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ enable-extensions = G
 per-file-ignores = 
     setup.py:D100
     docs/*.py:D100,A001
+    fairlearn/*/*.py:D107
     scripts/*.py:D100,D101,D102,D103,D104,D107,D205,D400,D401,RST201,RST205,RST301
     test/*.py:D104
     test/*/*.py:D100,D101,D102,D103,D104,D105,D107

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ per-file-ignores =
     setup.py:D100
     docs/*.py:D100,A001
     fairlearn/*.py:D100
-    fairlearn/*/*.py:D100,D101,D107,RST304
+    fairlearn/*/*.py:D100,D107,RST304
     scripts/*.py:D100,D101,D102,D103,D104,D107,D205,D400,D401,RST201,RST205,RST301
     test/*.py:D104
     test/*/*.py:D100,D101,D102,D103,D104,D105,D107

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,11 +2,14 @@
 max-line-length = 99
 enable-extensions = G
 
-# Will want to remove all the ignores for the fairlearn directory
-# However, the initial enforcement has to be kept to within reasonable limits
+# Some explanations for suppressions:
+# D100 requires docstrings on public modules but there is some issue with '_' prefixes
+# D107 requires docstrings on __init__ but these are ignored
 per-file-ignores = 
     setup.py:D100
     docs/*.py:D100,A001
+    fairlearn/_*.py:D100
+    fairlearn/*/_*.py:D100
     fairlearn/*/*.py:D107
     scripts/*.py:D100,D101,D102,D103,D104,D107,D205,D400,D401,RST201,RST205,RST301
     test/*.py:D104

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,11 +7,13 @@ enable-extensions = G
 # suppressions. For the following reasons, we still have the 
 # D100 requires docstrings on public modules but there is some issue with '_' prefixes on filenames
 # D107 requires docstrings on __init__ but these are ignored in our current sphinx configuration
+# RST902 is from trouble parsing the __all__ entry. This only happens in a single file
 per-file-ignores = 
     setup.py:D100
     docs/*.py:D100,A001
     fairlearn/*.py:D100
     fairlearn/*/*.py:D100,D107,RST304
+    fairlearn/metrics/__init__.py: RST902
     scripts/*.py:D100,D101,D102,D103,D104,D107,D205,D400,D401,RST201,RST205,RST301
     test/*.py:D104
     test/*/*.py:D100,D101,D102,D103,D104,D105,D107

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,12 +7,13 @@ enable-extensions = G
 # suppressions. For the following reasons, we still have some demaining:
 # D100 requires docstrings on public modules but there is some issue with '_' prefixes on filenames
 # D107 requires docstrings on __init__ but these are ignored in our current sphinx configuration
+# RST304 is about "unknown text roles" in sphinx. Unfortunately, things like :class: appear to be unknown
 # RST902 is from trouble parsing the __all__ entry. This only happens in a single file
 per-file-ignores = 
     setup.py:D100
     docs/*.py:D100,A001
     fairlearn/*.py:D100
-    fairlearn/*/*.py:D100,D107
+    fairlearn/*/*.py:D100,D107,RST304
     fairlearn/metrics/__init__.py: RST902
     scripts/*.py:D100,D101,D102,D103,D104,D107,D205,D400,D401,RST201,RST205,RST301
     test/*.py:D104

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,15 +2,16 @@
 max-line-length = 99
 enable-extensions = G
 
-# Some explanations for suppressions:
-# D100 requires docstrings on public modules but there is some issue with '_' prefixes
+# Suppress particular flake8 warnings
+# Ideally for the fairlearn directory (which becomes the wheel) we would have no
+# suppressions. For the following reasons, we still have the 
+# D100 requires docstrings on public modules but there is some issue with '_' prefixes on filenames
 # D107 requires docstrings on __init__ but these are ignored in our current sphinx configuration
 per-file-ignores = 
     setup.py:D100
     docs/*.py:D100,A001
     fairlearn/*.py:D100
     fairlearn/*/*.py:D100,D101,D107,RST304
-    fairlearn/metrics/__init__.py: RST902
     scripts/*.py:D100,D101,D102,D103,D104,D107,D205,D400,D401,RST201,RST205,RST301
     test/*.py:D104
     test/*/*.py:D100,D101,D102,D103,D104,D105,D107


### PR DESCRIPTION
Various updates for the documentation:
- Remove another `flake8` global suppression
- Add explanations for remaining `flake8` suppressions
- Replace the `:any:` references in the documentation with appropriate ones
- Make some file-level suppressions (which may have actually turned `flake8` off entirely on the file) specific to the appropriate lines