### PR TITLE
Update Release pipeline after KV move

### DIFF
--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -78,7 +78,7 @@ stages:
   parameters:
     poolImage: $(PoolImage)
     targetType: 'Test'
-    kvSubscription: fairlearn-pipeline-learning # This is actually the name of the service connection from the Project Settings page
+    kvSubscription: "Fairness - Automation (cecafb73-04ae-4432-9f96-d96925d28058)" # This is actually the name of the service connection from the Project Settings page
     kvVaultName: fairlearndeploy
     kvUsername: 'usernametest'
     kvPassword: 'passwordtest'

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -92,7 +92,7 @@ stages:
     poolImage: $(PoolImage)
     targetType: 'Prod'
     targetEnvironment: 'PyPI Deployment'
-    kvSubscription: fairlearn-pipeline-learning # This is actually the name of the service connection from the Project Settings page
+    kvSubscription: "Fairness - Automation (cecafb73-04ae-4432-9f96-d96925d28058)" # This is actually the name of the service connection from the Project Settings page
     kvVaultName: fairlearndeploy
     kvUsername: 'usernameprod'
     kvPassword: 'passwordprod'


### PR DESCRIPTION
The KeyVault containing the PyPI secrets has been moved to a more appropriate subscription. As a result, the Release pipeline needs to be updated with the correct service connection