### PR TITLE
Basic unit tests for EqualizedOdds and DemographicParity moments

### DIFF
--- a/test/unit/reductions/moments/__init__.py
+++ b/test/unit/reductions/moments/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.

--- a/test/unit/reductions/moments/data_generator.py
+++ b/test/unit/reductions/moments/data_generator.py
@@ -19,6 +19,33 @@ def simple_binary_threshold_data(number_a0, number_a1,
     The uniformly distributed score is set in the 'example_feature'
     of the resultant X array; the sensitive feature is included in
     this array under the label 'example_sensitive_feature'
+
+    :param number_a0: Number of samples to generate with the label a0
+    :type number_a0: int
+
+    :param number_a1: Number of samples to generate with the label a1
+    :type number_a1: int
+
+    :param a0_threshold: Threshold value for samples with label a0 to
+        get a result of '1' in the Y array
+    :type a0_threshold: float
+
+    :param a1_threshold: Threshold value for samples with label a1 to
+        get a result of '1' in the Y array
+    :type a1_threshold: float
+
+    :param a0_label: The label value for the a0 class
+    :type a0_label: int, string
+
+    :param a1_label: The label value for the a1 class
+    :type a1_label: int, string
+
+    Returns X, Y, A:
+        X is the feature array (containing the uniformly distributed feature
+        and the sensitive feature labels)
+        Y is the classification array (either 0 or 1)
+        A is the array of sensitive features (which will duplicate a column
+        in the X array)
     """
     a0s = np.full(number_a0, a0_label)
     a1s = np.full(number_a1, a1_label)

--- a/test/unit/reductions/moments/data_generator.py
+++ b/test/unit/reductions/moments/data_generator.py
@@ -8,7 +8,18 @@ import pandas as pd
 def simple_binary_threshold_data(number_a0, number_a1,
                                  a0_threshold, a1_threshold,
                                  a0_label, a1_label):
+    """Generate some simple (biased) thresholded data.
 
+    This is based on a rigged credit scoring scenario, with two
+    classes in the sensitive feature, denoted by a0 and a1. The
+    specified number of samples for each are uniformly generated in
+    the range zero to one, but the threshold for each class to get
+    a positive result in the Y array can be set differently for each.
+
+    The uniformly distributed score is set in the 'example_feature'
+    of the resultant X array; the sensitive feature is included in
+    this array under the label 'example_sensitive_feature'
+    """
     a0s = np.full(number_a0, a0_label)
     a1s = np.full(number_a1, a1_label)
 
@@ -23,6 +34,6 @@ def simple_binary_threshold_data(number_a0, number_a1,
 
     Y = np.concatenate((Y_a0, Y_a1), axis=None)
 
-    X = pd.DataFrame({"credit_score_feature": score_feature,
+    X = pd.DataFrame({"example_feature": score_feature,
                       "example_sensitive_feature": A})
     return X, Y, A

--- a/test/unit/reductions/moments/data_generator.py
+++ b/test/unit/reductions/moments/data_generator.py
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import numpy as np
+import pandas as pd
+
+
+def simple_binary_threshold_data(number_a0, number_a1,
+                                 a0_threshold, a1_threshold,
+                                 a0_label, a1_label):
+
+    a0s = np.full(number_a0, a0_label)
+    a1s = np.full(number_a1, a1_label)
+
+    a0_scores = np.linspace(0, 1, number_a0)
+    a1_scores = np.linspace(0, 1, number_a1)
+    score_feature = np.concatenate((a0_scores, a1_scores), axis=None)
+
+    A = np.concatenate((a0s, a1s), axis=None)
+
+    Y_a0 = [x > a0_threshold for x in a0_scores]
+    Y_a1 = [x > a1_threshold for x in a1_scores]
+
+    Y = np.concatenate((Y_a0, Y_a1), axis=None)
+
+    X = pd.DataFrame({"credit_score_feature": score_feature,
+                      "example_sensitive_feature": A})
+    return X, Y, A

--- a/test/unit/reductions/moments/test_moments_demographic_parity.py
+++ b/test/unit/reductions/moments/test_moments_demographic_parity.py
@@ -78,7 +78,7 @@ def test_construct_and_load():
     assert dp.pos_basis[0]['-', 'all', a1_label] == 0
 
     # Examine the neg_basis_present DF
-    assert dp.neg_basis_present[0] is True
+    assert dp.neg_basis_present[0]
 
 
 def test_project_lambda_smoke_negatives():

--- a/test/unit/reductions/moments/test_moments_demographic_parity.py
+++ b/test/unit/reductions/moments/test_moments_demographic_parity.py
@@ -78,7 +78,7 @@ def test_construct_and_load():
     assert dp.pos_basis[0]['-', 'all', a1_label] == 0
 
     # Examine the neg_basis_present DF
-    assert dp.neg_basis_present[0] == True
+    assert dp.neg_basis_present[0] is True
 
 
 def test_project_lambda_smoke_negatives():

--- a/test/unit/reductions/moments/test_moments_demographic_parity.py
+++ b/test/unit/reductions/moments/test_moments_demographic_parity.py
@@ -1,0 +1,57 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import numpy as np
+import pandas as pd
+
+from fairlearn.reductions import DemographicParity
+
+
+def simple_threshold_data(number_a0, number_a1,
+                          a0_threshold, a1_threshold,
+                          a0_label, a1_label):
+
+    a0s = np.full(number_a0, a0_label)
+    a1s = np.full(number_a1, a1_label)
+
+    a0_scores = np.linspace(0, 1, number_a0)
+    a1_scores = np.linspace(0, 1, number_a1)
+    score_feature = np.concatenate((a0_scores, a1_scores), axis=None)
+
+    A = np.concatenate((a0s, a1s), axis=None)
+
+    Y_a0 = [x > a0_threshold for x in a0_scores]
+    Y_a1 = [x > a1_threshold for x in a1_scores]
+
+    Y = np.concatenate((Y_a0, Y_a1), axis=None)
+
+    X = pd.DataFrame({"credit_score_feature": score_feature,
+                      "example_sensitive_feature": A})
+    return X, Y, A
+
+
+def test_construct_and_load():
+    dp = DemographicParity()
+
+    assert dp.short_name == "DemographicParity"
+
+    num_samples_a0 = 5
+    num_samples_a1 = 7
+
+    a0_threshold = 0.2
+    a1_threshold = 0.7
+
+    a0_label = 2
+    a1_label = 3
+
+    X, Y, A = simple_threshold_data(num_samples_a0, num_samples_a1,
+                                    a0_threshold, a1_threshold,
+                                    a0_label, a1_label)
+
+    dp.load_data(X, Y, sensitive_features=A)
+    assert dp.data_loaded
+    assert dp.n == num_samples_a0 + num_samples_a1
+    print("==========================")
+    print(dp.tags)
+    assert dp.tags['label'].equals(pd.Series(Y))
+    assert dp.tags['group_id'].equals(pd.Series(A))

--- a/test/unit/reductions/moments/test_moments_demographic_parity.py
+++ b/test/unit/reductions/moments/test_moments_demographic_parity.py
@@ -7,28 +7,7 @@ import pandas as pd
 from fairlearn.reductions import DemographicParity
 from fairlearn.reductions._moments.moment import _EVENT, _GROUP_ID, _SIGN
 
-
-def simple_threshold_data(number_a0, number_a1,
-                          a0_threshold, a1_threshold,
-                          a0_label, a1_label):
-
-    a0s = np.full(number_a0, a0_label)
-    a1s = np.full(number_a1, a1_label)
-
-    a0_scores = np.linspace(0, 1, number_a0)
-    a1_scores = np.linspace(0, 1, number_a1)
-    score_feature = np.concatenate((a0_scores, a1_scores), axis=None)
-
-    A = np.concatenate((a0s, a1s), axis=None)
-
-    Y_a0 = [x > a0_threshold for x in a0_scores]
-    Y_a1 = [x > a1_threshold for x in a1_scores]
-
-    Y = np.concatenate((Y_a0, Y_a1), axis=None)
-
-    X = pd.DataFrame({"credit_score_feature": score_feature,
-                      "example_sensitive_feature": A})
-    return X, Y, A
+from .data_generator import simple_binary_threshold_data
 
 
 def test_construct_and_load():
@@ -45,9 +24,9 @@ def test_construct_and_load():
     a0_label = 2
     a1_label = 3
 
-    X, Y, A = simple_threshold_data(num_samples_a0, num_samples_a1,
-                                    a0_threshold, a1_threshold,
-                                    a0_label, a1_label)
+    X, Y, A = simple_binary_threshold_data(num_samples_a0, num_samples_a1,
+                                           a0_threshold, a1_threshold,
+                                           a0_label, a1_label)
 
     # Load up the (rigged) data
     dp.load_data(X, Y, sensitive_features=A)
@@ -159,12 +138,12 @@ def test_signed_weights():
     a0_threshold = 0.2
     a1_threshold = 0.7
 
-    a0_label = 2
-    a1_label = 3
+    a0_label = "OneThing"
+    a1_label = "AnotherThing"
 
-    X, Y, A = simple_threshold_data(num_samples_a0, num_samples_a1,
-                                    a0_threshold, a1_threshold,
-                                    a0_label, a1_label)
+    X, Y, A = simple_binary_threshold_data(num_samples_a0, num_samples_a1,
+                                           a0_threshold, a1_threshold,
+                                           a0_label, a1_label)
 
     # Load up the (rigged) data
     dp.load_data(X, Y, sensitive_features=A)

--- a/test/unit/reductions/moments/test_moments_demographic_parity.py
+++ b/test/unit/reductions/moments/test_moments_demographic_parity.py
@@ -105,7 +105,7 @@ def test_project_lambda_smoke_negatives():
 
 def test_project_lambda_smoke_positives():
     # This is a repeat of the _negatives method but with
-    # the '+' indices arger
+    # the '+' indices larger
     dp = DemographicParity()
 
     events = ['all']

--- a/test/unit/reductions/moments/test_moments_demographic_parity.py
+++ b/test/unit/reductions/moments/test_moments_demographic_parity.py
@@ -102,14 +102,47 @@ def test_construct_and_load():
     assert dp.neg_basis_present[0] == True
 
 
-def test_project_lambda_smoke():
+def test_project_lambda_smoke_negatives():
     dp = DemographicParity()
-    df = pd.DataFrame()
 
-    df[0]['+', 'all', 'a'] = 1
-    df[0]['+', 'all', 'b'] = 2
-    df[0]['-', 'all', 'a'] = 11
-    df[0]['-', 'all', 'b'] = 19
+    events = ['all']
+    signs = ['+', '-']
+    labels = ['a', 'b']
+    midx = pd.MultiIndex.from_product(
+        [signs, events, labels],
+        names=[_SIGN, _EVENT, _GROUP_ID])
+
+    df = pd.DataFrame()
+    # Note that the '-' indices (11 and 19) are larger
+    # than the '+' indices (1 and 2)
+    df = 0 + pd.Series([1, 2, 11, 19], index=midx)
+
     ls = dp.project_lambda(df)
-    print(ls)
-    assert False
+
+    expected = pd.DataFrame()
+    expected = 0 + pd.Series([0, 0, 10, 17], index=midx)
+    assert expected.equals(ls)
+
+
+def test_project_lambda_smoke_positives():
+    # This is a repeat of the _negatives method but with
+    # the '+' indices arger
+    dp = DemographicParity()
+
+    events = ['all']
+    signs = ['+', '-']
+    labels = ['a', 'b']
+    midx = pd.MultiIndex.from_product(
+        [signs, events, labels],
+        names=[_SIGN, _EVENT, _GROUP_ID])
+
+    df = pd.DataFrame()
+    # Note that the '-' indices (11 and 19) are larger
+    # than the '+' indices (1 and 2)
+    df = 0 + pd.Series([23, 19, 5, 7], index=midx)
+
+    ls = dp.project_lambda(df)
+
+    expected = pd.DataFrame()
+    expected = 0 + pd.Series([18, 12, 0, 0], index=midx)
+    assert expected.equals(ls)

--- a/test/unit/reductions/moments/test_moments_demographic_parity.py
+++ b/test/unit/reductions/moments/test_moments_demographic_parity.py
@@ -63,12 +63,29 @@ def test_construct_and_load():
     assert len(dp.prob_event.index) == 1
     assert dp.prob_event.loc['all'] == 1
 
-    # Examine the prob_group_event DP
+    # Examine the prob_group_event DF
     # There's only an 'all' event but this records the fractions
     # of each label in the population
     assert len(dp.prob_group_event.index) == 2
     assert dp.prob_group_event.loc[('all', a0_label)] == num_samples_a0 / num_samples
     assert dp.prob_group_event.loc[('all', a1_label)] == num_samples_a1 / num_samples
 
-    print(dp.neg_basis)
-    assert len(dp.neg_basis.index)==10
+    # Examine the neg_basis DF
+    # This is obviously looking at the \lambda_{-} values in some way
+    assert len(dp.neg_basis.index) == 4
+    assert dp.neg_basis[0]['+', 'all', a0_label] == 0
+    assert dp.neg_basis[0]['+', 'all', a1_label] == 0
+    assert dp.neg_basis[0]['-', 'all', a0_label] == 1
+    assert dp.neg_basis[0]['-', 'all', a1_label] == 0
+
+    # Examine the pos_basis DF
+    # This is looking at the \lambda_{+} values and picking out the
+    # one associated with the first label
+    assert len(dp.pos_basis.index) == 4
+    assert dp.pos_basis[0]['+', 'all', a0_label] == 1
+    assert dp.pos_basis[0]['+', 'all', a1_label] == 0
+    assert dp.pos_basis[0]['-', 'all', a0_label] == 0
+    assert dp.pos_basis[0]['-', 'all', a1_label] == 0
+
+    print(dp.neg_basis_present)
+    assert False

--- a/test/unit/reductions/moments/test_moments_demographic_parity.py
+++ b/test/unit/reductions/moments/test_moments_demographic_parity.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 
 from fairlearn.reductions import DemographicParity
+from fairlearn.reductions._moments.moment import _EVENT, _GROUP_ID, _SIGN
 
 
 def simple_threshold_data(number_a0, number_a1,
@@ -58,6 +59,15 @@ def test_construct_and_load():
     assert dp.tags['group_id'].equals(pd.Series(A))
     assert dp.tags['event'].map(lambda x: x == 'all').all()
 
+    # Examine the index MultiIndex
+    events = ['all']
+    signs = ['+', '-']
+    labels = [2, 3]
+    expected_index = pd.MultiIndex.from_product(
+        [signs, events, labels],
+        names=[_SIGN, _EVENT, _GROUP_ID])
+    assert dp.index.equals(expected_index)
+
     # Examine the prob_event DF
     # There's only the 'all' event and everything belongs to it
     assert len(dp.prob_event.index) == 1
@@ -90,3 +100,16 @@ def test_construct_and_load():
 
     # Examine the neg_basis_present DF
     assert dp.neg_basis_present[0] == True
+
+
+def test_project_lambda_smoke():
+    dp = DemographicParity()
+    df = pd.DataFrame()
+
+    df[0]['+', 'all', 'a'] = 1
+    df[0]['+', 'all', 'b'] = 2
+    df[0]['-', 'all', 'a'] = 11
+    df[0]['-', 'all', 'b'] = 19
+    ls = dp.project_lambda(df)
+    print(ls)
+    assert False

--- a/test/unit/reductions/moments/test_moments_demographic_parity.py
+++ b/test/unit/reductions/moments/test_moments_demographic_parity.py
@@ -177,10 +177,15 @@ def test_signed_weights():
         names=[_SIGN, _EVENT, _GROUP_ID])
 
     lambda_vec = pd.Series([2000, 1000, 500, 100], index=midx, name=0)
+    lambda_a0 = 2000 - 500
+    lambda_a1 = 1000 - 100
 
-    print(lambda_vec)
-    print('========================')
+    sw_a0 = (lambda_a0 + lambda_a1) - lambda_a0 * (num_samples / num_samples_a0)
+    sw_a1 = (lambda_a0 + lambda_a1) - lambda_a1 * (num_samples / num_samples_a1)
+
+    w_a0 = np.full(num_samples_a0, sw_a0)
+    w_a1 = np.full(num_samples_a1, sw_a1)
+    expected = np.concatenate((w_a0, w_a1), axis=None)
 
     signed_weights = dp.signed_weights(lambda_vec)
-    print(signed_weights)
-    assert False
+    assert np.array_equal(expected, signed_weights)

--- a/test/unit/reductions/moments/test_moments_demographic_parity.py
+++ b/test/unit/reductions/moments/test_moments_demographic_parity.py
@@ -78,6 +78,7 @@ def test_construct_and_load():
     assert dp.pos_basis[0]['-', 'all', a1_label] == 0
 
     # Examine the neg_basis_present DF
+    assert len(dp.neg_basis_present) == 1
     assert dp.neg_basis_present[0]
 
 

--- a/test/unit/reductions/moments/test_moments_demographic_parity.py
+++ b/test/unit/reductions/moments/test_moments_demographic_parity.py
@@ -71,7 +71,8 @@ def test_construct_and_load():
     assert dp.prob_group_event.loc[('all', a1_label)] == num_samples_a1 / num_samples
 
     # Examine the neg_basis DF
-    # This is obviously looking at the \lambda_{-} values in some way
+    # This is obviously looking at the \lambda_{-} values and picking
+    # out the one associated with the first label
     assert len(dp.neg_basis.index) == 4
     assert dp.neg_basis[0]['+', 'all', a0_label] == 0
     assert dp.neg_basis[0]['+', 'all', a1_label] == 0
@@ -87,5 +88,5 @@ def test_construct_and_load():
     assert dp.pos_basis[0]['-', 'all', a0_label] == 0
     assert dp.pos_basis[0]['-', 'all', a1_label] == 0
 
-    print(dp.neg_basis_present)
-    assert False
+    # Examine the neg_basis_present DF
+    assert dp.neg_basis_present[0] == True

--- a/test/unit/reductions/moments/test_moments_demographic_parity.py
+++ b/test/unit/reductions/moments/test_moments_demographic_parity.py
@@ -116,8 +116,8 @@ def test_project_lambda_smoke_positives():
         names=[_SIGN, _EVENT, _GROUP_ID])
 
     df = pd.DataFrame()
-    # Note that the '-' indices (11 and 19) are larger
-    # than the '+' indices (1 and 2)
+    # Note that the '-' indices are smaller than
+    # the '+' ones
     df = 0 + pd.Series([23, 19, 5, 7], index=midx)
 
     ls = dp.project_lambda(df)

--- a/test/unit/reductions/moments/test_moments_demographic_parity.py
+++ b/test/unit/reductions/moments/test_moments_demographic_parity.py
@@ -14,6 +14,7 @@ def test_construct_and_load():
     dp = DemographicParity()
     assert dp.short_name == "DemographicParity"
 
+    # Generate some (rigged) data
     num_samples_a0 = 10
     num_samples_a1 = 30
     num_samples = num_samples_a0 + num_samples_a1

--- a/test/unit/reductions/moments/test_moments_demographic_parity.py
+++ b/test/unit/reductions/moments/test_moments_demographic_parity.py
@@ -146,3 +146,41 @@ def test_project_lambda_smoke_positives():
     expected = pd.DataFrame()
     expected = 0 + pd.Series([18, 12, 0, 0], index=midx)
     assert expected.equals(ls)
+
+
+def test_signed_weights():
+    dp = DemographicParity()
+    assert dp.short_name == "DemographicParity"
+
+    num_samples_a0 = 10
+    num_samples_a1 = 30
+    num_samples = num_samples_a0 + num_samples_a1
+
+    a0_threshold = 0.2
+    a1_threshold = 0.7
+
+    a0_label = 2
+    a1_label = 3
+
+    X, Y, A = simple_threshold_data(num_samples_a0, num_samples_a1,
+                                    a0_threshold, a1_threshold,
+                                    a0_label, a1_label)
+
+    # Load up the (rigged) data
+    dp.load_data(X, Y, sensitive_features=A)
+
+    events = ["all"]
+    signs = ["+", "-"]
+    labels = [a0_label, a1_label]
+    midx = pd.MultiIndex.from_product(
+        [signs, events, labels],
+        names=[_SIGN, _EVENT, _GROUP_ID])
+
+    lambda_vec = pd.Series([2000, 1000, 500, 100], index=midx, name=0)
+
+    print(lambda_vec)
+    print('========================')
+
+    signed_weights = dp.signed_weights(lambda_vec)
+    print(signed_weights)
+    assert False

--- a/test/unit/reductions/moments/test_moments_equalized_odds.py
+++ b/test/unit/reductions/moments/test_moments_equalized_odds.py
@@ -108,14 +108,13 @@ def test_project_lambda_smoke_negatives():
         names=[_SIGN, _EVENT, _GROUP_ID])
 
     df = pd.DataFrame()
-    # Note that the '-' indices (11 and 19) are larger
-    # than the '+' indices (1 and 2)
-    df = 0 + pd.Series([1, 2, 11, 19], index=midx)
+    # Note that the '-' labels are larger
+    df = 0 + pd.Series([1, 2, 11, 19, 1001, 1110, 1230, 1350], index=midx)
 
     ls = eqo.project_lambda(df)
 
     expected = pd.DataFrame()
-    expected = 0 + pd.Series([0, 0, 10, 17], index=midx)
+    expected = 0 + pd.Series([0, 0, 0, 0, 1000, 1108, 1219, 1331], index=midx)
     assert expected.equals(ls)
 
 
@@ -132,14 +131,13 @@ def test_project_lambda_smoke_positives():
         names=[_SIGN, _EVENT, _GROUP_ID])
 
     df = pd.DataFrame()
-    # Note that the '-' indices (11 and 19) are larger
-    # than the '+' indices (1 and 2)
-    df = 0 + pd.Series([23, 19, 5, 7], index=midx)
+    # Note that the '-' indices are now smaller
+    df = 0 + pd.Series([200, 300, 100, 600, 4, 5, 6, 7], index=midx)
 
     ls = eqo.project_lambda(df)
 
     expected = pd.DataFrame()
-    expected = 0 + pd.Series([18, 12, 0, 0], index=midx)
+    expected = 0 + pd.Series([196, 295, 94, 593, 0, 0, 0, 0], index=midx)
     assert expected.equals(ls)
 
 

--- a/test/unit/reductions/moments/test_moments_equalized_odds.py
+++ b/test/unit/reductions/moments/test_moments_equalized_odds.py
@@ -94,7 +94,7 @@ def test_construct_and_load():
     assert eqo.pos_basis[0]['-', 'label=True', a1_label] == 0
 
     # Examine the neg_basis_present DF
-    assert eqo.neg_basis_present[0] == True
+    assert eqo.neg_basis_present[0] is True
 
 
 def test_project_lambda_smoke_negatives():

--- a/test/unit/reductions/moments/test_moments_equalized_odds.py
+++ b/test/unit/reductions/moments/test_moments_equalized_odds.py
@@ -169,16 +169,33 @@ def test_signed_weights():
         [signs, events, labels],
         names=[_SIGN, _EVENT, _GROUP_ID])
 
-    lambda_vec = pd.Series([2000, 1000, 500, 100], index=midx, name=0)
-    lambda_a0 = 2000 - 500
-    lambda_a1 = 1000 - 100
+    lambda_vec = pd.Series([2000, 1000, 4000, 5000, 500, 100, 700, 900], index=midx, name=0)
 
-    sw_a0 = (lambda_a0 + lambda_a1) - lambda_a0 * (num_samples / num_samples_a0)
-    sw_a1 = (lambda_a0 + lambda_a1) - lambda_a1 * (num_samples / num_samples_a1)
+    lambda_a0_F = 2000 - 500
+    lambda_a0_T = 4000 - 700
+    num_a0_F = int(a0_threshold * num_samples_a0)
+    num_a0_T = num_samples_a0 - num_a0_F
 
-    w_a0 = np.full(num_samples_a0, sw_a0)
-    w_a1 = np.full(num_samples_a1, sw_a1)
-    expected = np.concatenate((w_a0, w_a1), axis=None)
+    lambda_a1_F = 1000 - 100
+    lambda_a1_T = 5000 - 900
+    num_a1_F = int(a1_threshold * num_samples_a1)
+    num_a1_T = num_samples_a1 - num_a1_F
+
+    sw_a0_F = (lambda_a0_F + lambda_a1_F) / (1 - sum(Y) / len(Y)) - \
+        lambda_a0_F * (num_samples / num_a0_F)
+    sw_a1_F = (lambda_a0_F + lambda_a1_F) / (1 - sum(Y) / len(Y)) - \
+        lambda_a1_F * (num_samples / num_a1_F)
+    sw_a0_T = (lambda_a0_T + lambda_a1_T) / (sum(Y) / len(Y)) - \
+        lambda_a0_T * (num_samples / num_a0_T)
+    sw_a1_T = (lambda_a0_T + lambda_a1_T) / (sum(Y) / len(Y)) - \
+        lambda_a1_T * (num_samples / num_a1_T)
+
+    w_a0_F = np.full(num_a0_F, sw_a0_F)
+    w_a0_T = np.full(num_a0_T, sw_a0_T)
+    w_a1_F = np.full(num_a1_F, sw_a1_F)
+    w_a1_T = np.full(num_a1_T, sw_a1_T)
+    expected = np.concatenate((w_a0_F, w_a0_T, w_a1_F, w_a1_T), axis=None)
 
     signed_weights = eqo.signed_weights(lambda_vec)
+    # Be bold and test for equality
     assert np.array_equal(expected, signed_weights)

--- a/test/unit/reductions/moments/test_moments_equalized_odds.py
+++ b/test/unit/reductions/moments/test_moments_equalized_odds.py
@@ -94,7 +94,9 @@ def test_construct_and_load():
     assert eqo.pos_basis[0]['-', 'label=True', a1_label] == 0
 
     # Examine the neg_basis_present DF
+    assert len(eqo.neg_basis_present) == 2
     assert eqo.neg_basis_present[0]
+    assert eqo.neg_basis_present[1]
 
 
 def test_project_lambda_smoke_negatives():

--- a/test/unit/reductions/moments/test_moments_equalized_odds.py
+++ b/test/unit/reductions/moments/test_moments_equalized_odds.py
@@ -94,7 +94,7 @@ def test_construct_and_load():
     assert eqo.pos_basis[0]['-', 'label=True', a1_label] == 0
 
     # Examine the neg_basis_present DF
-    assert eqo.neg_basis_present[0] is True
+    assert eqo.neg_basis_present[0]
 
 
 def test_project_lambda_smoke_negatives():

--- a/test/unit/reductions/moments/test_moments_equalized_odds.py
+++ b/test/unit/reductions/moments/test_moments_equalized_odds.py
@@ -100,7 +100,7 @@ def test_construct_and_load():
 def test_project_lambda_smoke_negatives():
     eqo = EqualizedOdds()
 
-    events = ['all']
+    events = ['label=False', 'label=True']
     signs = ['+', '-']
     labels = ['a', 'b']
     midx = pd.MultiIndex.from_product(
@@ -124,7 +124,7 @@ def test_project_lambda_smoke_positives():
     # the '+' indices larger
     eqo = EqualizedOdds()
 
-    events = ['all']
+    events = ['label=False', 'label=True']
     signs = ['+', '-']
     labels = ['a', 'b']
     midx = pd.MultiIndex.from_product(
@@ -145,7 +145,7 @@ def test_project_lambda_smoke_positives():
 
 def test_signed_weights():
     eqo = EqualizedOdds()
-    assert eqo.short_name == "DemographicParity"
+    assert eqo.short_name == "EqualizedOdds"
 
     num_samples_a0 = 10
     num_samples_a1 = 30
@@ -164,7 +164,7 @@ def test_signed_weights():
     # Load up the (rigged) data
     eqo.load_data(X, Y, sensitive_features=A)
 
-    events = ["all"]
+    events = ['label=False', 'label=True']
     signs = ["+", "-"]
     labels = [a0_label, a1_label]
     midx = pd.MultiIndex.from_product(

--- a/test/unit/reductions/moments/test_moments_equalized_odds.py
+++ b/test/unit/reductions/moments/test_moments_equalized_odds.py
@@ -14,6 +14,7 @@ def test_construct_and_load():
     eqo = EqualizedOdds()
     assert eqo.short_name == "EqualizedOdds"
 
+    # Generate some rigged data
     num_samples_a0 = 10
     num_samples_a1 = 30
     num_samples = num_samples_a0 + num_samples_a1

--- a/test/unit/reductions/moments/test_moments_equalized_odds.py
+++ b/test/unit/reductions/moments/test_moments_equalized_odds.py
@@ -1,0 +1,186 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import numpy as np
+import pandas as pd
+
+from fairlearn.reductions import EqualizedOdds
+from fairlearn.reductions._moments.moment import _EVENT, _GROUP_ID, _SIGN
+
+from .data_generator import simple_binary_threshold_data
+
+
+def test_construct_and_load():
+    eqo = EqualizedOdds()
+    assert eqo.short_name == "EqualizedOdds"
+
+    num_samples_a0 = 10
+    num_samples_a1 = 30
+    num_samples = num_samples_a0 + num_samples_a1
+
+    a0_threshold = 0.2
+    a1_threshold = 0.7
+
+    a0_label = "a0"
+    a1_label = "a1"
+
+    X, Y, A = simple_binary_threshold_data(num_samples_a0, num_samples_a1,
+                                           a0_threshold, a1_threshold,
+                                           a0_label, a1_label)
+
+    # Load up the (rigged) data
+    eqo.load_data(X, Y, sensitive_features=A)
+    assert eqo.data_loaded
+    assert eqo.n == num_samples_a0 + num_samples_a1
+
+    # Examine the tags DF
+    assert eqo.tags['label'].equals(pd.Series(Y))
+    assert eqo.tags['group_id'].equals(pd.Series(A))
+    expected_tags_event = ['label={0}'.format(a) for a in Y]
+    assert np.array_equal(expected_tags_event, eqo.tags['event'])
+
+    # Examine the index MultiIndex
+    events = ['label=False', 'label=True']
+    signs = ['+', '-']
+    labels = [a0_label, a1_label]
+    expected_index = pd.MultiIndex.from_product(
+        [signs, events, labels],
+        names=[_SIGN, _EVENT, _GROUP_ID])
+    assert eqo.index.equals(expected_index)
+
+    # Examine the prob_event DF
+    # There are two events - 'True' and 'False'
+    assert len(eqo.prob_event.index) == 2
+    assert eqo.prob_event.loc['label=False'] == 1 - sum(Y) / len(Y)
+    assert eqo.prob_event.loc['label=True'] == sum(Y) / len(Y)
+
+    # Examine the prob_group_event DF
+    # There's only an 'all' event but this records the fractions
+    # of each label in the population
+    assert len(eqo.prob_group_event.index) == 4
+    # Use the fact that our data are uniformly distributed in the range [0, 1]
+    # With the current values, it appears we don't need to fiddle for off-by-one cases
+    a0_below = a0_threshold * num_samples_a0
+    a0_above = num_samples_a0 - a0_below
+    assert eqo.prob_group_event.loc[('label=False', a0_label)] == a0_below / num_samples
+    assert eqo.prob_group_event.loc[('label=True', a0_label)] == a0_above / num_samples
+    a1_below = a1_threshold * num_samples_a1
+    a1_above = num_samples_a1 - a1_below
+    assert eqo.prob_group_event.loc[('label=False', a1_label)] == a1_below / num_samples
+    assert eqo.prob_group_event.loc[('label=True', a1_label)] == a1_above / num_samples
+
+    # Examine the neg_basis DF
+    assert len(eqo.neg_basis.index) == 8
+    assert eqo.neg_basis[0]['+', 'label=False', a0_label] == 0
+    assert eqo.neg_basis[0]['+', 'label=False', a1_label] == 0
+    assert eqo.neg_basis[0]['+', 'label=True', a0_label] == 0
+    assert eqo.neg_basis[0]['+', 'label=True', a1_label] == 0
+    assert eqo.neg_basis[0]['-', 'label=False', a0_label] == 1
+    assert eqo.neg_basis[0]['-', 'label=False', a1_label] == 0
+    assert eqo.neg_basis[0]['-', 'label=True', a0_label] == 0
+    assert eqo.neg_basis[0]['-', 'label=True', a1_label] == 0
+
+    # Examine the pos_basis DF
+    # This is looking at the \lambda_{+} values and picking out the
+    # one associated with the first label
+    assert len(eqo.pos_basis.index) == 8
+    assert eqo.pos_basis[0]['+', 'label=False', a0_label] == 1
+    assert eqo.pos_basis[0]['+', 'label=False', a1_label] == 0
+    assert eqo.pos_basis[0]['+', 'label=True', a0_label] == 0
+    assert eqo.pos_basis[0]['+', 'label=True', a1_label] == 0
+    assert eqo.pos_basis[0]['-', 'label=False', a0_label] == 0
+    assert eqo.pos_basis[0]['-', 'label=False', a1_label] == 0
+    assert eqo.pos_basis[0]['-', 'label=True', a0_label] == 0
+    assert eqo.pos_basis[0]['-', 'label=True', a1_label] == 0
+
+    # Examine the neg_basis_present DF
+    assert eqo.neg_basis_present[0] == True
+
+
+def test_project_lambda_smoke_negatives():
+    eqo = EqualizedOdds()
+
+    events = ['all']
+    signs = ['+', '-']
+    labels = ['a', 'b']
+    midx = pd.MultiIndex.from_product(
+        [signs, events, labels],
+        names=[_SIGN, _EVENT, _GROUP_ID])
+
+    df = pd.DataFrame()
+    # Note that the '-' indices (11 and 19) are larger
+    # than the '+' indices (1 and 2)
+    df = 0 + pd.Series([1, 2, 11, 19], index=midx)
+
+    ls = eqo.project_lambda(df)
+
+    expected = pd.DataFrame()
+    expected = 0 + pd.Series([0, 0, 10, 17], index=midx)
+    assert expected.equals(ls)
+
+
+def test_project_lambda_smoke_positives():
+    # This is a repeat of the _negatives method but with
+    # the '+' indices larger
+    eqo = EqualizedOdds()
+
+    events = ['all']
+    signs = ['+', '-']
+    labels = ['a', 'b']
+    midx = pd.MultiIndex.from_product(
+        [signs, events, labels],
+        names=[_SIGN, _EVENT, _GROUP_ID])
+
+    df = pd.DataFrame()
+    # Note that the '-' indices (11 and 19) are larger
+    # than the '+' indices (1 and 2)
+    df = 0 + pd.Series([23, 19, 5, 7], index=midx)
+
+    ls = eqo.project_lambda(df)
+
+    expected = pd.DataFrame()
+    expected = 0 + pd.Series([18, 12, 0, 0], index=midx)
+    assert expected.equals(ls)
+
+
+def test_signed_weights():
+    eqo = EqualizedOdds()
+    assert eqo.short_name == "DemographicParity"
+
+    num_samples_a0 = 10
+    num_samples_a1 = 30
+    num_samples = num_samples_a0 + num_samples_a1
+
+    a0_threshold = 0.2
+    a1_threshold = 0.7
+
+    a0_label = "OneThing"
+    a1_label = "AnotherThing"
+
+    X, Y, A = simple_binary_threshold_data(num_samples_a0, num_samples_a1,
+                                           a0_threshold, a1_threshold,
+                                           a0_label, a1_label)
+
+    # Load up the (rigged) data
+    eqo.load_data(X, Y, sensitive_features=A)
+
+    events = ["all"]
+    signs = ["+", "-"]
+    labels = [a0_label, a1_label]
+    midx = pd.MultiIndex.from_product(
+        [signs, events, labels],
+        names=[_SIGN, _EVENT, _GROUP_ID])
+
+    lambda_vec = pd.Series([2000, 1000, 500, 100], index=midx, name=0)
+    lambda_a0 = 2000 - 500
+    lambda_a1 = 1000 - 100
+
+    sw_a0 = (lambda_a0 + lambda_a1) - lambda_a0 * (num_samples / num_samples_a0)
+    sw_a1 = (lambda_a0 + lambda_a1) - lambda_a1 * (num_samples / num_samples_a1)
+
+    w_a0 = np.full(num_samples_a0, sw_a0)
+    w_a1 = np.full(num_samples_a1, sw_a1)
+    expected = np.concatenate((w_a0, w_a1), axis=None)
+
+    signed_weights = eqo.signed_weights(lambda_vec)
+    assert np.array_equal(expected, signed_weights)


### PR DESCRIPTION
Some very basic unit tests for the `EqualizedOdds` and `DemographicParity` moment classes. These are 'pinning' tests two establish the behaviour of these classes. The `gamma` method is not yet included in these tests, since that requires a trained model.