### PR TITLE
Convert Notebook tests to papermill

### DIFF
--- a/devops/all-tests-job-template.yml
+++ b/devops/all-tests-job-template.yml
@@ -44,7 +44,7 @@ jobs:
   - script: flake8 .
     displayName: "Run flake8"
 
-  - script: python -m pytest test/ --ignore=test/perf --junitxml=./TEST--TEST.xml -o junit_suite_name="$(Agent.JobName)"
+  - script: python -m pytest test/unit --junitxml=./TEST--TEST.xml -o junit_suite_name="$(Agent.JobName)"
     displayName: 'Run tests'
 
   - task: PublishTestResults@2

--- a/devops/all-tests-job-template.yml
+++ b/devops/all-tests-job-template.yml
@@ -44,7 +44,7 @@ jobs:
   - script: flake8 .
     displayName: "Run flake8"
 
-  - script: python -m pytest test/unit --junitxml=./TEST--TEST.xml -o junit_suite_name="$(Agent.JobName)"
+  - script: python -m pytest test/ --ignore=test/perf -m "not notebooks" --junitxml=./TEST--TEST.xml -o junit_suite_name="$(Agent.JobName)"
     displayName: 'Run tests'
 
   - task: PublishTestResults@2

--- a/devops/code-coverage-job-template.yml
+++ b/devops/code-coverage-job-template.yml
@@ -20,7 +20,7 @@ jobs:
   - script: pip install -r requirements.txt
     displayName: 'Install required packages'
 
-  - script: python -m pytest test/unit --junitxml=./TEST-TEST.xml --cov=fairlearn --cov-report=xml --cov-report=html -o unit_suite_name="${{ parameters.name }}"
+  - script: python -m pytest test -m "not notebooks" --ignore=test/perf --junitxml=./TEST-TEST.xml --cov=fairlearn --cov-report=xml --cov-report=html -o unit_suite_name="${{ parameters.name }}"
     displayName: 'Run tests'
 
   # Publish code coverage results

--- a/devops/notebook-job-template.yml
+++ b/devops/notebook-job-template.yml
@@ -35,7 +35,7 @@ jobs:
   - script: pip install -e .
     displayName: 'Install fairlearn in edit mode'
 
-  - script: python -m pytest notebooks/ --nbval --junitxml=./TEST-TEST.xml -o junit_suite_name="$(Agent.JobName)"
+  - script: python -m pytest test/notebooks/ --junitxml=./TEST-TEST.xml -o junit_suite_name="$(Agent.JobName)"
     displayName: 'Run notebooks as tests'
 
   - task: PublishTestResults@2

--- a/devops/notebook-job-template.yml
+++ b/devops/notebook-job-template.yml
@@ -35,7 +35,7 @@ jobs:
   - script: pip install -e .
     displayName: 'Install fairlearn in edit mode'
 
-  - script: python -m pytest test/notebooks/ --junitxml=./TEST-TEST.xml -o junit_suite_name="$(Agent.JobName)"
+  - script: python -m pytest test/ -m notebooks --ignore=test/perf --junitxml=./TEST-TEST.xml -o junit_suite_name="$(Agent.JobName)"
     displayName: 'Run notebooks as tests'
 
   - task: PublishTestResults@2

--- a/devops/notebook-pypi-job-template.yml
+++ b/devops/notebook-pypi-job-template.yml
@@ -64,7 +64,7 @@ jobs:
     displayName: "Install fairlearn with pip"
 
   # Run the notebooks under PyTest
-  - script: python -m pytest test -m notebooks --junitxml=./TEST--TEST.xml -o junit_suite_name="Notebooks $(Agent.JobName) targetType=${{parameters.targetType}} pipVersion=$(fairlearnVersionForpip)"
+  - script: python -m pytest test -m notebooks --ignore=test/perf --junitxml=./TEST--TEST.xml -o junit_suite_name="Notebooks $(Agent.JobName) targetType=${{parameters.targetType}} pipVersion=$(fairlearnVersionForpip)"
     displayName: 'Run notebooks with pytest'
 
   - task: PublishTestResults@2

--- a/devops/notebook-pypi-job-template.yml
+++ b/devops/notebook-pypi-job-template.yml
@@ -64,7 +64,7 @@ jobs:
     displayName: "Install fairlearn with pip"
 
   # Run the notebooks under PyTest
-  - script: python -m pytest notebooks/ --nbval  --junitxml=./TEST--TEST.xml -o junit_suite_name="Notebooks $(Agent.JobName) targetType=${{parameters.targetType}} pipVersion=$(fairlearnVersionForpip)"
+  - script: python -m pytest test -m notebooks --junitxml=./TEST--TEST.xml -o junit_suite_name="Notebooks $(Agent.JobName) targetType=${{parameters.targetType}} pipVersion=$(fairlearnVersionForpip)"
     displayName: 'Run notebooks with pytest'
 
   - task: PublishTestResults@2

--- a/devops/unit-tests-pypi-job-template.yml
+++ b/devops/unit-tests-pypi-job-template.yml
@@ -64,7 +64,7 @@ jobs:
     displayName: "Install fairlearn with pip"
 
   # Run the tests
-  - script: python -m pytest test/ --ignore=test/perf -m "notebooks" --junitxml=./TEST--TEST.xml -o junit_suite_name="$(Agent.JobName) targetType=${{parameters.targetType}} pipVersion=$(fairlearnVersionForpip)"
+  - script: python -m pytest test/ --ignore=test/perf -m "not notebooks" --junitxml=./TEST--TEST.xml -o junit_suite_name="$(Agent.JobName) targetType=${{parameters.targetType}} pipVersion=$(fairlearnVersionForpip)"
     displayName: 'Run tests'
 
   - task: PublishTestResults@2

--- a/devops/unit-tests-pypi-job-template.yml
+++ b/devops/unit-tests-pypi-job-template.yml
@@ -64,7 +64,7 @@ jobs:
     displayName: "Install fairlearn with pip"
 
   # Run the tests
-  - script: python -m pytest test/ --ignore=test/perf --junitxml=./TEST--TEST.xml -o junit_suite_name="$(Agent.JobName) targetType=${{parameters.targetType}} pipVersion=$(fairlearnVersionForpip)"
+  - script: python -m pytest test/ --ignore=test/perf -m "notebooks" --junitxml=./TEST--TEST.xml -o junit_suite_name="$(Agent.JobName) targetType=${{parameters.targetType}} pipVersion=$(fairlearnVersionForpip)"
     displayName: 'Run tests'
 
   - task: PublishTestResults@2

--- a/notebooks/Group Metrics.ipynb
+++ b/notebooks/Group Metrics.ipynb
@@ -15,6 +15,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import scrapbook as sb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import numpy as np\n",
     "import pandas as pd\n",
     "import sklearn.metrics as skm"
@@ -108,6 +117,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sb.glue(\"overall_recall\", group_metrics.overall)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -177,7 +195,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "sb.glue(\"recall_by_groups\", results.by_group)"
+   ]
   }
  ],
  "metadata": {
@@ -196,7 +216,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/notebooks/Group Metrics.ipynb
+++ b/notebooks/Group Metrics.ipynb
@@ -15,15 +15,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import scrapbook as sb"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "import numpy as np\n",
     "import pandas as pd\n",
     "import sklearn.metrics as skm"
@@ -117,15 +108,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sb.glue(\"overall_recall\", group_metrics.overall)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -189,18 +171,10 @@
     "print(\"Overall recall = \", results.overall)\n",
     "print(\"recall by groups = \", results.by_group)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sb.glue(\"recall_by_groups\", results.by_group)"
-   ]
   }
  ],
  "metadata": {
+  "celltoolbar": "Edit Metadata",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ papermill
 # Pin pytest due to VS Code issue
 pytest==5.0.1
 pytest-cov
-scrapbook
+nteract-scrapbook
 tempeh==0.1.11
 wheel
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ flake8-rst-docstrings
 requirements-parser
 
 # Required for test
+nbformat
 papermill
 # Pin pytest due to VS Code issue
 pytest==5.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,9 +16,11 @@ flake8-rst-docstrings
 requirements-parser
 
 # Required for test
+papermill
 # Pin pytest due to VS Code issue
 pytest==5.0.1
 pytest-cov
+scrapbook
 tempeh==0.1.11
 wheel
 

--- a/test/notebooks/__init__.py
+++ b/test/notebooks/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.

--- a/test/notebooks/test_group_metrics_nb.py
+++ b/test/notebooks/test_group_metrics_nb.py
@@ -1,0 +1,15 @@
+import papermill as pm
+import scrapbook as sb
+import pytest
+
+
+@pytest.mark.notebooks
+def test_group_metrics_notebook():
+    notebookname = "Group Metrics"
+    input_notebook = "notebooks/" + notebookname + ".ipynb"
+    output_notebook = "./test/notebooks" + notebookname + ".output.ipynb"
+
+    pm.execute_notebook(input_notebook, output_notebook)
+
+    nb = sb.read_notebook(output_notebook)
+    print(nb.scraps)  # print a dict of all scraps by name

--- a/test/notebooks/test_group_metrics_nb.py
+++ b/test/notebooks/test_group_metrics_nb.py
@@ -7,9 +7,13 @@ import pytest
 def test_group_metrics_notebook():
     notebookname = "Group Metrics"
     input_notebook = "notebooks/" + notebookname + ".ipynb"
-    output_notebook = "./test/notebooks" + notebookname + ".output.ipynb"
+    output_notebook = "./test/notebooks/" + notebookname + ".output.ipynb"
 
     pm.execute_notebook(input_notebook, output_notebook)
 
     nb = sb.read_notebook(output_notebook)
     print(nb.scraps)  # print a dict of all scraps by name
+    expected_overall_recall = 0.5
+    assert nb.scraps['overall_recall'].data == expected_overall_recall
+    expected_by_groups = {'a': 0.0, 'b': 0.5, 'c': 0.75, 'd': 0.0}
+    assert nb.scraps['recall_by_groups'].data == expected_by_groups

--- a/test/notebooks/test_notebooks.py
+++ b/test/notebooks/test_notebooks.py
@@ -119,5 +119,5 @@ def test_binary_classification_on_compas_dataset():
 def test_grid_search_with_census_data():
     nb_name = "Grid Search with Census Data"
     test_values = {}
-    test_values["len_nondominated"] = ScrapSpec("len(nondominated)", 50)
+    test_values["len_nondominated"] = ScrapSpec("len(non_dominated)", 50)
     assay_one_notebook(nb_name, test_values)

--- a/test/notebooks/test_notebooks.py
+++ b/test/notebooks/test_notebooks.py
@@ -8,61 +8,69 @@ import scrapbook as sb
 
 
 class ScrapSpec:
-    def __init__(self, key, command):
-        self.scrap_key = key
-        self.scrap_command = command
+    def __init__(self, code, expected):
+        self.code = code
+        self.expected = expected
 
     @property
-    def scrap_key(self):
-        return self._scrap_key
+    def code(self):
+        """Return the code to be inserted (string)."""
+        return self._code
 
-    @scrap_key.setter
-    def scrap_key(self, value):
-        self._scrap_key = value
+    @code.setter
+    def code(self, value):
+        self._code = value
 
     @property
-    def scrap_command(self):
-        return self._scrap_command
+    def expected(self):
+        """Return the expected evaluation of the code (Python object)."""
+        return self._expected
 
-    @scrap_command.setter
-    def scrap_command(self, value):
-        self._scrap_command = value
+    @expected.setter
+    def expected(self, value):
+        self._expected = value
 
 
 def append_scrapbook_commands(input_nb_path, output_nb_path, scrap_specs):
     notebook = nbf.read(input_nb_path, as_version=nbf.NO_CONVERT)
 
     scrapbook_cells = []
+    # Always need to import nteract-scrapbook
     scrapbook_cells.append(nbf.v4.new_code_cell(source="import scrapbook as sb"))
 
-    for s in scrap_specs:
-        source = "sb.glue(\"{0}\", {1})".format(s.scrap_key, s.scrap_command)
+    # Create a cell to store each key and value in the scrapbook
+    for k, v in scrap_specs.items():
+        source = "sb.glue(\"{0}\", {1})".format(k, v.code)
         scrapbook_cells.append(nbf.v4.new_code_cell(source=source))
 
+    # Append the cells to the notebook
     [notebook['cells'].append(c) for c in scrapbook_cells]
 
+    # Write out the new notebook
     nbf.write(notebook, output_nb_path)
+
+
+def assay_one_notebook(notebook_name, test_values):
+    input_notebook = "notebooks/" + notebook_name + ".ipynb"
+    processed_notebook = "./test/notebooks/" + notebook_name + ".processed.ipynb"
+    output_notebook = "./test/notebooks/" + notebook_name + ".output.ipynb"
+
+    append_scrapbook_commands(input_notebook, processed_notebook, test_values)
+    pm.execute_notebook(processed_notebook, output_notebook)
+    nb = sb.read_notebook(output_notebook)
+
+    for k, v in test_values.items():
+        assert nb.scraps[k].data == v.expected
 
 
 @pytest.mark.notebooks
 def test_group_metrics_notebook():
-    notebookname = "Group Metrics"
-    input_notebook = "notebooks/" + notebookname + ".ipynb"
-    processed_notebook = "./test/notebooks/" + notebookname + ".processed.ipynb"
-    output_notebook = "./test/notebooks/" + notebookname + ".output.ipynb"
+    overall_recall_key = "overall_recall"
+    by_groups_key = "recall_by_groups"
 
-    cmds = []
-    cmds.append(ScrapSpec("overall_recall", "group_metrics.overall"))
-    cmds.append(ScrapSpec("recall_by_groups", "results.by_group"))
+    test_values = {}
+    test_values[overall_recall_key] = ScrapSpec("group_metrics.overall", 0.5)
+    test_values[by_groups_key] = ScrapSpec(
+        "results.by_group", {'a': 0.0, 'b': 0.5, 'c': 0.75, 'd': 0.0})
 
-    append_scrapbook_commands(input_notebook, processed_notebook, cmds)
-
-    pm.execute_notebook(processed_notebook, output_notebook)
-
-    nb = sb.read_notebook(output_notebook)
-
-    expected_overall_recall = 0.5
-    assert nb.scraps['overall_recall'].data == expected_overall_recall
-
-    expected_by_groups = {'a': 0.0, 'b': 0.5, 'c': 0.75, 'd': 0.0}
-    assert nb.scraps['recall_by_groups'].data == expected_by_groups
+    assay_one_notebook("Group Metrics", test_values)

--- a/test/notebooks/test_notebooks.py
+++ b/test/notebooks/test_notebooks.py
@@ -127,7 +127,8 @@ def test_grid_search_with_census_data():
 def test_mitigating_disparities_in_ranking_from_binary_data():
     nb_name = "Mitigating Disparities in Ranking from Binary Data"
     test_values = {}
+    # Needs wider bound due to randomness in ExponentiatedGradient
     test_values["sel_eg_X_alt_disparity"] = ScrapSpec(
         "sel_expgrad_X_alt.loc[ 'disparity', :][0]",
-        pytest.approx(1.36446))
+        pytest.approx(0.35, abs=0.02))
     assay_one_notebook(nb_name, test_values)

--- a/test/notebooks/test_notebooks.py
+++ b/test/notebooks/test_notebooks.py
@@ -113,3 +113,11 @@ def test_binary_classification_on_compas_dataset():
     )
 
     assay_one_notebook(nb_name, test_values)
+
+
+@pytest.mark.notebooks
+def test_grid_search_with_census_data():
+    nb_name = "Grid Search with Census Data"
+    test_values = {}
+    test_values["len_nondominated"] = ScrapSpec("len(nondominated)", 50)
+    assay_one_notebook(nb_name, test_values)

--- a/test/notebooks/test_notebooks.py
+++ b/test/notebooks/test_notebooks.py
@@ -87,3 +87,16 @@ def test_group_metrics_notebook():
         "results.by_group", {'a': 0.0, 'b': 0.5, 'c': 0.75, 'd': 0.0})
 
     assay_one_notebook("Group Metrics", test_values)
+
+
+@pytest.mark.notebooks
+def test_grid_search_for_binary_classification():
+    nb_name = "Grid Search for Binary Classification"
+
+    test_values = {}
+    test_values["best_lambda_second_grid"] = ScrapSpec(
+        "lambda_best_second", pytest.approx(0.8333333333))
+    test_values["best_coeff_second0"] = ScrapSpec(
+        "second_sweep.best_result.predictor.coef_[0][0]", pytest.approx(2.53725364))
+
+    assay_one_notebook(nb_name, test_values)

--- a/test/notebooks/test_notebooks.py
+++ b/test/notebooks/test_notebooks.py
@@ -12,8 +12,9 @@ def test_group_metrics_notebook():
     pm.execute_notebook(input_notebook, output_notebook)
 
     nb = sb.read_notebook(output_notebook)
-    print(nb.scraps)  # print a dict of all scraps by name
+
     expected_overall_recall = 0.5
     assert nb.scraps['overall_recall'].data == expected_overall_recall
+
     expected_by_groups = {'a': 0.0, 'b': 0.5, 'c': 0.75, 'd': 0.0}
     assert nb.scraps['recall_by_groups'].data == expected_by_groups

--- a/test/notebooks/test_notebooks.py
+++ b/test/notebooks/test_notebooks.py
@@ -121,3 +121,13 @@ def test_grid_search_with_census_data():
     test_values = {}
     test_values["len_nondominated"] = ScrapSpec("len(non_dominated)", 13)
     assay_one_notebook(nb_name, test_values)
+
+
+@pytest.mark.notebooks
+def test_mitigating_disparities_in_ranking_from_binary_data():
+    nb_name = "Mitigating Disparities in Ranking from Binary Data"
+    test_values = {}
+    test_values["sel_eg_X_alt_disparity"] = ScrapSpec(
+        "sel_expgrad_X_alt.loc[ 'disparity', :][0]",
+        pytest.approx(1.36446))
+    assay_one_notebook(nb_name, test_values)

--- a/test/notebooks/test_notebooks.py
+++ b/test/notebooks/test_notebooks.py
@@ -119,5 +119,5 @@ def test_binary_classification_on_compas_dataset():
 def test_grid_search_with_census_data():
     nb_name = "Grid Search with Census Data"
     test_values = {}
-    test_values["len_nondominated"] = ScrapSpec("len(non_dominated)", 50)
+    test_values["len_nondominated"] = ScrapSpec("len(non_dominated)", 13)
     assay_one_notebook(nb_name, test_values)

--- a/test/notebooks/test_notebooks.py
+++ b/test/notebooks/test_notebooks.py
@@ -100,3 +100,16 @@ def test_grid_search_for_binary_classification():
         "second_sweep.best_result.predictor.coef_[0][0]", pytest.approx(2.53725364))
 
     assay_one_notebook(nb_name, test_values)
+
+
+@pytest.mark.notebooks
+def test_binary_classification_on_compas_dataset():
+    nb_name = "Binary Classification on COMPAS dataset"
+
+    test_values = {}
+    test_values["pp_eo_aa_pignore"] = ScrapSpec(
+        "postprocessed_predictor_EO._post_processed_predictor_by_sensitive_feature['African-American']._p_ignore",  # noqa: E501
+        pytest.approx(0.2320703126)
+    )
+
+    assay_one_notebook(nb_name, test_values)

--- a/test/notebooks/test_notebooks.py
+++ b/test/notebooks/test_notebooks.py
@@ -1,15 +1,33 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import nbformat as nbf
 import papermill as pm
-import scrapbook as sb
 import pytest
+import scrapbook as sb
 
 
 @pytest.mark.notebooks
 def test_group_metrics_notebook():
     notebookname = "Group Metrics"
     input_notebook = "notebooks/" + notebookname + ".ipynb"
+    processed_notebook = "./test/notebooks/" + notebookname + ".processed.ipynb"
     output_notebook = "./test/notebooks/" + notebookname + ".output.ipynb"
 
-    pm.execute_notebook(input_notebook, output_notebook)
+    notebook = nbf.read(input_notebook, as_version=nbf.NO_CONVERT)
+    # sb.glue("overall_recall", group_metrics.overall)
+    # sb.glue("recall_by_groups", results.by_group)
+    scrapbook_cells = []
+    scrapbook_cells.append(nbf.v4.new_code_cell(source="import scrapbook as sb"))
+    scrapbook_cells.append(nbf.v4.new_code_cell(
+        source="sb.glue(\"overall_recall\", group_metrics.overall)"))
+    scrapbook_cells.append(nbf.v4.new_code_cell(
+        source="sb.glue(\"recall_by_groups\", results.by_group)"))
+    [notebook['cells'].append(c) for c in scrapbook_cells]
+
+    nbf.write(notebook, processed_notebook)
+
+    pm.execute_notebook(processed_notebook, output_notebook)
 
     nb = sb.read_notebook(output_notebook)
 

--- a/test/notebooks/test_notebooks.py
+++ b/test/notebooks/test_notebooks.py
@@ -14,7 +14,7 @@ class ScrapSpec:
 
     @property
     def code(self):
-        """Return the code to be inserted (string)."""
+        """The code to be inserted (string)."""  # noqa:D401
         return self._code
 
     @code.setter
@@ -23,7 +23,7 @@ class ScrapSpec:
 
     @property
     def expected(self):
-        """Return the expected evaluation of the code (Python object)."""
+        """The expected evaluation of the code (Python object)."""  # noqa:D401
         return self._expected
 
     @expected.setter
@@ -51,6 +51,19 @@ def append_scrapbook_commands(input_nb_path, output_nb_path, scrap_specs):
 
 
 def assay_one_notebook(notebook_name, test_values):
+    """Test a single notebook.
+
+    This uses nbformat to append `nteract-scrapbook` commands to the
+    specified notebook. The content of the commands and their expected
+    values are stored in the `test_values` dictionary. The keys of this
+    dictionary are strings to be used as scrapbook keys. They corresponding
+    value is a `ScrapSpec` tuple. The `code` member of this tuple is
+    the code (as a string) to be run to generate the scrapbook value. The
+    `expected` member is a Python object which is checked for equality with
+    the scrapbook value
+
+    Makes certain assumptions about directory layout.
+    """
     input_notebook = "notebooks/" + notebook_name + ".ipynb"
     processed_notebook = "./test/notebooks/" + notebook_name + ".processed.ipynb"
     output_notebook = "./test/notebooks/" + notebook_name + ".output.ipynb"

--- a/test/notebooks/test_notebooks.py
+++ b/test/notebooks/test_notebooks.py
@@ -130,5 +130,5 @@ def test_mitigating_disparities_in_ranking_from_binary_data():
     # Needs wider bound due to randomness in ExponentiatedGradient
     test_values["sel_eg_X_alt_disparity"] = ScrapSpec(
         "sel_expgrad_X_alt.loc[ 'disparity', :][0]",
-        pytest.approx(0.35, abs=0.02))
+        pytest.approx(0.35, abs=0.04))
     assay_one_notebook(nb_name, test_values)

--- a/test/perf/test_performance.py
+++ b/test/perf/test_performance.py
@@ -31,6 +31,7 @@ if not os.getcwd().endswith("fairlearn"):
 
 @pytest.mark.parametrize("perf_test_configuration", all_perf_test_configurations,
                          ids=all_perf_test_configurations_descriptions)
+@pytest.mark.perf
 def test_perf(perf_test_configuration, workspace, request, wheel_file):
     print("Starting with test case {}".format(request.node.name))
 

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers = 
+    notebooks: marks tests for notebooks (deselect with '-m' "not notebooks")

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers = 
     notebooks: marks tests for notebooks (deselect with '-m' "not notebooks")
+    perf: marks tests for performance


### PR DESCRIPTION
Rather than using `nbval`, convert our notebook tests to use `papermill`. With the help of `nteract-scrapbook` we can then examine the contents of particular variables from the notebooks to ensure that we're getting the expected results.

Explicit `scrapbook` commands are required to save out values for future examination, but we don't want to include these when our users look at the notebooks. Accordingly, we include machinery for adding the necessary cells to the notebooks dynamically.