### PR TITLE
Exclude install tests in code coverage check

### DIFF
--- a/devops/templates/code-coverage-job-template.yml
+++ b/devops/templates/code-coverage-job-template.yml
@@ -20,7 +20,7 @@ jobs:
   - script: pip install -r requirements.txt
     displayName: 'Install required packages'
 
-  - script: python -m pytest test -m "not notebooks" --ignore=test/perf --junitxml=./TEST-TEST.xml --cov=fairlearn --cov-report=xml --cov-report=html -o unit_suite_name="${{ parameters.name }}"
+  - script: python -m pytest test -m "not notebooks" --ignore=test/perf --ignore=test/install --junitxml=./TEST-TEST.xml --cov=fairlearn --cov-report=xml --cov-report=html -o unit_suite_name="${{ parameters.name }}"
     displayName: 'Run tests'
 
   # Publish code coverage results

--- a/devops/templates/python-infra-upgrade-steps-template.yml
+++ b/devops/templates/python-infra-upgrade-steps-template.yml
@@ -1,7 +1,7 @@
 # template to get pip and setuptools to the latest version
 
 steps:
-  - script: pip install --upgrade pip
+  - script: python -m pip install --upgrade pip
     displayName: 'Upgrade pip to latest version'
 
   - script: pip install --upgrade setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ papermill
 pytest==5.0.1
 pytest-cov
 nteract-scrapbook
-tempeh==0.1.11
+tempeh==0.1.12
 wheel
 
 # Required for notebooks


### PR DESCRIPTION
They'll unexpectedly succeed otherwise and that will cause the check to fail.

Signed-off-by: Roman Lutz <rolutz@microsoft.com>