### PR TITLE
MNT use sklearn's NotFittedError instead of NotFittedException

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+### v0.4.2
+
+* If methods such as `predict` are called before `fit`, `sklearn`'s
+  `NotFittedError` is raised instead of `NotFittedException`, and the latter
+  is now removed.
+
 ### v0.4.2, 2020-01-24
 * Separated out matplotlib dependency into an extension that can be installed via `pip install fairlearn[customplots]`.
 * Added a `GroupMetricSet` class to hold collections of `GroupMetricResult` objects

--- a/fairlearn/exceptions.py
+++ b/fairlearn/exceptions.py
@@ -1,8 +1,0 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License.
-
-"""Module holding specialised exceptions for fairlearn."""
-
-
-class NotFittedException(ValueError):
-    """Exception to use if :code:`predict()` is called before :code:`fit()`."""

--- a/fairlearn/postprocessing/_threshold_optimizer.py
+++ b/fairlearn/postprocessing/_threshold_optimizer.py
@@ -14,7 +14,7 @@ import numpy as np
 import pandas as pd
 import random
 
-from fairlearn.exceptions import NotFittedException
+from sklearn.exceptions import NotFittedError
 from fairlearn.postprocessing import PostProcessing
 from ._constants import (LABEL_KEY, SCORE_KEY, SENSITIVE_FEATURE_KEY, OUTPUT_SEPARATOR,
                          DEMOGRAPHIC_PARITY, EQUALIZED_ODDS)
@@ -175,7 +175,7 @@ class ThresholdOptimizer(PostProcessing):
 
     def _validate_post_processed_predictor_is_fitted(self):
         if not self._post_processed_predictor_by_sensitive_feature:
-            raise NotFittedException(PREDICT_BEFORE_FIT_ERROR_MESSAGE)
+            raise NotFittedError(PREDICT_BEFORE_FIT_ERROR_MESSAGE)
 
     def _validate_input_data(self, X, sensitive_features, y=None):
         allowed_input_types = [list, np.ndarray, pd.DataFrame, pd.Series]

--- a/fairlearn/reductions/_grid_search/grid_search.py
+++ b/fairlearn/reductions/_grid_search/grid_search.py
@@ -9,7 +9,7 @@ from time import time
 
 from fairlearn._input_validation import _validate_and_reformat_reductions_input
 from fairlearn import _NO_PREDICT_BEFORE_FIT
-from fairlearn.exceptions import NotFittedException
+from sklearn.exceptions import NotFittedError
 from fairlearn.reductions import Reduction
 from fairlearn.reductions._moments import Moment, ClassificationMoment
 from .grid_search_result import GridSearchResult
@@ -270,7 +270,7 @@ class GridSearch(Reduction):
         :type X: numpy.ndarray or pandas.DataFrame
         """
         if self.best_result is None:
-            raise NotFittedException(_NO_PREDICT_BEFORE_FIT)
+            raise NotFittedError(_NO_PREDICT_BEFORE_FIT)
         return self.best_result.predictor.predict(X)
 
     def predict_proba(self, X):
@@ -283,5 +283,5 @@ class GridSearch(Reduction):
         :type X: numpy.ndarray or pandas.DataFrame
         """
         if self.best_result is None:
-            raise NotFittedException(_NO_PREDICT_BEFORE_FIT)
+            raise NotFittedError(_NO_PREDICT_BEFORE_FIT)
         return self.best_result.predictor.predict_proba(X)

--- a/test/unit/reductions/grid_search/test_grid_search_arguments.py
+++ b/test/unit/reductions/grid_search/test_grid_search_arguments.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 from sklearn.linear_model import LogisticRegression, LinearRegression
 
-from fairlearn.exceptions import NotFittedException
+from sklearn.exceptions import NotFittedError
 from fairlearn.reductions import GridSearch
 from fairlearn.reductions import DemographicParity, EqualizedOdds
 from fairlearn.reductions import GroupLossMoment, ZeroOneLoss
@@ -202,7 +202,7 @@ class ArgumentTests:
         X, _, _ = self._quick_data()
 
         message = str("Must call fit before attempting to make predictions")
-        with pytest.raises(NotFittedException) as execInfo:
+        with pytest.raises(NotFittedError) as execInfo:
             gs.predict(X)
 
         assert message == execInfo.value.args[0]
@@ -212,7 +212,7 @@ class ArgumentTests:
         X, _, _ = self._quick_data()
 
         message = str("Must call fit before attempting to make predictions")
-        with pytest.raises(NotFittedException) as execInfo:
+        with pytest.raises(NotFittedError) as execInfo:
             gs.predict_proba(X)
 
         assert message == execInfo.value.args[0]


### PR DESCRIPTION
Fixes #253.

This PR replaces `NotFittedException` with `sklearn.exceptions.NotFittedError`, and removes the `exceptions.py` file, since that exception was the only on present in it.