### PR TITLE
Fix build wheels script

### DIFF
--- a/scripts/build_wheels.py
+++ b/scripts/build_wheels.py
@@ -39,18 +39,18 @@ def main(argv):
     parser = build_argument_parser()
     args = parser.parse_args(argv)
 
-    if "FAIRLEARN_DEV_VERSION" in os.environ:
+    if _fairlearn_dev_version_env_var_name in os.environ:
         raise Exception("Environment variable {} must not be set"
                         .format(_fairlearn_dev_version_env_var_name))
+
+    if args.target_type == "Test":
+        os.environ[_fairlearn_dev_version_env_var_name] = args.dev_version
 
     with _LogWrapper("installation of fairlearn"):
         subprocess.check_call(["pip", "install", "-e", ".[customplots]"])
 
     with _LogWrapper("processing README.md"):
         process_readme("README.md", "README.md")
-
-    if args.target_type == "Test":
-        os.environ[_fairlearn_dev_version_env_var_name] = args.dev_version
 
     with _LogWrapper("storing fairlearn version in {}".format(args.version_filename)):
         import fairlearn


### PR DESCRIPTION
Env var needs to be set before installing fairlearn to make the written version of the package correct. Currently it doesn't include "dev<number>" if it's the test configuration.

Signed-off-by: Roman Lutz <rolutz@microsoft.com>