### PR TITLE
Updates for GroupMetricResult and GroupMetricSet

### DIFF
--- a/fairlearn/metrics/_group_metric_result.py
+++ b/fairlearn/metrics/_group_metric_result.py
@@ -125,3 +125,23 @@ class GroupMetricResult:
     @range_ratio.setter
     def range_ratio(self, value):
         self._range_ratio = value
+
+    def __eq__(self, other):
+        result = NotImplemented
+        if isinstance(other, GroupMetricResult):
+            result = self.overall == other.overall
+            result = result and self.by_group == other.by_group
+            result = result and self.maximum == other.maximum
+            result = result and self.minimum == other.minimum
+            result = result and self.argmax_set == other.argmax_set
+            result = result and self.argmin_set == other.argmin_set
+            result = result and self.range == other.range
+            result = result and self.range_ratio == other.range_ratio
+        return result
+
+    def __ne__(self, other):
+        are_equal = self.__eq__(other)
+        if are_equal is NotImplemented:
+            return are_equal
+        else:
+            return not are_equal

--- a/fairlearn/metrics/_group_metric_result.py
+++ b/fairlearn/metrics/_group_metric_result.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+import numpy as np
+
 
 class GroupMetricResult:
     """Class to hold the result of a grouped metric.
@@ -127,16 +129,27 @@ class GroupMetricResult:
         self._range_ratio = value
 
     def __eq__(self, other):
+        """Compare two `GroupMetricResult` objects for equality."""
         result = NotImplemented
         if isinstance(other, GroupMetricResult):
-            result = self.overall == other.overall
-            result = result and self.by_group == other.by_group
-            result = result and self.maximum == other.maximum
-            result = result and self.minimum == other.minimum
-            result = result and self.argmax_set == other.argmax_set
-            result = result and self.argmin_set == other.argmin_set
-            result = result and self.range == other.range
-            result = result and self.range_ratio == other.range_ratio
+            if isinstance(self.overall, np.ndarray) and isinstance(other.overall, np.ndarray):
+                result = np.array_equal(self.overall, other.overall)
+                result = result and self.by_group.keys() == other.by_group.keys()
+                for k in self.by_group.keys():
+                    result = result and np.array_equal(self.by_group[k], other.by_group[k])
+            elif isinstance(self.overall, np.ndarray) or isinstance(other.overall, np.ndarray):
+                # Note that the previous 'and' test means that only one
+                # side of this 'or' can be true
+                result = False
+            else:
+                result = self.overall == other.overall
+                result = result and self.by_group == other.by_group
+                result = result and self.maximum == other.maximum
+                result = result and self.minimum == other.minimum
+                result = result and self.argmax_set == other.argmax_set
+                result = result and self.argmin_set == other.argmin_set
+                result = result and self.range == other.range
+                result = result and self.range_ratio == other.range_ratio
         return result
 
     def __ne__(self, other):

--- a/fairlearn/metrics/_group_metric_result.py
+++ b/fairlearn/metrics/_group_metric_result.py
@@ -153,6 +153,7 @@ class GroupMetricResult:
         return result
 
     def __ne__(self, other):
+        """Compare two `GroupMetricResult` objects for inequality."""
         are_equal = self.__eq__(other)
         if are_equal is NotImplemented:
             return are_equal

--- a/fairlearn/metrics/_group_metric_set.py
+++ b/fairlearn/metrics/_group_metric_set.py
@@ -182,3 +182,23 @@ class GroupMetricSet:
                 self.y_true, self.y_pred, self.groups)
 
         self.metrics = computed_metrics
+
+    def __eq__(self, other):
+        """Compare two `GroupMetricSet` objects for equality."""
+        result = NotImplemented
+        if isinstance(other, GroupMetricSet):
+            result = self.model_type == other.model_type
+            result = result and np.array_equal(self.y_true, other.y_true)
+            result = result and np.array_equal(self.y_pred, other.y_pred)
+            result = result and np.array_equal(self.groups, other.groups)
+            result = result and np.array_equal(self.group_names, other.group_names)
+            result = result and self.metrics == other.metrics
+        return result
+
+    def __ne__(self, other):
+        """Compare two `GroupMetricSet` objects for inequality."""
+        are_equal = self.__eq__(other)
+        if are_equal is NotImplemented:
+            return are_equal
+        else:
+            return not are_equal

--- a/fairlearn/metrics/_group_metric_set.py
+++ b/fairlearn/metrics/_group_metric_set.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+import numpy as np
+
 from . import group_accuracy_score, group_balanced_root_mean_squared_error
 from . import group_fallout_rate, group_max_error
 from . import group_mean_absolute_error, group_mean_overprediction
@@ -156,14 +158,15 @@ class GroupMetricSet:
             raise ValueError(_METRICS_VALUES_MSG)
         self._metrics = value
 
-    def compute(self, y_true, y_pred, groups, model_type=BINARY_CLASSIFICATION, group_names=None):
+    def compute(self, y_true, y_pred, groups, model_type=BINARY_CLASSIFICATION):
         """Compute the default metrics."""
         self.y_true = y_true
         self.y_pred = y_pred
-        self.groups = groups
         self.model_type = model_type
-        if group_names is not None:
-            self.group_names = group_names
+
+        unique_groups = sorted(list(np.unique(groups)))
+        self.group_names = [str(x) for x in unique_groups]
+        self.groups = [unique_groups.index(x) for x in groups]
 
         function_dict = None
         if self.model_type == GroupMetricSet.BINARY_CLASSIFICATION:

--- a/fairlearn/metrics/_group_metric_set.py
+++ b/fairlearn/metrics/_group_metric_set.py
@@ -86,7 +86,7 @@ class GroupMetricSet:
         self._y_pred = None
         self._groups = None
         self._group_names = None
-        self._group_title = None
+        self._group_title = 'Group Title Not Set'
         self._metrics = None
 
     @property

--- a/fairlearn/metrics/_group_metric_set.py
+++ b/fairlearn/metrics/_group_metric_set.py
@@ -86,6 +86,7 @@ class GroupMetricSet:
         self._y_pred = None
         self._groups = None
         self._group_names = None
+        self._group_title = None
         self._metrics = None
 
     @property
@@ -151,6 +152,15 @@ class GroupMetricSet:
         self._group_names = value
 
     @property
+    def group_title(self):
+        """Return the title for the groups."""
+        return self._group_title
+
+    @group_title.setter
+    def group_title(self, value):
+        self._group_title = str(value)
+
+    @property
     def metrics(self):
         """Return the GUID-GroupMetricResult dictionary of group metrics."""
         return self._metrics
@@ -200,6 +210,7 @@ class GroupMetricSet:
         result = NotImplemented
         if isinstance(other, GroupMetricSet):
             result = self.model_type == other.model_type
+            result = result and self.group_title == other.group_title
             result = result and np.array_equal(self.y_true, other.y_true)
             result = result and np.array_equal(self.y_pred, other.y_pred)
             result = result and np.array_equal(self.groups, other.groups)

--- a/fairlearn/metrics/_group_metric_set.py
+++ b/fairlearn/metrics/_group_metric_set.py
@@ -17,6 +17,7 @@ from . import GroupMetricResult
 
 from fairlearn.metrics._input_manipulations import _convert_to_ndarray_1d
 
+_GROUPS_NOT_SEQUENTIAL_INTEGERS = "The unique values of the groups property must be sequential integers from zero"  # noqa: E501
 _GROUP_NAMES_MSG = "The group_names property must be a list of strings"
 _METRICS_KEYS_MSG = "Keys for metrics dictionary must be strings"
 _METRICS_VALUES_MSG = "Values for metrics dictionary must be of type GroupMetricResult"
@@ -121,11 +122,17 @@ class GroupMetricSet:
 
     @property
     def groups(self):
-        """Return the array of group values."""
+        """Return the array of group values.
+
+        The unique values will always be sequential integers from zero.
+        """
         return self._groups
 
     @groups.setter
     def groups(self, value):
+        unique_values = np.unique(value)
+        if not np.array_equal(unique_values, np.array(range(len(unique_values)))):
+            raise ValueError(_GROUPS_NOT_SEQUENTIAL_INTEGERS)
         self._groups = _convert_to_ndarray_1d(value)
 
     @property
@@ -159,7 +166,12 @@ class GroupMetricSet:
         self._metrics = value
 
     def compute(self, y_true, y_pred, groups, model_type=BINARY_CLASSIFICATION):
-        """Compute the default metrics."""
+        """Compute the default metrics.
+
+        This will also automatically provide a remapping of the groups so that
+        the unique values of the stored `groups` property will be sequential
+        integers from zero.
+        """
         self.y_true = y_true
         self.y_pred = y_pred
         self.model_type = model_type

--- a/fairlearn/metrics/_group_metric_set.py
+++ b/fairlearn/metrics/_group_metric_set.py
@@ -15,8 +15,7 @@ from . import GroupMetricResult
 
 from fairlearn.metrics._input_manipulations import _convert_to_ndarray_1d
 
-_GROUP_NAMES_KEYS_MSG = "Keys for group_names dictionary must be integers"
-_GROUP_NAMES_VALUES_MSG = "Values for group_names dictionary must be strings"
+_GROUP_NAMES_MSG = "The group_names property must be a list of strings"
 _METRICS_KEYS_MSG = "Keys for metrics dictionary must be strings"
 _METRICS_VALUES_MSG = "Values for metrics dictionary must be of type GroupMetricResult"
 
@@ -129,17 +128,16 @@ class GroupMetricSet:
 
     @property
     def group_names(self):
-        """Return the group_names dictionary."""
+        """Return the group_names list."""
         return self._group_names
 
     @group_names.setter
     def group_names(self, value):
-        key_types = set(type(k) for k in value.keys())
-        if key_types != {int}:
-            raise ValueError(_GROUP_NAMES_KEYS_MSG)
-        value_types = set(type(v) for v in value.values())
+        if not type(value) is list:
+            raise ValueError(_GROUP_NAMES_MSG)
+        value_types = set(type(v) for v in value)
         if value_types != {str}:
-            raise ValueError(_GROUP_NAMES_VALUES_MSG)
+            raise ValueError(_GROUP_NAMES_MSG)
 
         self._group_names = value
 

--- a/test/unit/metrics/test_group_metric_result_comparison.py
+++ b/test/unit/metrics/test_group_metric_result_comparison.py
@@ -15,7 +15,9 @@ def test_simple_equality():
     b = group_accuracy_score(Y_true, Y_pred, groups)
 
     assert a == b
+    assert b == a
     assert not(a != b)
+    assert not(b != a)
 
 
 def test_simple_inequality():
@@ -23,11 +25,36 @@ def test_simple_inequality():
     b = group_accuracy_score(Y_true, Y_pred, gr_inv)
 
     assert not(a == b)
+    assert not(b == a)
     assert a != b
+    assert b != a
+
 
 def test_complex_equality():
     a = group_confusion_matrix(Y_true, Y_pred, groups)
     b = group_confusion_matrix(Y_true, Y_pred, groups)
 
     assert a == b
+    assert b == a
     assert not(a != b)
+    assert not(b != a)
+
+
+def test_complex_inequality():
+    a = group_confusion_matrix(Y_true, Y_pred, groups)
+    b = group_confusion_matrix(Y_true, Y_pred, gr_inv)
+
+    assert not(a == b)
+    assert not(b == a)
+    assert a != b
+    assert b != a
+
+
+def test_mixed_types():
+    a = group_accuracy_score(Y_true, Y_pred, groups)
+    b = group_confusion_matrix(Y_true, Y_pred, groups)
+
+    assert not(a == b)
+    assert not(b == a)
+    assert a != b
+    assert b != a

--- a/test/unit/metrics/test_group_metric_result_comparison.py
+++ b/test/unit/metrics/test_group_metric_result_comparison.py
@@ -1,0 +1,33 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from fairlearn.metrics import group_accuracy_score
+from fairlearn.metrics import group_confusion_matrix
+
+Y_true = [0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1]
+Y_pred = [1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1]
+groups = [0, 1, 1, 1, 1, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1]
+gr_inv = [1-g for g in groups]
+
+
+def test_simple_equality():
+    a = group_accuracy_score(Y_true, Y_pred, groups)
+    b = group_accuracy_score(Y_true, Y_pred, groups)
+
+    assert a == b
+    assert not(a != b)
+
+
+def test_simple_inequality():
+    a = group_accuracy_score(Y_true, Y_pred, groups)
+    b = group_accuracy_score(Y_true, Y_pred, gr_inv)
+
+    assert not(a == b)
+    assert a != b
+
+def test_complex_equality():
+    a = group_confusion_matrix(Y_true, Y_pred, groups)
+    b = group_confusion_matrix(Y_true, Y_pred, groups)
+
+    assert a == b
+    assert not(a != b)

--- a/test/unit/metrics/test_group_metric_set.py
+++ b/test/unit/metrics/test_group_metric_set.py
@@ -155,7 +155,7 @@ def test_groups_alphabetical():
     target = GroupMetricSet()
     regular = GroupMetricSet()
 
-    # Make 'target' the same as 'regular' but with different integers for the groups
+    # Make 'target' the same as 'regular' but with strings for the groups
     target.compute(Y_true, Y_pred, gr_alp, model_type=GroupMetricSet.BINARY_CLASSIFICATION)
     regular.compute(Y_true, Y_pred, groups, model_type=GroupMetricSet.BINARY_CLASSIFICATION)
 

--- a/test/unit/metrics/test_group_metric_set.py
+++ b/test/unit/metrics/test_group_metric_set.py
@@ -48,24 +48,24 @@ def test_groups():
 
 def test_group_names():
     target = GroupMetricSet()
-    target.group_names = {0: 'a', 1: 'b'}
+    target.group_names = ['a', 'b']
     assert target.group_names[0] == 'a'
     assert target.group_names[1] == 'b'
 
 
-def test_group_names_keys_not_int():
+def test_group_names_not_list():
     target = GroupMetricSet()
     with pytest.raises(ValueError) as exception_context:
         target.group_names = {'a': 'b', 'c': 'd'}
-    expected = "Keys for group_names dictionary must be integers"
+    expected = "The group_names property must be a list of strings"
     assert exception_context.value.args[0] == expected
 
 
 def test_group_names_values_not_string():
     target = GroupMetricSet()
     with pytest.raises(ValueError) as exception_context:
-        target.group_names = {0: 1, 2: 3}
-    expected = "Values for group_names dictionary must be strings"
+        target.group_names = [0, 1, 2, 'a']
+    expected = "The group_names property must be a list of strings"
     assert exception_context.value.args[0] == expected
 
 
@@ -98,6 +98,8 @@ def test_metrics_values_not_groupmetricresult():
 Y_true = [0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1]
 Y_pred = [1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1]
 groups = [0, 1, 0, 1, 0, 1, 0, 1, 1, 1, 0, 1, 0, 0, 0, 1, 0, 0]
+gr_in2 = [2*(x+1) for x in groups]
+gr_alp = ['a' if x == 0 else 'b' for x in groups]
 
 
 def test_compute_binary():
@@ -110,6 +112,7 @@ def test_compute_binary():
     assert np.array_equal(Y_true, target.y_true)
     assert np.array_equal(Y_pred, target.y_pred)
     assert np.array_equal(groups, target.groups)
+    assert np.array_equal(['0', '1'], target.group_names)
     assert len(target.metrics) == 10
     assert target.metrics[GroupMetricSet.GROUP_ACCURACY_SCORE].overall == sample_expected.overall
     for g in np.unique(groups):
@@ -127,8 +130,45 @@ def test_compute_regression():
     assert np.array_equal(Y_true, target.y_true)
     assert np.array_equal(Y_pred, target.y_pred)
     assert np.array_equal(groups, target.groups)
+    assert np.array_equal(['0', '1'], target.group_names)
     assert len(target.metrics) == 12
     assert target.metrics[GroupMetricSet.GROUP_BALANCED_ROOT_MEAN_SQUARED_ERROR].overall == sample_expected.overall  # noqa: E501
     for g in np.unique(groups):
         assert (target.metrics[GroupMetricSet.GROUP_BALANCED_ROOT_MEAN_SQUARED_ERROR].by_group[g]
                 == sample_expected.by_group[g])
+
+
+def test_groups_not_sequential_int():
+    target = GroupMetricSet()
+    regular = GroupMetricSet()
+
+    # Make 'target' the same as 'regular' but with different integers for the groups
+    target.compute(Y_true, Y_pred, gr_in2, model_type=GroupMetricSet.BINARY_CLASSIFICATION)
+    regular.compute(Y_true, Y_pred, groups, model_type=GroupMetricSet.BINARY_CLASSIFICATION)
+
+    assert np.array_equal(['2', '4'], target.group_names)
+
+    tm = target.metrics[GroupMetricSet.GROUP_ACCURACY_SCORE]
+    rm = target.metrics[GroupMetricSet.GROUP_ACCURACY_SCORE]
+
+    assert tm.overall == rm.overall
+    assert tm.by_group == rm.by_group
+    assert tm == rm
+
+
+def test_groups_alphabetical():
+    target = GroupMetricSet()
+    regular = GroupMetricSet()
+
+    # Make 'target' the same as 'regular' but with different integers for the groups
+    target.compute(Y_true, Y_pred, gr_alp, model_type=GroupMetricSet.BINARY_CLASSIFICATION)
+    regular.compute(Y_true, Y_pred, groups, model_type=GroupMetricSet.BINARY_CLASSIFICATION)
+
+    assert np.array_equal(['a', 'b'], target.group_names)
+
+    tm = target.metrics[GroupMetricSet.GROUP_ACCURACY_SCORE]
+    rm = target.metrics[GroupMetricSet.GROUP_ACCURACY_SCORE]
+
+    assert tm.overall == rm.overall
+    assert tm.by_group == rm.by_group
+    assert tm == rm

--- a/test/unit/metrics/test_group_metric_set.py
+++ b/test/unit/metrics/test_group_metric_set.py
@@ -167,5 +167,27 @@ def test_groups_alphabetical():
     assert tm.overall == rm.overall
     assert tm.by_group == rm.by_group
     assert tm == rm
-    
+
     assert target.metrics == regular.metrics
+
+
+def test_equality():
+    a = GroupMetricSet()
+    b = GroupMetricSet()
+
+    a.compute(Y_true, Y_pred, gr_alp, model_type=GroupMetricSet.BINARY_CLASSIFICATION)
+    b.compute(Y_true, Y_pred, gr_alp, model_type=GroupMetricSet.BINARY_CLASSIFICATION)
+
+    assert a == b
+    assert not(a != b)
+
+
+def test_inequality():
+    a = GroupMetricSet()
+    b = GroupMetricSet()
+
+    a.compute(Y_true, Y_pred, groups, model_type=GroupMetricSet.BINARY_CLASSIFICATION)
+    b.compute(Y_true, Y_pred, gr_alp, model_type=GroupMetricSet.BINARY_CLASSIFICATION)
+
+    assert not(a == b)
+    assert a != b

--- a/test/unit/metrics/test_group_metric_set.py
+++ b/test/unit/metrics/test_group_metric_set.py
@@ -148,12 +148,7 @@ def test_groups_not_sequential_int():
 
     assert np.array_equal(['2', '4'], target.group_names)
 
-    tm = target.metrics[GroupMetricSet.GROUP_ACCURACY_SCORE]
-    rm = target.metrics[GroupMetricSet.GROUP_ACCURACY_SCORE]
-
-    assert tm.overall == rm.overall
-    assert tm.by_group == rm.by_group
-    assert tm == rm
+    assert target.metrics == regular.metrics
 
 
 def test_groups_alphabetical():
@@ -172,3 +167,5 @@ def test_groups_alphabetical():
     assert tm.overall == rm.overall
     assert tm.by_group == rm.by_group
     assert tm == rm
+    
+    assert target.metrics == regular.metrics

--- a/test/unit/metrics/test_group_metric_set.py
+++ b/test/unit/metrics/test_group_metric_set.py
@@ -41,9 +41,33 @@ def test_y_pred():
 
 def test_groups():
     target = GroupMetricSet()
-    target.groups = [4, 5, 6]
+    target.groups = [0, 1, 2]
     assert isinstance(target.groups, np.ndarray)
-    assert np.array_equal(target.groups, [4, 5, 6])
+    assert np.array_equal(target.groups, [0, 1, 2])
+
+
+def test_groups_not_from_zero():
+    target = GroupMetricSet()
+    with pytest.raises(ValueError) as exception_context:
+        target.groups = [4, 5, 6]
+    msg = "The unique values of the groups property must be sequential integers from zero"
+    assert exception_context.value.args[0] == msg
+
+
+def test_groups_not_sequential():
+    target = GroupMetricSet()
+    with pytest.raises(ValueError) as exception_context:
+        target.groups = [0, 2, 4]
+    msg = "The unique values of the groups property must be sequential integers from zero"
+    assert exception_context.value.args[0] == msg
+
+
+def test_groups_strings():
+    target = GroupMetricSet()
+    with pytest.raises(ValueError) as exception_context:
+        target.groups = ['0', '1', '2']
+    msg = "The unique values of the groups property must be sequential integers from zero"
+    assert exception_context.value.args[0] == msg
 
 
 def test_group_names():


### PR DESCRIPTION
Add (in)equality operators to `GroupMetricResult` and `GroupMetricSet`, along with basic tests. These will simplify other testing in future.

Change `GroupMetricSet` so that the `groups` have to be specified as sequential integers from zero. If this is not the case then the `compute()` method will remap the supplied groups to `[0, 1, 2, ….]` and put the stringified original values into the `group_names` property. Since the keys are now sequential integers, convert the `group_names` property itself from a dictionary into a list.

Closes #275 