### PR TITLE
Report: Fix copy bug on overprediction explanation in binary classifier

### DIFF
--- a/visualization/FairnessDashboard/src/WizardReport.tsx
+++ b/visualization/FairnessDashboard/src/WizardReport.tsx
@@ -119,7 +119,8 @@ export class WizardReport extends React.PureComponent<IReportProps, IState> {
         presentationArea: {
             display: "flex",
             flexDirection: "row",
-            padding: "20px 0 30px 90px"
+            padding: "20px 0 30px 90px",
+            backgroundColor: 'white'
         },
         chartWrapper: {
             flex: "1 0 40%",
@@ -344,7 +345,7 @@ export class WizardReport extends React.PureComponent<IReportProps, IState> {
                     <div className={WizardReport.classNames.colorBlock} style={{backgroundColor: ChartColors[0]}}/>
                     <div>
                         <div>{localization.Report.overestimationError}</div>
-                        <div>{localization.Report.underpredictionExplanation}</div>
+                        <div>{localization.Report.overpredictionExplanation}</div>
                     </div>
                 </div>
                 <div className={WizardReport.classNames.textRow}>{localization.Report.classificationAccuracyHowToRead1}</div>


### PR DESCRIPTION
hello!  The code that points to the copy for explaining what overprediction and underprediction are has a typo, check out the part of the example UCI notebook highlighted in purple:

![image](https://user-images.githubusercontent.com/1056957/74681022-5156b980-5190-11ea-873e-6ec4a3bd768f.png)

Here's this diff for the test app in the project (the NaN is intentional in the setup for the test app, and some data is random):

### copy change
<img width="968" alt="Screen Shot 2020-02-17 at 2 11 11 PM" src="https://user-images.githubusercontent.com/1056957/74680929-12286880-5190-11ea-936c-3c968bcba48f.png">

Separately, this PR adds in a background color for the `presentationArea` to fix this in the test app.  This isn't a visible issue in Jupyter since the cell background is white, but this is what that same screen looks like in the test app without the background color:

### presentationArea backgroundColor
<img width="979" alt="Screen Shot 2020-02-17 at 2 04 02 PM" src="https://user-images.githubusercontent.com/1056957/74680926-105ea500-5190-11ea-9c17-63fd16c88dbb.png">


Also, I assume to merge this we need to build the widget assets and check them in, but I didn't do any of that here yet.