### PR TITLE
Rename arguments to create_group_metric_set

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * `ThresholdOptimizer` now performs validations during `fit`, and not during
   `__init__`. It also stores the fitted given estimator in the `estimator_`
   attribute.
+* Rename arguments of `create_group_metric_set()` to match the dashboard
 
 ### v0.4.4
 * Remove `GroupMetricSet` in favour of a `create_group_metric_set` method

--- a/fairlearn/metrics/_group_metric_set.py
+++ b/fairlearn/metrics/_group_metric_set.py
@@ -98,16 +98,16 @@ REGRESSION_METRICS[GROUP_ZERO_ONE_LOSS] = group_zero_one_loss
 def create_group_metric_set(model_type,
                             y_true,
                             y_preds,
-                            group_memberships,
+                            sensitive_features,
                             model_titles=None,
-                            group_titles=None,
+                            sensitive_feature_names=None,
                             extra_metrics=None):
     """Create a dictionary matching the Dashboard's cache."""
     if extra_metrics is not None:
         raise NotImplementedError("No support for extra_metrics yet")
 
     # We could consider checking that the length of y_preds matches model_titles
-    # and that the length of group_memberships matches group_titles
+    # and that the length of sensitive_features matches sensitive_feature_names
 
     result = dict()
     result[_SCHEMA] = _GROUP_METRIC_SET

--- a/fairlearn/metrics/_group_metric_set.py
+++ b/fairlearn/metrics/_group_metric_set.py
@@ -13,13 +13,11 @@ from . import group_miss_rate, group_precision_score, group_r2_score
 from . import group_recall_score, group_roc_auc_score, group_root_mean_squared_error
 from . import group_selection_rate, group_specificity_score, group_zero_one_loss
 
-_GROUP_NAMES_MSG = "The group_names property must be a list of strings"
+_GROUP_NAMES_MSG = "The sensitive_feature_names property must be a list of strings"
 _METRICS_KEYS_MSG = "Keys for metrics dictionary must be strings"
 _METRICS_VALUES_MSG = "Values for metrics dictionary must be of type GroupMetricResult"
 
-_ARRAYS_NOT_SAME_LENGTH = "Lengths of y_true, y_pred and groups must match"
-_BIN_MISMATCH_FOR_METRIC = "The groups for metric {0} do not match the groups property"
-_GROUP_NAMES_BAD_COUNT = "Count of group_names not the same as the number of unique groups"
+_ARRAYS_NOT_SAME_LENGTH = "Lengths of y_true, y_pred and sensitive_features must match"
 
 _Y_TRUE = 'trueY'
 _Y_PRED = 'predictedY'

--- a/fairlearn/metrics/_group_metric_set.py
+++ b/fairlearn/metrics/_group_metric_set.py
@@ -133,14 +133,14 @@ def create_group_metric_set(model_type,
     result[_PRECOMPUTED_METRICS] = []
     result[_PRECOMPUTED_BINS] = []
     result[_MODEL_NAMES] = []
-    for g, group_membership in enumerate(group_memberships):
+    for g, group_membership in enumerate(sensitive_features):
         _gm = np.asarray(group_membership).tolist()
         _unique_groups = sorted(list(np.unique(_gm)))
         group_names = [str(x) for x in _unique_groups]
         groups = [_unique_groups.index(x) for x in _gm]
         bin_dict = {_BIN_VECTOR: groups, _BIN_LABELS: group_names}
-        if group_titles is not None:
-            bin_dict[_FEATURE_BIN_NAME] = group_titles[g]
+        if sensitive_feature_names is not None:
+            bin_dict[_FEATURE_BIN_NAME] = sensitive_feature_names[g]
         result[_PRECOMPUTED_BINS].append(bin_dict)
 
         model_list = []

--- a/test/unit/metrics/test_create_group_metric_set.py
+++ b/test/unit/metrics/test_create_group_metric_set.py
@@ -18,7 +18,7 @@ def test_bad_model_type():
 
 
 def test_smoke():
-    # Single model, single group vector, no names
+    # Single model, single sensitive feature vector, no names
     Y_true = [0, 1, 0, 1, 1, 1, 1, 1, 0, 1, 0]
     Y_pred = [[0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1]]
     sensitive_feature = [['a', 'b', 'b', 'a', 'b', 'b', 'b', 'a', 'b', 'b', 'b']]
@@ -74,14 +74,15 @@ def test_smoke():
 
 
 def test_two_models():
-    # Two models, single group vector, no names
-    Y_true = [0, 1, 0, 1, 1, 1, 1, 1, 0, 1, 0]
-    Y_pred = [[0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1],
-              [1, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0]]
-    Groups = [['a', 'b', 'b', 'a', 'b', 'b', 'b', 'a', 'b', 'b', 'b']]
-    gr_int = [int(x == 'b') for x in Groups[0]]
+    # Two models, single sensitive feature vector, no names
+    Y_true = [0, 1, 0, 1, 1, 1, 1, 1, 0, 1, 0, 0, 0, 1, 1]
+    Y_pred = [[0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1],
+              [1, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0]]
+    a, b = 'a', 'b'
+    sensitive_features = [[b, a, a, b, b, a, a, b, b, a, b, a, b, a, b]]
+    sf_int = [int(x == 'b') for x in sensitive_features[0]]
 
-    result = create_group_metric_set('binary_classification', Y_true, Y_pred, Groups)
+    result = create_group_metric_set('binary_classification', Y_true, Y_pred, sensitive_features)
     assert result['predictionType'] == 'binaryClassification'
     assert result['schemaType'] == 'groupMetricSet'
     assert result['schemaVersion'] == 0
@@ -93,7 +94,7 @@ def test_two_models():
     assert len(result['precomputedFeatureBins']) == 1
     bin_dict = result['precomputedFeatureBins'][0]
     assert isinstance(bin_dict, dict)
-    assert np.array_equal(bin_dict['binVector'], gr_int)
+    assert np.array_equal(bin_dict['binVector'], sf_int)
     assert np.array_equal(bin_dict['binLabels'], ['a', 'b'])
 
     assert isinstance(result['predictedY'], list)
@@ -115,7 +116,7 @@ def test_two_models():
 
         accuracy = metrics_g0_m0['accuracy_score']
         assert isinstance(accuracy, dict)
-        gmr = group_accuracy_score(Y_true, Y_pred[i], Groups[0])
+        gmr = group_accuracy_score(Y_true, Y_pred[i], sensitive_features[0])
         assert gmr.overall == pytest.approx(accuracy['global'])
         assert isinstance(accuracy['bins'], list)
         assert len(accuracy['bins']) == 2
@@ -124,7 +125,7 @@ def test_two_models():
 
         roc_auc = metrics_g0_m0['balanced_accuracy_score']
         assert isinstance(roc_auc, dict)
-        gmr = group_roc_auc_score(Y_true, Y_pred[i], sensitive_feature[0])
+        gmr = group_roc_auc_score(Y_true, Y_pred[i], sensitive_features[0])
         assert gmr.overall == pytest.approx(roc_auc['global'])
         assert isinstance(roc_auc['bins'], list)
         assert len(roc_auc['bins']) == 2

--- a/test/unit/metrics/test_create_group_metric_set.py
+++ b/test/unit/metrics/test_create_group_metric_set.py
@@ -258,16 +258,16 @@ def test_two_named_sensitive_features():
 
 
 def test_two_named_models():
-    # Two models, single group vector, no names
+    # Two models, single sensitive feature vector, no names
     Y_true = [0, 1, 0, 1, 1, 1, 1, 1, 0, 1, 0]
     Y_pred = [[0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1],
               [1, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0]]
-    Groups = [['a', 'b', 'b', 'a', 'b', 'b', 'b', 'a', 'b', 'b', 'b']]
-    gr_int = [int(x == 'b') for x in Groups[0]]
+    sensitive_features = [['b', 'a', 'a', 'b', 'b', 'b', 'b', 'a', 'b', 'b', 'b']]
+    sf_int = [int(x == 'b') for x in sensitive_features[0]]
     model_names = ['firstModel', 'secondModel']
 
     result = create_group_metric_set('binary_classification',
-                                     Y_true, Y_pred, Groups,
+                                     Y_true, Y_pred, sensitive_features,
                                      model_titles=model_names)
     assert result['predictionType'] == 'binaryClassification'
     assert result['schemaType'] == 'groupMetricSet'
@@ -280,7 +280,7 @@ def test_two_named_models():
     assert len(result['precomputedFeatureBins']) == 1
     bin_dict = result['precomputedFeatureBins'][0]
     assert isinstance(bin_dict, dict)
-    assert np.array_equal(bin_dict['binVector'], gr_int)
+    assert np.array_equal(bin_dict['binVector'], sf_int)
     assert np.array_equal(bin_dict['binLabels'], ['a', 'b'])
 
     assert isinstance(result['modelNames'], list)

--- a/test/unit/metrics/test_create_group_metric_set.py
+++ b/test/unit/metrics/test_create_group_metric_set.py
@@ -117,7 +117,7 @@ def test_two_groups():
     Y_true = [0, 1, 0, 1, 1, 1, 1, 1, 0, 1, 0]
     Y_pred = [[0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1]]
     # First group is just 'a' and 'b'. Second is 4, 5 and 6
-    Groups = [['a', 'b', 'b', 'a', 'b', 'b', 'b', 'a', 'b', 'b', 'b'],
+    Groups = [['b', 'a', 'a', 'a', 'b', 'b', 'b', 'a', 'b', 'b', 'b'],
               [4, 5, 6, 6, 5, 4, 4, 5, 5, 6, 6]]
     gr_int = [int(x == 'b') for x in Groups[0]]
 
@@ -194,7 +194,7 @@ def test_two_named_groups():
 
     result = create_group_metric_set('binary_classification',
                                      Y_true, Y_pred, Groups,
-                                     group_titles=group_titles)
+                                     sensitive_feature_names=group_titles)
     assert result['predictionType'] == 'binaryClassification'
     assert result['schemaType'] == 'groupMetricSet'
     assert result['schemaVersion'] == 0


### PR DESCRIPTION
Bring the argument names for `create_group_metric_set` into line with the Dashboard:

- `group_memberships` becomes `sensitive_features`
- `group_titles` becomes `sensitive_feature_names`

This change propagates through the tests as well