### PR TITLE
add auto-assign-reviewers action

### DIFF
--- a/.github/auto-assign-reviewers-config.yml
+++ b/.github/auto-assign-reviewers-config.yml
@@ -1,0 +1,35 @@
+# Configuration for .github/workflows/auto-assign-reviewers.yml
+# Documentation for the action and configuration: https://github.com/marketplace/actions/auto-assign-action
+
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set addAssignees to 'author' to set the PR creator as the assignee.
+addAssignees: author
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0
+
+reviewers:
+  - romanlutz
+  - riedgar-ms
+
+# TODO: eventually use reviewGroups to split up by logic, e.g. to have a
+# - mitigationGroup
+# - visualizationGroup
+# depending on the path. That doesn't seem to be possible yet.
+
+# Set to true to add reviewers from different groups to pull requests
+# useReviewGroups: true
+
+# A list of reviewers, split into different groups, to be added to pull requests (GitHub user name)
+# reviewGroups:
+#   groupA:
+#     - reviewerA
+#     - reviewerB
+#     - reviewerC
+#   groupB:
+#     - reviewerD
+#     - reviewerE
+#     - reviewerF

--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -1,0 +1,15 @@
+name: Auto-Assign-Reviewers
+
+on: pull_request
+
+jobs:
+  add-reviewers:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Auto Assign Action
+      uses: kentaro-m/auto-assign-action@v1.1.0
+      # documentation: https://github.com/marketplace/actions/auto-assign-action
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: ".github/auto-assign-reviewers-config.yml"


### PR DESCRIPTION
Adding a simple GitHub action to always assing me and Richard as reviewers. I'm planning to refine this in the future, ideally based on interest/specialization, but the current GitHub action doesn't have that functionality yet AFAICT. This PR also demonstrates a simple example of how to use GitHub actions in case we want to replace Azure Pipelines at some point.

addresses #285 

Signed-off-by: Roman Lutz <rolutz@microsoft.com>