### PR TITLE
WIP Update Demographic Parity and Equalized Odds based on ratios.

### DIFF
--- a/fairlearn/reductions/_moments/conditional_selection_rate.py
+++ b/fairlearn/reductions/_moments/conditional_selection_rate.py
@@ -106,8 +106,8 @@ class ConditionalSelectionRate(ClassificationMoment):
         :type lambda_vec: :class:`pandas:pandas.Series`
         """
         lambda_signed = lambda_vec["+"] - lambda_vec["-"]
-        adjust = lambda_signed.sum(level=_EVENT) / self.prob_event \
-            - lambda_signed / self.prob_group_event
+        adjust = (self.ratio * lambda_signed.sum(level=_EVENT) / self.prob_event) \
+            - (lambda_signed / self.prob_group_event)
         signed_weights = self.tags.apply(
             lambda row: adjust[row[_EVENT], row[_GROUP_ID]], axis=1
         )
@@ -141,6 +141,10 @@ class DemographicParity(ConditionalSelectionRate):
 
     short_name = "DemographicParity"
 
+    def __init__(self, ratio=1.0):
+        super(DemographicParity, self).__init__()
+        self.ratio = ratio
+
     def load_data(self, X, y, **kwargs):
         """Load the specified data into the object."""
         super().load_data(X, y, event=_ALL, **kwargs)
@@ -172,6 +176,10 @@ class EqualizedOdds(ConditionalSelectionRate):
     """
 
     short_name = "EqualizedOdds"
+
+    def __init__(self, ratio=1.0):
+        super(EqualizedOdds, self).__init__()
+        self.ratio = ratio
 
     def load_data(self, X, y, **kwargs):
         """Load the specified data into the object."""


### PR DESCRIPTION
## What's there in this PR?
- Update to take in a constructor parameter `ratio` to `conditional_selection_rate` that will be used to implement a ratio based fairness constraint in the `signed_weights` method. 
- The only update was while calculating the `signed_weights` the 2nd parameter in the paper - `\lambda_a` for DP and `\lambda_{(a, Y_i)}` for EO,  will now be multiplied by a ratio `self.ratio` before sending the signed weights back.
- The default value for this parameter (`self.ratio`), if not sent, is 1. Hence, does not affect the current API. 

## Testing
- Ran the smoke test `test_smoke` in `test_exponentiatedgradient_smoke.py` and they all passed.

#### TODO:
- Add some unit tests around this ratio change. 
- Add documentation for the extra parameter `ratio` being added in the constructor. 