### PR TITLE
Bump matplotlib to 3.2.1 and remove TkAgg workaround

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Required for fairlearn
-matplotlib>=3.1.3
+matplotlib>=3.2.1
 numpy>=1.17.2
 pandas>=0.25.1
 scikit-learn>=0.22.1

--- a/test/unit/postprocessing/test_plots.py
+++ b/test/unit/postprocessing/test_plots.py
@@ -1,18 +1,13 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-# On MacOS we need to use TKAgg before importing matplotlib.pyplot.
-# This used to work on all platforms until matplotlib 3.2.0 broke it on Linux.
-# Consider removing the OS-based if after a future release of matplotlib (issue #320).
-import matplotlib
-matplotlib.use('TkAgg')
-import matplotlib.pyplot as plt  # noqa: E402
-import pkg_resources  # noqa: E402
-import pytest  # noqa: E402
-from fairlearn.postprocessing import ThresholdOptimizer, plot_threshold_optimizer  # noqa: E402
-from fairlearn.postprocessing._constants import DEMOGRAPHIC_PARITY, EQUALIZED_ODDS  # noqa: E402
+import matplotlib.pyplot as plt
+import pkg_resources
+import pytest
+from fairlearn.postprocessing import ThresholdOptimizer, plot_threshold_optimizer
+from fairlearn.postprocessing._constants import DEMOGRAPHIC_PARITY, EQUALIZED_ODDS
 
-from .conftest import scores_ex, ExamplePredictor, _data_ex1, _data_ex2, _data_ex3  # noqa: E402
+from .conftest import scores_ex, ExamplePredictor, _data_ex1, _data_ex2, _data_ex3
 
 
 PYTEST_MPL_NOT_INSTALLED_MSG = "skipping plotting tests because pytest-mpl is not installed"

--- a/test/unit/postprocessing/test_plots.py
+++ b/test/unit/postprocessing/test_plots.py
@@ -51,7 +51,7 @@ def is_py35_on_macos():
 
 @pytest.mark.skipif(is_py35_on_macos(), reason="Python 3.5 on MacOS requires TkAgg.")
 @pytest.mark.skipif(not is_mpl_installed(), reason=PYTEST_MPL_NOT_INSTALLED_MSG)
-class PlottingTests:
+class TestPlots:
     @pytest.mark.mpl_image_compare(filename="equalized_odds_ex1.png")
     def test_plot_equalized_odds_ex1(self):
         return _fit_and_plot(EQUALIZED_ODDS, _data_ex1)

--- a/test/unit/postprocessing/test_plots.py
+++ b/test/unit/postprocessing/test_plots.py
@@ -5,9 +5,8 @@
 # This used to work on all platforms until matplotlib 3.2.0 broke it on Linux.
 # Consider removing the OS-based if after a future release of matplotlib (issue #320).
 import platform
-if platform.system() == "Darwin":
-    import matplotlib
-    matplotlib.use('TkAgg')
+import matplotlib
+matplotlib.use('TkAgg')
 import matplotlib.pyplot as plt  # noqa: E402
 import pkg_resources  # noqa: E402
 import pytest  # noqa: E402

--- a/test/unit/postprocessing/test_plots.py
+++ b/test/unit/postprocessing/test_plots.py
@@ -4,7 +4,6 @@
 # On MacOS we need to use TKAgg before importing matplotlib.pyplot.
 # This used to work on all platforms until matplotlib 3.2.0 broke it on Linux.
 # Consider removing the OS-based if after a future release of matplotlib (issue #320).
-import platform
 import matplotlib
 matplotlib.use('TkAgg')
 import matplotlib.pyplot as plt  # noqa: E402

--- a/test/unit/postprocessing/test_plots.py
+++ b/test/unit/postprocessing/test_plots.py
@@ -1,9 +1,10 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import matplotlib.pyplot as plt
 import pkg_resources
+import platform
 import pytest
+import sys
 from fairlearn.postprocessing import ThresholdOptimizer, plot_threshold_optimizer
 from fairlearn.postprocessing._constants import DEMOGRAPHIC_PARITY, EQUALIZED_ODDS
 
@@ -24,6 +25,8 @@ generated images with the baseline plots (using pytest --mpl)."""
 
 
 def _fit_and_plot(constraints, plotting_data):
+    import matplotlib.pyplot as plt
+
     adjusted_predictor = ThresholdOptimizer(estimator=ExamplePredictor(scores_ex),
                                             constraints=constraints)
     adjusted_predictor.fit(plotting_data.X, plotting_data.y,
@@ -42,37 +45,33 @@ def is_mpl_installed():
         return False
 
 
+def is_py35_on_macos():
+    return sys.version_info[0] == 3 and sys.version_info[1] == 5 and platform.system() == "Darwin"
+
+
+@pytest.mark.skipif(is_py35_on_macos(), reason="Python 3.5 on MacOS requires TkAgg.")
 @pytest.mark.skipif(not is_mpl_installed(), reason=PYTEST_MPL_NOT_INSTALLED_MSG)
-@pytest.mark.mpl_image_compare(filename="equalized_odds_ex1.png")
-def test_plot_equalized_odds_ex1():
-    return _fit_and_plot(EQUALIZED_ODDS, _data_ex1)
+class PlottingTests:
+    @pytest.mark.mpl_image_compare(filename="equalized_odds_ex1.png")
+    def test_plot_equalized_odds_ex1(self):
+        return _fit_and_plot(EQUALIZED_ODDS, _data_ex1)
 
+    @pytest.mark.mpl_image_compare(filename="equalized_odds_ex2.png")
+    def test_plot_equalized_odds_ex2(self):
+        return _fit_and_plot(EQUALIZED_ODDS, _data_ex2)
 
-@pytest.mark.skipif(not is_mpl_installed(), reason=PYTEST_MPL_NOT_INSTALLED_MSG)
-@pytest.mark.mpl_image_compare(filename="equalized_odds_ex2.png")
-def test_plot_equalized_odds_ex2():
-    return _fit_and_plot(EQUALIZED_ODDS, _data_ex2)
+    @pytest.mark.mpl_image_compare(filename="equalized_odds_ex3.png")
+    def test_plot_equalized_odds_ex3(self):
+        return _fit_and_plot(EQUALIZED_ODDS, _data_ex3)
 
+    @pytest.mark.mpl_image_compare(filename="demographic_parity_ex1.png")
+    def test_plot_demographic_parity_ex1(self):
+        return _fit_and_plot(DEMOGRAPHIC_PARITY, _data_ex1)
 
-@pytest.mark.skipif(not is_mpl_installed(), reason=PYTEST_MPL_NOT_INSTALLED_MSG)
-@pytest.mark.mpl_image_compare(filename="equalized_odds_ex3.png")
-def test_plot_equalized_odds_ex3():
-    return _fit_and_plot(EQUALIZED_ODDS, _data_ex3)
+    @pytest.mark.mpl_image_compare(filename="demographic_parity_ex2.png")
+    def test_plot_demographic_parity_ex2(self):
+        return _fit_and_plot(DEMOGRAPHIC_PARITY, _data_ex2)
 
-
-@pytest.mark.skipif(not is_mpl_installed(), reason=PYTEST_MPL_NOT_INSTALLED_MSG)
-@pytest.mark.mpl_image_compare(filename="demographic_parity_ex1.png")
-def test_plot_demographic_parity_ex1():
-    return _fit_and_plot(DEMOGRAPHIC_PARITY, _data_ex1)
-
-
-@pytest.mark.skipif(not is_mpl_installed(), reason=PYTEST_MPL_NOT_INSTALLED_MSG)
-@pytest.mark.mpl_image_compare(filename="demographic_parity_ex2.png")
-def test_plot_demographic_parity_ex2():
-    return _fit_and_plot(DEMOGRAPHIC_PARITY, _data_ex2)
-
-
-@pytest.mark.skipif(not is_mpl_installed(), reason=PYTEST_MPL_NOT_INSTALLED_MSG)
-@pytest.mark.mpl_image_compare(filename="demographic_parity_ex3.png")
-def test_plot_demographic_parity_ex3():
-    return _fit_and_plot(DEMOGRAPHIC_PARITY, _data_ex3)
+    @pytest.mark.mpl_image_compare(filename="demographic_parity_ex3.png")
+    def test_plot_demographic_parity_ex3(self):
+        return _fit_and_plot(DEMOGRAPHIC_PARITY, _data_ex3)


### PR DESCRIPTION
Closes #320 
Without using TkAgg our plotting tests would fail on MacOS. With 3.2.1 this isn't the case anymore, so we can happily remove the special case for MacOS in general, and apply a skip for MacOS with python 3.5 only. This means all future python versions as well as >=3.6 are tested without TkAgg specifically enabled.