### PR TITLE
Release v0.4.5

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,17 @@ postprocessor.predict(X, sensitive_features=sensitive_features)
 First add a description of the changes introduced in the package version you
 want to release to [CHANGES.md](CHANGES.md).
 
+It is also best to verify that the Dashboard loads correctly. This is slightly
+involved:
+1. Create a wheel by running `python setup.py sdist bdist_wheel` from the
+repository root. This will create a `dist` directory which contains a `.whl`
+file.
+1. Create a new Conda environment for the test
+1. In this new environment, install this wheel by running
+`pip install dist/<FILENAME>.whl`
+1. Install any pip packages required for the notebooks
+1. Check that the dashboard loads in the notebooks
+
 We have a [Azure DevOps
 Pipeline](https://dev.azure.com/responsibleai/fairlearn/_build?definitionId=48&_a=summary)
 which takes care of building wheels and pushing to PyPI. Validations are also

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Fairlearn is a Python package that empowers developers of artificial intelligenc
 
 ## Current release
 
-- The current stable release is available at [Fairlearn v0.4.4](https://github.com/fairlearn/fairlearn/tree/v0.4.4).
+- The current stable release is available at [Fairlearn v0.4.5](https://github.com/fairlearn/fairlearn/tree/v0.4.5).
 
 - Our current version differs substantially from version 0.2 or earlier. Users of these older versions should visit our [onboarding guide](#onboarding-guide).
 

--- a/fairlearn/__init__.py
+++ b/fairlearn/__init__.py
@@ -9,7 +9,7 @@ import sys
 # Finesse the version
 _FAIRLEARN_DEV_VERSION_ENV_VAR = "FAIRLEARN_DEV_VERSION"
 
-_base_version = "0.4.4"
+_base_version = "0.4.5"
 _dev_version = ""
 
 if _FAIRLEARN_DEV_VERSION_ENV_VAR in os.environ.keys():


### PR DESCRIPTION
A second attempt at releasing v0.4.5, including instructions on how to validate that the dashboard loads correctly.