### PR TITLE
Improve pipeline job generation

### DIFF
--- a/devops/PR-Gate.yml
+++ b/devops/PR-Gate.yml
@@ -14,49 +14,20 @@ pool:
 jobs:
 - template: templates/all-tests-job-template.yml
   parameters:
-    platform: Linux
-    vmImage: 'ubuntu-16.04'
-    testRunType: 'Unit'
-    installationType: 'None'
-    pyVersions: [3.7]
-    freezeArtifactStem: $(FreezeArtifactStem)
-    freezeFileStem: $(FreezeFileStem)
-
-- template: templates/all-tests-job-template.yml
-  parameters:
-    platform: Windows
-    vmImage:  'vs2017-win2016'
-    testRunType: 'Unit'
-    installationType: 'None'
-    pyVersions: [3.6]
+    platforms:  { Linux: ubuntu-latest, Windows: vs2017-win2016 }
+    installationType: 'PipLocal'
+    pyVersions: [3.5, 3.6]
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFileStem: $(FreezeFileStem)
     
 - template: templates/all-tests-job-template.yml
   parameters:
-    platform: MacOS
-    vmImage:  'macos-latest'
-    testRunType: 'Unit'
+    platforms: { MacOS: macos-latest }
+    testRunTypes: ['Unit']
     installationType: 'None'
-    pyVersions: [3.7]
+    pyVersions: [3.7, 3.8]
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFileStem: $(FreezeFileStem)
-
-- template: templates/all-tests-job-template.yml
-  parameters:
-    platform: Linux
-    testRunType: 'Notebooks'
-    installationType: 'PipLocal'
-    vmImage: 'ubuntu-16.04'
-    pyVersions: [3.6]
-
-- template: templates/all-tests-job-template.yml
-  parameters:
-    platform: Windows
-    testRunType: 'Notebooks'
-    installationType: 'PipLocal'
-    vmImage: 'vs2017-win2016'
-    pyVersions: [3.8]
 
 - template: templates/build-widget-job-template.yml
 

--- a/devops/PR-Gate.yml
+++ b/devops/PR-Gate.yml
@@ -14,9 +14,17 @@ pool:
 jobs:
 - template: templates/all-tests-job-template.yml
   parameters:
-    platforms:  { Linux: ubuntu-latest, Windows: vs2017-win2016 }
+    platforms:  { Linux: ubuntu-latest }
     installationType: 'PipLocal'
-    pyVersions: [3.5, 3.6]
+    pyVersions: [3.5]
+    freezeArtifactStem: $(FreezeArtifactStem)
+    freezeFileStem: $(FreezeFileStem)
+
+- template: templates/all-tests-job-template.yml
+  parameters:
+    platforms:  { Windows: vs2017-win2016 }
+    installationType: 'PipLocal'
+    pyVersions: [3.6]
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFileStem: $(FreezeFileStem)
     

--- a/devops/nightly-requirements-fixed.yml
+++ b/devops/nightly-requirements-fixed.yml
@@ -23,43 +23,8 @@ pool:
 jobs:
 - template: templates/all-tests-job-template.yml
   parameters:
-    platform: Linux
-    vmImage: 'ubuntu-16.04'
-    testRunType: 'Unit'
-    installationType: 'None'
-    pyVersions: [3.5, 3.6, 3.7, 3.8]
-    freezeArtifactStem: $(FreezeArtifactStem)
-    freezeFileStem: $(FreezeFileStem)
-    pinRequirements: True
-
-- template: templates/all-tests-job-template.yml
-  parameters:
-    platform: Windows
-    vmImage:  'vs2017-win2016'
-    testRunType: 'Unit'
-    installationType: 'None'
-    pyVersions: [3.5, 3.6, 3.7, 3.8]
-    freezeArtifactStem: $(FreezeArtifactStem)
-    freezeFileStem: $(FreezeFileStem)
-    pinRequirements: True
-
-- template: templates/all-tests-job-template.yml
-  parameters:
-    platform: Linux
-    testRunType: 'Notebooks'
+    platforms:  { Linux: ubuntu-latest, Windows: vs2017-win2016 }
     installationType: 'PipLocal'
-    vmImage: 'ubuntu-16.04'
-    pyVersions: [3.5, 3.6, 3.7, 3.8]
-    freezeArtifactStem: $(FreezeArtifactStem)
-    freezeFileStem: $(FreezeFileStem)
-    pinRequirements: True
-
-- template: templates/all-tests-job-template.yml
-  parameters:
-    platform: Windows
-    testRunType: 'Notebooks'
-    installationType: 'PipLocal'
-    vmImage: 'vs2017-win2016'
     pyVersions: [3.5, 3.6, 3.7, 3.8]
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFileStem: $(FreezeFileStem)

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -24,8 +24,7 @@ jobs:
   parameters:
     platform: Linux
     vmImage: 'ubuntu-16.04'
-    testRunType: 'Unit'
-    installationType: 'None'
+    installationType: 'PipLocal'
     pyVersions: [3.5, 3.6, 3.7, 3.8]
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFileStem: $(FreezeFileStem)
@@ -34,8 +33,7 @@ jobs:
   parameters:
     platform: Windows
     vmImage:  'vs2017-win2016'
-    testRunType: 'Unit'
-    installationType: 'None'
+    installationType: 'PipLocal'
     pyVersions: [3.5, 3.6, 3.7, 3.8]
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFileStem: $(FreezeFileStem)
@@ -44,28 +42,8 @@ jobs:
   parameters:
     platform: MacOS
     vmImage:  'macos-latest'
-    testRunType: 'Unit'
+    testRunTypes: ['Unit']
     installationType: 'None'
-    pyVersions: [3.5, 3.6, 3.7, 3.8]
-    freezeArtifactStem: $(FreezeArtifactStem)
-    freezeFileStem: $(FreezeFileStem)
-
-- template: templates/all-tests-job-template.yml
-  parameters:
-    platform: Linux
-    testRunType: 'Notebooks'
-    installationType: 'PipLocal'
-    vmImage: 'ubuntu-16.04'
-    pyVersions: [3.5, 3.6, 3.7, 3.8]
-    freezeArtifactStem: $(FreezeArtifactStem)
-    freezeFileStem: $(FreezeFileStem)
-
-- template: templates/all-tests-job-template.yml
-  parameters:
-    platform: Windows
-    testRunType: 'Notebooks'
-    installationType: 'PipLocal'
-    vmImage: 'vs2017-win2016'
     pyVersions: [3.5, 3.6, 3.7, 3.8]
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFileStem: $(FreezeFileStem)

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -22,17 +22,7 @@ pool:
 jobs:
 - template: templates/all-tests-job-template.yml
   parameters:
-    platform: Linux
-    vmImage: 'ubuntu-16.04'
-    installationType: 'PipLocal'
-    pyVersions: [3.5, 3.6, 3.7, 3.8]
-    freezeArtifactStem: $(FreezeArtifactStem)
-    freezeFileStem: $(FreezeFileStem)
-
-- template: templates/all-tests-job-template.yml
-  parameters:
-    platform: Windows
-    vmImage:  'vs2017-win2016'
+    platforms:  { Linux: ubuntu-latest, Windows: vs2017-win2016 }
     installationType: 'PipLocal'
     pyVersions: [3.5, 3.6, 3.7, 3.8]
     freezeArtifactStem: $(FreezeArtifactStem)
@@ -40,8 +30,7 @@ jobs:
     
 - template: templates/all-tests-job-template.yml
   parameters:
-    platform: MacOS
-    vmImage:  'macos-latest'
+    platforms: { MacOS: macos-latest }
     testRunTypes: ['Unit']
     installationType: 'None'
     pyVersions: [3.5, 3.6, 3.7, 3.8]

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -31,19 +31,9 @@ stages:
     
   jobs:
   - template: templates/all-tests-job-template.yml
-      parameters:
-      platforms:  { Linux: ubuntu-latest, Windows: vs2017-win2016 }
-      installationType: 'PipLocal'
-      pyVersions: [3.5, 3.6, 3.7, 3.8]
-      freezeArtifactStem: "PreDeployment"
-      freezeFileStem: $(FreezeFileStem)
-
-  - template: templates/all-tests-job-template.yml
     parameters:
-      platform: Windows
-      vmImage:  'vs2017-win2016'
-      testRunType: 'Unit'
-      installationType: 'None'
+      platforms: { Linux: ubuntu-latest, Windows: vs2017-win2016 }
+      installationType: 'PipLocal'
       pyVersions: [3.5, 3.6, 3.7, 3.8]
       freezeArtifactStem: "PreDeployment"
       freezeFileStem: $(FreezeFileStem)

--- a/devops/pypi-release.yml
+++ b/devops/pypi-release.yml
@@ -31,11 +31,9 @@ stages:
     
   jobs:
   - template: templates/all-tests-job-template.yml
-    parameters:
-      platform: Linux
-      vmImage: 'ubuntu-16.04'
-      testRunType: 'Unit'
-      installationType: 'None'
+      parameters:
+      platforms:  { Linux: ubuntu-latest, Windows: vs2017-win2016 }
+      installationType: 'PipLocal'
       pyVersions: [3.5, 3.6, 3.7, 3.8]
       freezeArtifactStem: "PreDeployment"
       freezeFileStem: $(FreezeFileStem)
@@ -52,30 +50,9 @@ stages:
       
   - template: templates/all-tests-job-template.yml
     parameters:
-      platform: MacOS
-      vmImage:  'macos-latest'
-      testRunType: 'Unit'
+      platforms: { MacOS: macos-latest }
+      testRunTypes: ['Unit']
       installationType: 'None'
-      pyVersions: [3.5, 3.6, 3.7, 3.8]
-      freezeArtifactStem: "PreDeployment"
-      freezeFileStem: $(FreezeFileStem)
-
-  - template: templates/all-tests-job-template.yml
-    parameters:
-      platform: Linux
-      vmImage: 'ubuntu-16.04'
-      testRunType: 'Notebooks'
-      installationType: 'PipLocal'
-      pyVersions: [3.5, 3.6, 3.7, 3.8]
-      freezeArtifactStem: "PreDeployment"
-      freezeFileStem: $(FreezeFileStem)
-
-  - template: templates/all-tests-job-template.yml
-    parameters:
-      platform: Windows
-      vmImage: 'vs2017-win2016'
-      testRunType: 'Notebooks'
-      installationType: 'PipLocal'
       pyVersions: [3.5, 3.6, 3.7, 3.8]
       freezeArtifactStem: "PreDeployment"
       freezeFileStem: $(FreezeFileStem)

--- a/devops/templates/all-tests-job-template.yml
+++ b/devops/templates/all-tests-job-template.yml
@@ -53,7 +53,7 @@ jobs:
           parameters:
             testRunType: ${{trt}}
             installationType: ${{parameters.installationType}}
-            pythonVersion: $(PyVer)
+            pythonVersion: ${{pyVer}}
             pinRequirements: ${{parameters.pinRequirements}}
             requirementsFile: $(RequirementsFile)
             freezeArtifact: $(FreezeArtifact)

--- a/devops/templates/all-tests-job-template.yml
+++ b/devops/templates/all-tests-job-template.yml
@@ -56,7 +56,7 @@ jobs:
   steps:
   - template: test-run-step-template.yml
     parameters:
-      testRunType: $(TestRunType)
+      testRunType: ${{testRunType}}
       installationType: ${{parameters.installationType}}
       pythonVersion: $(PyVer)
       pinRequirements: ${{parameters.pinRequirements}}

--- a/devops/templates/all-tests-job-template.yml
+++ b/devops/templates/all-tests-job-template.yml
@@ -56,7 +56,7 @@ jobs:
   steps:
   - template: test-run-step-template.yml
     parameters:
-      testRunType: '$(TestRunType)'
+      testRunType: $(TestRunType)
       installationType: ${{parameters.installationType}}
       pythonVersion: $(PyVer)
       pinRequirements: ${{parameters.pinRequirements}}

--- a/devops/templates/all-tests-job-template.yml
+++ b/devops/templates/all-tests-job-template.yml
@@ -39,12 +39,12 @@ jobs:
     maxParallel: 4
     matrix:
       ${{ each pyVer in parameters.pyVersions }}:
-        ${{ each testRunType in parameters.testRunTypes }}:
-          ${{testRunType}}_${{ pyVer }}:
+        ${{ each trt in parameters.testRunTypes }}:
+          ${{trt}}_${{ pyVer }}:
             PyVer: ${{ pyVer }}
-            TestRunType: ${{testRunType}}
+            TestRunType: ${{trt}}
             RequirementsFile: requirements-${{pyVer}}.txt
-            FreezeArtifact: '${{parameters.freezeArtifactStem}}${{parameters.platform}}${{parameters.testRunType}}${{pyVer}}'
+            FreezeArtifact: '${{parameters.freezeArtifactStem}}${{parameters.platform}}${{trt}}${{pyVer}}'
             FreezeFile: '${{parameters.freezeFileStem}}-${{parameters.name}}${{pyVer}}.txt'
 
   variables:
@@ -56,7 +56,7 @@ jobs:
   steps:
   - template: test-run-step-template.yml
     parameters:
-      testRunType: ${{testRunType}}
+      testRunType: ${{trt}}
       installationType: ${{parameters.installationType}}
       pythonVersion: $(PyVer)
       pinRequirements: ${{parameters.pinRequirements}}

--- a/devops/templates/all-tests-job-template.yml
+++ b/devops/templates/all-tests-job-template.yml
@@ -20,7 +20,7 @@
 parameters:
   platform: ''
   vmImage: ''
-  testRunType: ''
+  testRunTypes: ['Unit', 'Notebooks']
   installationType: ''
   pyVersions: [3.5, 3.6, 3.7, 3.8]
   pinRequirements: False
@@ -39,11 +39,13 @@ jobs:
     maxParallel: 2
     matrix:
       ${{ each pyVer in parameters.pyVersions }}:
-        ${{ pyVer }}:
-          PyVer: ${{ pyVer }}
-          RequirementsFile: requirements-${{pyVer}}.txt
-          FreezeArtifact: '${{parameters.freezeArtifactStem}}${{parameters.platform}}${{parameters.testRunType}}${{pyVer}}'
-          FreezeFile: '${{parameters.freezeFileStem}}-${{parameters.name}}${{pyVer}}.txt'
+        ${{ each testRunType in parameters.testRunTypes }}:
+          ${{testRunType}}_${{ pyVer }}:
+            PyVer: ${{ pyVer }}
+            TestRunType: ${{testRunType}}
+            RequirementsFile: requirements-${{pyVer}}.txt
+            FreezeArtifact: '${{parameters.freezeArtifactStem}}${{parameters.platform}}${{parameters.testRunType}}${{pyVer}}'
+            FreezeFile: '${{parameters.freezeFileStem}}-${{parameters.name}}${{pyVer}}.txt'
 
   variables:
     ${{ if eq(parameters.targetType, 'Test') }}:
@@ -53,9 +55,9 @@ jobs:
 
   steps:
 
-  - ${{ if notIn(parameters.testRunType, 'Unit', 'Notebooks') }}:
+  - ${{ if notIn($(TestRunType), 'Unit', 'Notebooks') }}:
     - script: exit 1
-      displayName: "Bad testRunType: ${{parameters.testRunType}}"
+      displayName: "Bad testRunType: $(TestRunType)"
 
   - task: UsePythonVersion@0
     displayName: 'Use Python $(PyVer)'
@@ -88,11 +90,11 @@ jobs:
     displayName: "Run flake8"
 
   # =================================================
-  - ${{ if eq(parameters.testRunType, 'Unit')}}:
+  - ${{ if eq($(TestRunType), 'Unit')}}:
     - script: python -m pytest test/ --ignore=test/install -m "not notebooks" --junitxml=./TEST--TEST.xml -o junit_suite_name="$(Agent.JobName)"
       displayName: 'Run unit tests'
 
-  - ${{ if eq(parameters.testRunType, 'Notebooks')}}:
+  - ${{ if eq($(TestRunType), 'Notebooks')}}:
     - script: python -m pytest test/ -m notebooks --junitxml=./TEST-TEST.xml -o junit_suite_name="$(Agent.JobName)"
       displayName: 'Run notebooks as tests'
   # =================================================

--- a/devops/templates/all-tests-job-template.yml
+++ b/devops/templates/all-tests-job-template.yml
@@ -20,7 +20,7 @@
 parameters:
   platform: ''
   vmImage: ''
-  testRunTypes: ['Unit', 'Notebooks']
+  testRunTypes: ['Units', 'Notebooks']
   installationType: ''
   pyVersions: [3.5, 3.6, 3.7, 3.8]
   pinRequirements: False

--- a/devops/templates/all-tests-job-template.yml
+++ b/devops/templates/all-tests-job-template.yml
@@ -32,11 +32,11 @@ parameters:
   versionArtifactFile:
 
 jobs:
-- job: ${{ parameters.platform }}_${{parameters.testRunType}}
+- job: ${{ parameters.platform }}
   pool:
     vmImage: ${{ parameters.vmImage }}
   strategy:
-    maxParallel: 2
+    maxParallel: 4
     matrix:
       ${{ each pyVer in parameters.pyVersions }}:
         ${{ each testRunType in parameters.testRunTypes }}:

--- a/devops/templates/all-tests-job-template.yml
+++ b/devops/templates/all-tests-job-template.yml
@@ -45,8 +45,8 @@ jobs:
               ${{ if eq(parameters.targetType, 'Prod') }}:
                 pypiUrl: https://pypi.org/simple/
               RequirementsFile: requirements-${{pyVer}}.txt
-              FreezeArtifact: '${{parameters.freezeArtifactStem}}${{parameters.platform}}${{trt}}${{pyVer}}'
-              FreezeFile: '${{parameters.freezeFileStem}}-${{parameters.name}}${{pyVer}}.txt'
+              FreezeArtifact: '${{parameters.freezeArtifactStem}}${{p.Key}}${{trt}}${{pyVer}}'
+              FreezeFile: '${{parameters.freezeFileStem}}-${{p.Key}}${{trt}}${{pyVer}}.txt'
 
           steps:
           - template: test-run-step-template.yml

--- a/devops/templates/all-tests-job-template.yml
+++ b/devops/templates/all-tests-job-template.yml
@@ -20,7 +20,7 @@
 parameters:
   platforms: { Linux: ubuntu-latest, Windows: vs2017-win2016 }
   testRunTypes: ['Unit', 'Notebooks']
-  installationType: ''
+  installationType:
   pyVersions: [3.5, 3.6, 3.7, 3.8]
   pinRequirements: False
   freezeArtifactStem: 

--- a/devops/templates/all-tests-job-template.yml
+++ b/devops/templates/all-tests-job-template.yml
@@ -56,7 +56,7 @@ jobs:
   steps:
   - template: test-run-step-template.yml
     parameters:
-      testRunType: $(TestRunType)
+      testRunType: '$(TestRunType)'
       installationType: ${{parameters.installationType}}
       pythonVersion: $(PyVer)
       pinRequirements: ${{parameters.pinRequirements}}

--- a/devops/templates/all-tests-job-template.yml
+++ b/devops/templates/all-tests-job-template.yml
@@ -18,9 +18,7 @@
 # of Fairlearn to fetch from it.
 
 parameters:
-  platform: ''
-  vmImage: ''
-  platforms: { Linux: ubuntu-latest, Windows: vs2017-win2016}
+  platforms: { Linux: ubuntu-latest, Windows: vs2017-win2016 }
   testRunTypes: ['Unit', 'Notebooks']
   installationType: ''
   pyVersions: [3.5, 3.6, 3.7, 3.8]
@@ -33,9 +31,9 @@ parameters:
   versionArtifactFile:
 
 jobs:
-  - ${{ each pyVer in parameters.pyVersions }}:
+  - ${{ each p in parameters.platforms }}:
     - ${{ each trt in parameters.testRunTypes }}:
-      - ${{ each p in parameters.platforms }}:
+      - ${{ each pyVer in parameters.pyVersions }}:
         - job:
           displayName: ${{ format('{0} {1} {2}', p.Key , trt, pyVer) }}
           pool:

--- a/devops/templates/all-tests-job-template.yml
+++ b/devops/templates/all-tests-job-template.yml
@@ -35,7 +35,7 @@ parameters:
 jobs:
   - ${{ each pyVer in parameters.pyVersions }}:
     - ${{ each trt in parameters.testRunTypes }}:
-      - ${{ each p in platforms }}:
+      - ${{ each p in parameters.platforms }}:
         - job:
           displayName: ${{ format('{0} {1} {2}', p.Key , trt, pyVer) }}
           pool:

--- a/devops/templates/all-tests-job-template.yml
+++ b/devops/templates/all-tests-job-template.yml
@@ -20,7 +20,7 @@
 parameters:
   platform: ''
   vmImage: ''
-  testRunTypes: ['Units', 'Notebooks']
+  testRunTypes: ['Unit', 'Notebooks']
   installationType: ''
   pyVersions: [3.5, 3.6, 3.7, 3.8]
   pinRequirements: False

--- a/devops/templates/all-tests-job-template.yml
+++ b/devops/templates/all-tests-job-template.yml
@@ -35,7 +35,7 @@ jobs:
   - ${{ each pyVer in parameters.pyVersions }}:
     - ${{ each trt in parameters.testRunTypes }}:
       - job:
-        displayName: ${{ format('{0} {1} {2}', parameters.platform , trt, pyVer }}
+        displayName: ${{ format('{0} {1} {2}', parameters.platform , trt, pyVer) }}
         pool:
           vmImage: ${{ parameters.vmImage }}
 

--- a/devops/templates/all-tests-job-template.yml
+++ b/devops/templates/all-tests-job-template.yml
@@ -20,6 +20,7 @@
 parameters:
   platform: ''
   vmImage: ''
+  platforms: { Linux: ubuntu-latest, Windows: vs2017-win2016}
   testRunTypes: ['Unit', 'Notebooks']
   installationType: ''
   pyVersions: [3.5, 3.6, 3.7, 3.8]
@@ -34,31 +35,32 @@ parameters:
 jobs:
   - ${{ each pyVer in parameters.pyVersions }}:
     - ${{ each trt in parameters.testRunTypes }}:
-      - job:
-        displayName: ${{ format('{0} {1} {2}', parameters.platform , trt, pyVer) }}
-        pool:
-          vmImage: ${{ parameters.vmImage }}
+      - ${{ each p in platforms }}:
+        - job:
+          displayName: ${{ format('{0} {1} {2}', p.Key , trt, pyVer) }}
+          pool:
+            vmImage: ${{ p.value }}
 
-        variables:
-            ${{ if eq(parameters.targetType, 'Test') }}:
-              pypiUrl: https://test.pypi.org/simple/
-            ${{ if eq(parameters.targetType, 'Prod') }}:
-              pypiUrl: https://pypi.org/simple/
-            RequirementsFile: requirements-${{pyVer}}.txt
-            FreezeArtifact: '${{parameters.freezeArtifactStem}}${{parameters.platform}}${{trt}}${{pyVer}}'
-            FreezeFile: '${{parameters.freezeFileStem}}-${{parameters.name}}${{pyVer}}.txt'
+          variables:
+              ${{ if eq(parameters.targetType, 'Test') }}:
+                pypiUrl: https://test.pypi.org/simple/
+              ${{ if eq(parameters.targetType, 'Prod') }}:
+                pypiUrl: https://pypi.org/simple/
+              RequirementsFile: requirements-${{pyVer}}.txt
+              FreezeArtifact: '${{parameters.freezeArtifactStem}}${{parameters.platform}}${{trt}}${{pyVer}}'
+              FreezeFile: '${{parameters.freezeFileStem}}-${{parameters.name}}${{pyVer}}.txt'
 
-        steps:
-        - template: test-run-step-template.yml
-          parameters:
-            testRunType: ${{trt}}
-            installationType: ${{parameters.installationType}}
-            pythonVersion: ${{pyVer}}
-            pinRequirements: ${{parameters.pinRequirements}}
-            requirementsFile: $(RequirementsFile)
-            freezeArtifact: $(FreezeArtifact)
-            freezeFile: $(FreezeFile)
-            # Following are used if the installationType is PyPI
-            pypiUrl: $(pypiUrl)
-            versionArtifactName: ${{parameters.versionArtifactName}}
-            versionArtifactFile: ${{parameters.versionArtifactFile}}
+          steps:
+          - template: test-run-step-template.yml
+            parameters:
+              testRunType: ${{trt}}
+              installationType: ${{parameters.installationType}}
+              pythonVersion: ${{pyVer}}
+              pinRequirements: ${{parameters.pinRequirements}}
+              requirementsFile: $(RequirementsFile)
+              freezeArtifact: $(FreezeArtifact)
+              freezeFile: $(FreezeFile)
+              # Following are used if the installationType is PyPI
+              pypiUrl: $(pypiUrl)
+              versionArtifactName: ${{parameters.versionArtifactName}}
+              versionArtifactFile: ${{parameters.versionArtifactFile}}

--- a/devops/templates/all-tests-job-template.yml
+++ b/devops/templates/all-tests-job-template.yml
@@ -54,51 +54,16 @@ jobs:
       pypiUrl: https://pypi.org/simple/
 
   steps:
-
-  - ${{ if notIn($(TestRunType), 'Unit', 'Notebooks') }}:
-    - script: exit 1
-      displayName: "Bad testRunType: $(TestRunType)"
-
-  - task: UsePythonVersion@0
-    displayName: 'Use Python $(PyVer)'
-    inputs:
-      versionSpec: '$(PyVer)' 
-      addToPath: true
-
-  - template: python-infra-upgrade-steps-template.yml
-
-  - template: requirements-installation-steps-template.yml
+  - template: test-run-step-template.yml
     parameters:
-      pyVer: '$(PyVer)'
-      requirementsFile: $(RequirementsFile)
+      testRunType: $(TestRunType)
+      installationType: ${{parameters.installationType}}
+      pythonVersion: $(PyVer)
       pinRequirements: ${{parameters.pinRequirements}}
-
-  - template: pip-freeze-to-artifact-steps-template.yml
-    parameters:
+      requirementsFile: $(RequirementsFile)
       freezeArtifact: $(FreezeArtifact)
       freezeFile: $(FreezeFile)
-
-  - template: fairlearn-installation-step-template.yml
-    parameters:
-      installationType: ${{parameters.installationType}}
+      # Following are used if the installationType is PyPI
       pypiUrl: $(pypiUrl)
       versionArtifactName: ${{parameters.versionArtifactName}}
       versionArtifactFile: ${{parameters.versionArtifactFile}}
-      pipVersionVariable: variableForPipVersion
-    
-  - script: flake8 .
-    displayName: "Run flake8"
-
-  # =================================================
-  - ${{ if eq($(TestRunType), 'Unit')}}:
-    - script: python -m pytest test/ --ignore=test/install -m "not notebooks" --junitxml=./TEST--TEST.xml -o junit_suite_name="$(Agent.JobName)"
-      displayName: 'Run unit tests'
-
-  - ${{ if eq($(TestRunType), 'Notebooks')}}:
-    - script: python -m pytest test/ -m notebooks --junitxml=./TEST-TEST.xml -o junit_suite_name="$(Agent.JobName)"
-      displayName: 'Run notebooks as tests'
-  # =================================================
-
-  - task: PublishTestResults@2
-    displayName: 'Publish Test Results **/TEST-*.xml'
-    condition: succeededOrFailed()

--- a/devops/templates/all-tests-job-template.yml
+++ b/devops/templates/all-tests-job-template.yml
@@ -1,21 +1,17 @@
-# Template for setting up the python environment (with optional pinned requirements)
-# and running all tests (except for install tests)
-
-# Some key parameters:
-
-# platform
-# A human-readable string which should be set to match vmImage
-
-# testRunType: {Unit, Notebooks}
-# Specifies the set of tests to be run
-
-# installationType: {None, PipLocal, PyPI}
-# Specifies how Fairlearn should be made available. Note
-# that the Notebooks tests will not work with 'None'
-# If PyPI is specified, then targetType, versionArtifactName
-# and versionArtifactFile need to be specified, in order to
-# determine which PyPI archive to use, and which version
-# of Fairlearn to fetch from it.
+# Template for running tests on multiple Python versions and platforms
+#
+# This is a driver for test-run-step-template.yml
+#
+# platforms is a dictionary to specify the VM images to use
+# for the runs. The keys are human-readable titles, the values
+# are vmImage names
+#
+# testRunTypes specifies the different test suites to run
+#
+# pyVersions lists the Python versions to use
+#
+# The set of jobs submitted is the Cartesian product of these
+# three parameters
 
 parameters:
   platforms: { Linux: ubuntu-latest, Windows: vs2017-win2016 }
@@ -31,13 +27,13 @@ parameters:
   versionArtifactFile:
 
 jobs:
-  - ${{ each p in parameters.platforms }}:
-    - ${{ each trt in parameters.testRunTypes }}:
+  - ${{ each plat in parameters.platforms }}:
+    - ${{ each testRunType in parameters.testRunTypes }}:
       - ${{ each pyVer in parameters.pyVersions }}:
         - job:
-          displayName: ${{ format('{0} {1} {2}', p.Key , trt, pyVer) }}
+          displayName: ${{ format('{0} {1} {2}', plat.Key , testRunType, pyVer) }}
           pool:
-            vmImage: ${{ p.value }}
+            vmImage: ${{ plat.value }}
 
           variables:
               ${{ if eq(parameters.targetType, 'Test') }}:
@@ -45,13 +41,13 @@ jobs:
               ${{ if eq(parameters.targetType, 'Prod') }}:
                 pypiUrl: https://pypi.org/simple/
               RequirementsFile: requirements-${{pyVer}}.txt
-              FreezeArtifact: '${{parameters.freezeArtifactStem}}${{p.Key}}${{trt}}${{pyVer}}'
-              FreezeFile: '${{parameters.freezeFileStem}}-${{p.Key}}${{trt}}${{pyVer}}.txt'
+              FreezeArtifact: '${{parameters.freezeArtifactStem}}-${{plat.Key}}-${{testRunType}}-${{pyVer}}'
+              FreezeFile: '${{parameters.freezeFileStem}}-${{plat.Key}}-${{testRunType}}-${{pyVer}}.txt'
 
           steps:
           - template: test-run-step-template.yml
             parameters:
-              testRunType: ${{trt}}
+              testRunType: ${{testRunType}}
               installationType: ${{parameters.installationType}}
               pythonVersion: ${{pyVer}}
               pinRequirements: ${{parameters.pinRequirements}}

--- a/devops/templates/all-tests-job-template.yml
+++ b/devops/templates/all-tests-job-template.yml
@@ -32,38 +32,33 @@ parameters:
   versionArtifactFile:
 
 jobs:
-- job: ${{ parameters.platform }}
-  pool:
-    vmImage: ${{ parameters.vmImage }}
-  strategy:
-    maxParallel: 4
-    matrix:
-      ${{ each pyVer in parameters.pyVersions }}:
-        ${{ each trt in parameters.testRunTypes }}:
-          ${{trt}}_${{ pyVer }}:
-            PyVer: ${{ pyVer }}
-            TestRunType: ${{trt}}
+  - ${{ each pyVer in parameters.pyVersions }}:
+    - ${{ each trt in parameters.testRunTypes }}:
+      - job:
+        displayName: ${{ format('{0} {1} {2}', parameters.platform , trt, pyVer }}
+        pool:
+          vmImage: ${{ parameters.vmImage }}
+
+        variables:
+            ${{ if eq(parameters.targetType, 'Test') }}:
+              pypiUrl: https://test.pypi.org/simple/
+            ${{ if eq(parameters.targetType, 'Prod') }}:
+              pypiUrl: https://pypi.org/simple/
             RequirementsFile: requirements-${{pyVer}}.txt
             FreezeArtifact: '${{parameters.freezeArtifactStem}}${{parameters.platform}}${{trt}}${{pyVer}}'
             FreezeFile: '${{parameters.freezeFileStem}}-${{parameters.name}}${{pyVer}}.txt'
 
-  variables:
-    ${{ if eq(parameters.targetType, 'Test') }}:
-      pypiUrl: https://test.pypi.org/simple/
-    ${{ if eq(parameters.targetType, 'Prod') }}:
-      pypiUrl: https://pypi.org/simple/
-
-  steps:
-  - template: test-run-step-template.yml
-    parameters:
-      testRunType: ${{trt}}
-      installationType: ${{parameters.installationType}}
-      pythonVersion: $(PyVer)
-      pinRequirements: ${{parameters.pinRequirements}}
-      requirementsFile: $(RequirementsFile)
-      freezeArtifact: $(FreezeArtifact)
-      freezeFile: $(FreezeFile)
-      # Following are used if the installationType is PyPI
-      pypiUrl: $(pypiUrl)
-      versionArtifactName: ${{parameters.versionArtifactName}}
-      versionArtifactFile: ${{parameters.versionArtifactFile}}
+        steps:
+        - template: test-run-step-template.yml
+          parameters:
+            testRunType: ${{trt}}
+            installationType: ${{parameters.installationType}}
+            pythonVersion: $(PyVer)
+            pinRequirements: ${{parameters.pinRequirements}}
+            requirementsFile: $(RequirementsFile)
+            freezeArtifact: $(FreezeArtifact)
+            freezeFile: $(FreezeFile)
+            # Following are used if the installationType is PyPI
+            pypiUrl: $(pypiUrl)
+            versionArtifactName: ${{parameters.versionArtifactName}}
+            versionArtifactFile: ${{parameters.versionArtifactFile}}

--- a/devops/templates/fairlearn-installation-step-template.yml
+++ b/devops/templates/fairlearn-installation-step-template.yml
@@ -9,20 +9,23 @@
 # `pip install` a wheel file from a pipeline Artifact
 
 parameters:
-  installationType: 'None'
-  pypiUrl:
-  versionArtifactName:
-  versionArtifactFile:
-  pipVersionVariable: 'pipVersionVar'
+- name: installationType
+  type: string
+  values:
+  - None
+  - PipLocal
+  - PyPI
+- name: pypiUrl
+  type: string
+- name: versionArtifactName
+  type: string
+- name: versionArtifactFile
+  type: string
+- name: pipVersionVariable
+  type: string
+  default: pipVersionVar
 
 steps:
-# Validation of installationType
-# Something is strange with template condition vs task condition
-- ${{ if notIn(parameters.installationType, 'None', 'PipLocal', 'PyPI') }}:
-  - script: exit 1
-    displayName: "Bad installationType: ${{parameters.installationType}}"
-    condition: notIn('${{parameters.installationType}}', 'None', 'PipLocal', 'PyPI')
-
 # ==============================================================
 # Install PipLocal
 - ${{ if eq(parameters.installationType, 'PipLocal') }}:

--- a/devops/templates/pypi-deployment-stages-template.yml
+++ b/devops/templates/pypi-deployment-stages-template.yml
@@ -99,12 +99,10 @@ stages:
   jobs:
   - template: all-tests-job-template.yml
     parameters:
-      platform: Linux
-      vmImage: 'ubuntu-16.04'
+      platforms:  { Linux: ubuntu-latest, Windows: vs2017-win2016 }
+      pyVersions: [3.5, 3.6, 3.7, 3.8]
       freezeArtifactStem: ${{parameters.freezeArtifactStem}}
       freezeFileStem: ${{parameters.freezeFileStem}}
-      pyVersions: [3.5, 3.6, 3.7, 3.8]
-      testRunType: 'Unit'
       installationType: 'PyPI'
       targetType: ${{parameters.targetType}}
       versionArtifactName: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
@@ -112,43 +110,9 @@ stages:
 
   - template: all-tests-job-template.yml
     parameters:
-      platform: Windows
-      vmImage: 'vs2017-win2016'
+      platforms: { MacOS: macos-latest }
+      testRunTypes: ['Unit']
       pyVersions: [3.5, 3.6, 3.7, 3.8]
-      testRunType: 'Unit'
-      installationType: 'PyPI'
-      targetType: ${{parameters.targetType}}
-      versionArtifactName: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
-      versionArtifactFile: '${{parameters.versionFileStem}}${{parameters.targetType}}'
-
-  - template: all-tests-job-template.yml
-    parameters:
-      platform: MacOS
-      vmImage: 'macos-latest'
-      pyVersions: [3.5, 3.6, 3.7, 3.8]
-      testRunType: 'Unit'
-      installationType: 'PyPI'
-      targetType: ${{parameters.targetType}}
-      versionArtifactName: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
-      versionArtifactFile: '${{parameters.versionFileStem}}${{parameters.targetType}}'
-
-  - template: all-tests-job-template.yml
-    parameters:
-      platform: Linux
-      vmImage: 'ubuntu-16.04'
-      pyVersions: [3.5, 3.6, 3.7, 3.8]
-      testRunType: 'Notebooks'
-      installationType: 'PyPI'
-      targetType: ${{parameters.targetType}}
-      versionArtifactName: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'
-      versionArtifactFile: '${{parameters.versionFileStem}}${{parameters.targetType}}'
-
-  - template: all-tests-job-template.yml
-    parameters:
-      platform: Windows
-      vmImage: 'vs2017-win2016'
-      pyVersions: [3.5, 3.6, 3.7, 3.8]
-      testRunType: 'Notebooks'
       installationType: 'PyPI'
       targetType: ${{parameters.targetType}}
       versionArtifactName: '${{parameters.versionArtifactStem}}${{parameters.targetType}}'

--- a/devops/templates/test-run-step-template.yml
+++ b/devops/templates/test-run-step-template.yml
@@ -12,7 +12,7 @@ parameters:
 - name: pinRequirements
   type: boolean
   default: False
-- name: requirementsFile:
+- name: requirementsFile
   type: string
 - name: freezeArtifact
   type: string

--- a/devops/templates/test-run-step-template.yml
+++ b/devops/templates/test-run-step-template.yml
@@ -1,9 +1,6 @@
 parameters:
 - name: testRunType
   type: string
-  values:
-  - Unit
-  - Notebooks
 - name: installationType
   type: string
 - name: pythonVersion
@@ -30,7 +27,8 @@ steps:
 
 - ${{ if notIn(parameters.testRunType, 'Unit', 'Notebooks') }}:
   - script: exit 1
-    displayName: "Bad testRunType: -${{parameters.testRunType}}-"
+    displayName: "Validate testRunType: ${{parameters.testRunType}}"
+    condition: notIn(${{parameters.testRunType, 'Unit', 'Notebooks'}})
 
 - task: UsePythonVersion@0
   displayName: 'Use Python ${{parameters.pythonVersion}}'

--- a/devops/templates/test-run-step-template.yml
+++ b/devops/templates/test-run-step-template.yml
@@ -28,7 +28,7 @@ steps:
 - ${{ if notIn(parameters.testRunType, 'Unit', 'Notebooks') }}:
   - script: exit 1
     displayName: "Validate testRunType: ${{parameters.testRunType}}"
-    condition: notIn(${{parameters.testRunType, 'Unit', 'Notebooks'}})
+    condition: notIn(${{parameters.testRunType}}, 'Unit', 'Notebooks')
 
 - task: UsePythonVersion@0
   displayName: 'Use Python ${{parameters.pythonVersion}}'

--- a/devops/templates/test-run-step-template.yml
+++ b/devops/templates/test-run-step-template.yml
@@ -15,7 +15,7 @@ steps:
 
 - ${{ if notIn(parameters.testRunType, 'Unit', 'Notebooks') }}:
   - script: exit 1
-    displayName: "Bad testRunType: ${{parameters.testRunType}}"
+    displayName: "Bad testRunType: -${{parameters.testRunType}}-"
 
 - task: UsePythonVersion@0
   displayName: 'Use Python ${{parameters.pythonVersion}}'

--- a/devops/templates/test-run-step-template.yml
+++ b/devops/templates/test-run-step-template.yml
@@ -1,3 +1,12 @@
+# Template to run a single set of tests
+# - Specifies Python version
+# - Installs requirements
+# - Saves 'pip freeze' to Artifact
+# - Installs fairlearn via specified means
+# - Runs flake8
+# - Runs specified test suite
+# - Saves test results
+
 parameters:
 - name: testRunType
   type: string

--- a/devops/templates/test-run-step-template.yml
+++ b/devops/templates/test-run-step-template.yml
@@ -1,15 +1,30 @@
 parameters:
-  testRunType: 'Unit'
-  installationType: 'None'
-  pythonVersion: 3.7
-  pinRequirements: False
-  requirementsFile:
-  freezeArtifact: 
-  freezeFile:
+- name: testRunType
+  type: string
+  values:
+  - Unit
+  - Notebooks
+- name: installationType
+  type: string
+- name: pythonVersion
+  type: number
+  default: 3.7
+- name: pinRequirements
+  type: boolean
+  default: False
+- name: requirementsFile:
+  type: string
+- name: freezeArtifact
+  type: string
+- name: freezeFile
+  type: string
   # Following are used if the installationType is PyPI
-  pypiUrl: 
-  versionArtifactName:
-  versionArtifactFile:
+- name: pypiUrl
+  type: string
+- name: versionArtifactName
+  type: string
+- name: versionArtifactFile
+  type: string
 
 steps:
 

--- a/devops/templates/test-run-step-template.yml
+++ b/devops/templates/test-run-step-template.yml
@@ -1,0 +1,62 @@
+parameters:
+  testRunType: 'Unit'
+  installationType: 'None'
+  pythonVersion: 3.7
+  pinRequirements: False
+  requirementsFile:
+  freezeArtifact: 
+  freezeFile:
+  # Following are used if the installationType is PyPI
+  pypiUrl: 
+  versionArtifactName:
+  versionArtifactFile:
+
+steps:
+
+- ${{ if notIn(parameters.testRunType, 'Unit', 'Notebooks') }}:
+  - script: exit 1
+    displayName: "Bad testRunType: parameters.testRunType"
+
+- task: UsePythonVersion@0
+  displayName: 'Use Python ${{parameters.pythonVersion}}'
+  inputs:
+    versionSpec: '${{parameters.pythonVersion}}' 
+    addToPath: true
+
+- template: python-infra-upgrade-steps-template.yml
+
+- template: requirements-installation-steps-template.yml
+  parameters:
+    pyVer: '${{parameters.pythonVersion}}'
+    requirementsFile: ${{parameters.requirementsFile}}
+    pinRequirements: ${{parameters.pinRequirements}}
+
+- template: pip-freeze-to-artifact-steps-template.yml
+  parameters:
+    freezeArtifact: ${{parameters.freezeArtifact}}
+    freezeFile: ${{parameters.freezeFile}}
+
+- template: fairlearn-installation-step-template.yml
+  parameters:
+    installationType: ${{parameters.installationType}}
+    pypiUrl: ${{parameters.pypiUrl}}
+    versionArtifactName: ${{parameters.versionArtifactName}}
+    versionArtifactFile: ${{parameters.versionArtifactFile}}
+    pipVersionVariable: variableForPipVersion
+  
+- script: flake8 .
+  displayName: "Run flake8"
+
+# =================================================
+- ${{ if eq(parameters.testRunType, 'Unit')}}:
+  - script: python -m pytest test/ --ignore=test/install -m "not notebooks" --junitxml=./TEST--TEST.xml -o junit_suite_name="$(Agent.JobName)"
+    displayName: 'Run unit tests'
+
+- ${{ if eq(parameters.testRunType, 'Notebooks')}}:
+  - script: python -m pytest test/ -m notebooks --junitxml=./TEST-TEST.xml -o junit_suite_name="$(Agent.JobName)"
+    displayName: 'Run notebooks as tests'
+# =================================================
+
+- task: PublishTestResults@2
+  displayName: 'Publish Test Results **/TEST-*.xml'
+  condition: succeededOrFailed()

--- a/devops/templates/test-run-step-template.yml
+++ b/devops/templates/test-run-step-template.yml
@@ -7,7 +7,7 @@ parameters:
 - name: installationType
   type: string
 - name: pythonVersion
-  type: number
+  type: string
   default: 3.7
 - name: pinRequirements
   type: boolean

--- a/devops/templates/test-run-step-template.yml
+++ b/devops/templates/test-run-step-template.yml
@@ -1,10 +1,13 @@
 parameters:
 - name: testRunType
   type: string
+  values:
+  - Unit
+  - Notebooks
 - name: installationType
   type: string
 - name: pythonVersion
-  type: string
+  type: number
   default: 3.7
 - name: pinRequirements
   type: boolean
@@ -28,7 +31,6 @@ steps:
 - ${{ if notIn(parameters.testRunType, 'Unit', 'Notebooks') }}:
   - script: exit 1
     displayName: "Validate testRunType: ${{parameters.testRunType}}"
-    condition: notIn(${{parameters.testRunType}}, 'Unit', 'Notebooks')
 
 - task: UsePythonVersion@0
   displayName: 'Use Python ${{parameters.pythonVersion}}'

--- a/devops/templates/test-run-step-template.yml
+++ b/devops/templates/test-run-step-template.yml
@@ -15,7 +15,7 @@ steps:
 
 - ${{ if notIn(parameters.testRunType, 'Unit', 'Notebooks') }}:
   - script: exit 1
-    displayName: "Bad testRunType: parameters.testRunType"
+    displayName: "Bad testRunType: ${{parameters.testRunType}}"
 
 - task: UsePythonVersion@0
   displayName: 'Use Python ${{parameters.pythonVersion}}'

--- a/devops/templates/test-run-step-template.yml
+++ b/devops/templates/test-run-step-template.yml
@@ -27,11 +27,6 @@ parameters:
   type: string
 
 steps:
-
-- ${{ if notIn(parameters.testRunType, 'Unit', 'Notebooks') }}:
-  - script: exit 1
-    displayName: "Validate testRunType: ${{parameters.testRunType}}"
-
 - task: UsePythonVersion@0
   displayName: 'Use Python ${{parameters.pythonVersion}}'
   inputs:


### PR DESCRIPTION
Refactor the job generation portions of the pipelines, so that more than the Python version is automatically expanded. The new system generates a job matrix which is a cartesian product over platforms, test runs and Python versions.

This is related to #371, but does not yet close that issue.