### PR TITLE
Enable GridSearch with more than 2 sensitive feature values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
   * Add `group_summary` transformers.
 * Fix warning due to changing default `dtype` when creating an empty
   `pandas.Series`.
+* Enable `GridSearch` for more than two sensitive features values.
 
 ### v0.4.5
 * Changes to `ThresholdOptimizer`:

--- a/fairlearn/_input_validation.py
+++ b/fairlearn/_input_validation.py
@@ -20,8 +20,6 @@ _MESSAGE_RATIO_NOT_IN_RANGE = "ratio must lie between (0,1]"
 _INPUT_DATA_FORMAT_ERROR_MESSAGE = "The only allowed input data formats for {} are: {}. " \
                                      "Your provided data was of type {}."
 _EMPTY_INPUT_ERROR_MESSAGE = "At least one of sensitive_features, labels, or scores are empty."
-_SENSITIVE_FEATURES_THRESHOLD_ERROR_TEMPLATE = "Sensitive features contain more than {} unique" \
-                                               " values"
 _LABELS_NOT_0_1_ERROR_MESSAGE = "Supplied y labels are not 0 or 1"
 _MORE_THAN_ONE_COLUMN_ERROR_MESSAGE = "{} is a {} with more than one column"
 _NOT_ALLOWED_TYPE_ERROR_MESSAGE = "{} is not an ndarray, Series or DataFrame"
@@ -35,8 +33,7 @@ _ALLOWED_INPUT_TYPES_Y = [np.ndarray, pd.DataFrame, pd.Series, list]
 _SENSITIVE_FEATURE_COMPRESSION_SEPARATOR = ","
 
 
-def _validate_and_reformat_input(X, y=None, expect_y=True, enforce_binary_labels=False, 
-                                 group_warn_threshold=None, **kwargs):
+def _validate_and_reformat_input(X, y=None, expect_y=True, enforce_binary_labels=False, **kwargs):
     """Validate input data and return the data in an appropriate format.
 
     :param X: The feature matrix
@@ -48,9 +45,6 @@ def _validate_and_reformat_input(X, y=None, expect_y=True, enforce_binary_labels
     :param enforce_binary_labels: if True raise exception if there are more than two distinct
         values in the `y` data; default False
     :type enforce_binary_labels: bool
-    :param group_warn_threshold: threshold on the number of groups as defined by sensitive
-        features above which a warning is displayed; default None
-    :type group_warn_threshold: int
     :return: the validated and reformatted X, y, and sensitive_features; note that certain
         estimators rely on metadata encoded in X which may be stripped during the reformatting
         process, so mitigation methods should ideally use the input X instead of the returned X
@@ -84,11 +78,6 @@ def _validate_and_reformat_input(X, y=None, expect_y=True, enforce_binary_labels
     if len(sensitive_features.shape) > 1 and sensitive_features.shape[1] > 1:
         sensitive_features = \
             _compress_multiple_sensitive_features_into_single_column(sensitive_features)
-
-    if group_warn_threshold is not None:
-        if len(np.unique(sensitive_features)) > group_warn_threshold:
-            logger.warning(_SENSITIVE_FEATURES_THRESHOLD_ERROR_TEMPLATE
-                           .format(group_warn_threshold))
 
     # If we don't have a y, then need to fiddle with return type to
     # avoid a warning from pandas

--- a/fairlearn/_input_validation.py
+++ b/fairlearn/_input_validation.py
@@ -1,10 +1,13 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+import logging
 import numpy as np
 import pandas as pd
 from sklearn.utils.validation import check_X_y, check_consistent_length, check_array
 
+
+logger = logging.getLogger(__file__)
 
 _KW_SENSITIVE_FEATURES = "sensitive_features"
 
@@ -17,7 +20,7 @@ _MESSAGE_RATIO_NOT_IN_RANGE = "ratio must lie between (0,1]"
 _INPUT_DATA_FORMAT_ERROR_MESSAGE = "The only allowed input data formats for {} are: {}. " \
                                      "Your provided data was of type {}."
 _EMPTY_INPUT_ERROR_MESSAGE = "At least one of sensitive_features, labels, or scores are empty."
-_SENSITIVE_FEATURES_NON_BINARY_ERROR_MESSAGE = "Sensitive features contain more than two unique" \
+_SENSITIVE_FEATURES_THRESHOLD_ERROR_TEMPLATE = "Sensitive features contain more than {} unique" \
                                                " values"
 _LABELS_NOT_0_1_ERROR_MESSAGE = "Supplied y labels are not 0 or 1"
 _MORE_THAN_ONE_COLUMN_ERROR_MESSAGE = "{} is a {} with more than one column"
@@ -32,8 +35,8 @@ _ALLOWED_INPUT_TYPES_Y = [np.ndarray, pd.DataFrame, pd.Series, list]
 _SENSITIVE_FEATURE_COMPRESSION_SEPARATOR = ","
 
 
-def _validate_and_reformat_input(X, y=None, expect_y=True, enforce_binary_sensitive_feature=False,
-                                 enforce_binary_labels=False, **kwargs):
+def _validate_and_reformat_input(X, y=None, expect_y=True, enforce_binary_labels=False, 
+                                 group_warn_threshold=None, **kwargs):
     """Validate input data and return the data in an appropriate format.
 
     :param X: The feature matrix
@@ -42,12 +45,12 @@ def _validate_and_reformat_input(X, y=None, expect_y=True, enforce_binary_sensit
     :type y: numpy.ndarray, pandas.DataFrame, pandas.Series, or list
     :param expect_y: if True y needs to be provided, otherwise ignores the argument; default True
     :type expect_y: bool
-    :param enforce_binary_sensitive_feature: if True raise exception if there are more than two
-        distinct values in the `sensitive_features` data from `kwargs`; default False
-    :type enforce_binary_sensitive_feature: bool
     :param enforce_binary_labels: if True raise exception if there are more than two distinct
         values in the `y` data; default False
     :type enforce_binary_labels: bool
+    :param group_warn_threshold: threshold on the number of groups as defined by sensitive
+        features above which a warning is displayed; default None
+    :type group_warn_threshold: int
     :return: the validated and reformatted X, y, and sensitive_features; note that certain
         estimators rely on metadata encoded in X which may be stripped during the reformatting
         process, so mitigation methods should ideally use the input X instead of the returned X
@@ -82,9 +85,10 @@ def _validate_and_reformat_input(X, y=None, expect_y=True, enforce_binary_sensit
         sensitive_features = \
             _compress_multiple_sensitive_features_into_single_column(sensitive_features)
 
-    if enforce_binary_sensitive_feature:
-        if len(np.unique(sensitive_features)) > 2:
-            raise ValueError(_SENSITIVE_FEATURES_NON_BINARY_ERROR_MESSAGE)
+    if group_warn_threshold is not None:
+        if len(np.unique(sensitive_features)) > group_warn_threshold:
+            logger.warning(_SENSITIVE_FEATURES_THRESHOLD_ERROR_TEMPLATE
+                           .format(group_warn_threshold))
 
     # If we don't have a y, then need to fiddle with return type to
     # avoid a warning from pandas

--- a/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
+++ b/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
@@ -194,6 +194,7 @@ class ExponentiatedGradient(BaseEstimator, MetaEstimatorMixin):
         :rtype: Scalar or vector
         """
         positive_probs = self._pmf_predict(X)[:, 1]
+        print(positive_probs)
         return (positive_probs >= np.random.rand(len(positive_probs))) * 1
 
     def _pmf_predict(self, X):
@@ -207,5 +208,7 @@ class ExponentiatedGradient(BaseEstimator, MetaEstimatorMixin):
         pred = pd.DataFrame()
         for t in range(len(self._hs)):
             pred[t] = self._hs[t](X)
+        print(pred)
         positive_probs = pred[self._weights.index].dot(self._weights).to_frame()
+        print(positive_probs)
         return np.concatenate((1-positive_probs, positive_probs), axis=1)

--- a/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
+++ b/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
@@ -194,7 +194,6 @@ class ExponentiatedGradient(BaseEstimator, MetaEstimatorMixin):
         :rtype: Scalar or vector
         """
         positive_probs = self._pmf_predict(X)[:, 1]
-        print(positive_probs)
         return (positive_probs >= np.random.rand(len(positive_probs))) * 1
 
     def _pmf_predict(self, X):
@@ -208,7 +207,5 @@ class ExponentiatedGradient(BaseEstimator, MetaEstimatorMixin):
         pred = pd.DataFrame()
         for t in range(len(self._hs)):
             pred[t] = self._hs[t](X)
-        print(pred)
         positive_probs = pred[self._weights.index].dot(self._weights).to_frame()
-        print(positive_probs)
         return np.concatenate((1-positive_probs, positive_probs), axis=1)

--- a/fairlearn/reductions/_grid_search/_grid_generator.py
+++ b/fairlearn/reductions/_grid_search/_grid_generator.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 GRID_DIMENSION_WARN_THRESHOLD = 4
 GRID_DIMENSION_WARN_TEMPLATE = "The grid has {} dimensions. It is not recommended to use more " \
                                "than {}, otherwise a prohibitively large grid size is required " \
-                               "to explore the grid thoroughly. For such cases consider using " \
+                               "to explore the space thoroughly. For such cases consider using " \
                                "ExponentiatedGradient from the fairlearn.reductions module."
 GRID_SIZE_WARN_TEMPLATE = "Generating a grid with {} grid points. It is recommended to use at " \
                           "least {} grid points. Please consider increasing grid_size."

--- a/fairlearn/reductions/_grid_search/_grid_generator.py
+++ b/fairlearn/reductions/_grid_search/_grid_generator.py
@@ -10,7 +10,11 @@ logger = logging.getLogger(__name__)
 
 GRID_DIMENSION_WARN_THRESHOLD = 4
 GRID_DIMENSION_WARN_TEMPLATE = "The grid has {} dimensions. It is not recommended to use more " \
-                               "than {}."
+                               "than {}, otherwise a prohibitively large grid size is required " \
+                               "to explore the grid thoroughly. For such cases consider using " \
+                               "ExponentiatedGradient from the fairlearn.reductions module."
+GRID_SIZE_WARN_TEMPLATE = "Generating a grid with {} grid points. It is recommended to use at " \
+                          "least {} grid points. Please consider increasing grid_size."
 
 
 class _GridGenerator:
@@ -28,9 +32,12 @@ class _GridGenerator:
         else:
             true_dim = self.dim
 
-        print(pos_basis)
         if true_dim > GRID_DIMENSION_WARN_THRESHOLD:
             logger.warning(GRID_DIMENSION_WARN_TEMPLATE, true_dim, GRID_DIMENSION_WARN_THRESHOLD)
+
+        recommended_min_grid_size = 2**true_dim
+        if grid_size < recommended_min_grid_size:
+            logger.warning(GRID_SIZE_WARN_TEMPLATE, grid_size, recommended_min_grid_size)
 
         # a conservative lower bound on the scaling parameter of the grid
         n_units = (float(grid_size) / (2.0**neg_allowed.sum())) ** (1.0 / true_dim) - 1

--- a/fairlearn/reductions/_grid_search/_grid_generator.py
+++ b/fairlearn/reductions/_grid_search/_grid_generator.py
@@ -1,8 +1,16 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+import logging
 import numpy as np
 import pandas as pd
+
+
+logger = logging.getLogger(__name__)
+
+GRID_DIMENSION_WARN_THRESHOLD = 4
+GRID_DIMENSION_WARN_TEMPLATE = "The grid has {} dimensions. It is not recommended to use more " \
+                               "than {}."
 
 
 class _GridGenerator:
@@ -20,8 +28,12 @@ class _GridGenerator:
         else:
             true_dim = self.dim
 
+        print(pos_basis)
+        if true_dim > GRID_DIMENSION_WARN_THRESHOLD:
+            logger.warning(GRID_DIMENSION_WARN_TEMPLATE, true_dim, GRID_DIMENSION_WARN_THRESHOLD)
+
         # a conservative lower bound on the scaling parameter of the grid
-        n_units = (float(grid_size) / (2.0**neg_allowed.sum())) ** (1.0 / true_dim) - 1   # noqa: E501
+        n_units = (float(grid_size) / (2.0**neg_allowed.sum())) ** (1.0 / true_dim) - 1
         n_units = int(np.floor(n_units))
         if n_units < 0:
             n_units = 0

--- a/fairlearn/reductions/_grid_search/grid_search.py
+++ b/fairlearn/reductions/_grid_search/grid_search.py
@@ -17,6 +17,7 @@ from ._grid_generator import _GridGenerator
 logger = logging.getLogger(__name__)
 
 TRADEOFF_OPTIMIZATION = "tradeoff_optimization"
+GROUP_WARN_THRESHOLD = 4
 
 
 class GridSearch(BaseEstimator, MetaEstimatorMixin):
@@ -114,8 +115,8 @@ class GridSearch(BaseEstimator, MetaEstimatorMixin):
             is_classification_reduction = False
 
         _, y_train, sensitive_features_train = _validate_and_reformat_input(
-            X, y, enforce_binary_sensitive_feature=True,
-            enforce_binary_labels=is_classification_reduction, **kwargs)
+            X, y, enforce_binary_labels=is_classification_reduction,
+            group_warn_threshold=GROUP_WARN_THRESHOLD, **kwargs)
 
         kwargs[_KW_SENSITIVE_FEATURES] = sensitive_features_train
 

--- a/fairlearn/reductions/_grid_search/grid_search.py
+++ b/fairlearn/reductions/_grid_search/grid_search.py
@@ -17,7 +17,6 @@ from ._grid_generator import _GridGenerator
 logger = logging.getLogger(__name__)
 
 TRADEOFF_OPTIMIZATION = "tradeoff_optimization"
-GROUP_WARN_THRESHOLD = 4
 
 
 class GridSearch(BaseEstimator, MetaEstimatorMixin):
@@ -115,8 +114,7 @@ class GridSearch(BaseEstimator, MetaEstimatorMixin):
             is_classification_reduction = False
 
         _, y_train, sensitive_features_train = _validate_and_reformat_input(
-            X, y, enforce_binary_labels=is_classification_reduction,
-            group_warn_threshold=GROUP_WARN_THRESHOLD, **kwargs)
+            X, y, enforce_binary_labels=is_classification_reduction, **kwargs)
 
         kwargs[_KW_SENSITIVE_FEATURES] = sensitive_features_train
 

--- a/test/unit/reductions/grid_search/test_grid_search_arguments.py
+++ b/test/unit/reductions/grid_search/test_grid_search_arguments.py
@@ -208,7 +208,6 @@ class ArgumentTests:
         grid_dimensions = n_groups - 1
 
         if 2**(n_groups-1) > grid_size:
-            print(log_records)
             assert len(log_records) == 1
             size_log_record = log_records[0]
             assert GRID_SIZE_WARN_TEMPLATE.format(grid_size, 2**grid_dimensions) \

--- a/test/unit/reductions/grid_search/utilities.py
+++ b/test/unit/reductions/grid_search/utilities.py
@@ -4,14 +4,23 @@
 import numpy as np
 
 
-def _quick_data(A_two_dim=False):
+def _quick_data(A_two_dim=False, n_groups=2):
     # Data are random and do not matter for these tests
     feature_1 = [0, 1, 2, 3, 4, 5, 6, 7]
     feature_2 = [5, 4, 3, 2, 7, 8, 3, 4]
     feature_3 = [9, 2, 4, 2, 9, 3, 1, 8]
     X = np.stack((feature_1, feature_2, feature_3), -1)
     Y = np.array([0, 1, 0, 1, 1, 1, 1, 0])
-    A = np.array([1, 0, 0, 0, 0, 1, 1, 1])
+
+    if n_groups == 2:
+        A = np.array([1, 0, 0, 0, 0, 1, 1, 1])
+    elif n_groups == 3:
+        A = np.array([1, 0, 2, 0, 0, 1, 2, 1])
+    elif n_groups == 4:
+        A = np.array([3, 0, 2, 0, 3, 1, 2, 1])
+    else:
+        raise ValueError("_quick_data only supports 2, 3, or 4 sensitive feature values.")
+
     if A_two_dim:
         # Grid Search is still restricted to binary sensitive features.
         # Even though we provide multiple columns of sensitive features,

--- a/test/unit/reductions/grid_search/utilities.py
+++ b/test/unit/reductions/grid_search/utilities.py
@@ -18,6 +18,8 @@ def _quick_data(A_two_dim=False, n_groups=2):
         A = np.array([1, 0, 2, 0, 0, 1, 2, 1])
     elif n_groups == 4:
         A = np.array([3, 0, 2, 0, 3, 1, 2, 1])
+    elif n_groups == 5:
+        A = np.array([3, 0, 2, 0, 3, 4, 2, 1])
     else:
         raise ValueError("_quick_data only supports 2, 3, or 4 sensitive feature values.")
 

--- a/test/unit/reductions/test_smoke.py
+++ b/test/unit/reductions/test_smoke.py
@@ -24,7 +24,8 @@ if platform.system() != "Darwin":
 @pytest.mark.parametrize("Mitigator", [ExponentiatedGradient, GridSearch])
 @pytest.mark.parametrize("Constraints", [DemographicParity, EqualizedOdds])
 @pytest.mark.parametrize("Estimator", _ESTIMATORS)
-def test_smoke(Mitigator, Constraints, Estimator):
+@pytest.mark.parametrize("n_sensitive_feature_values", [2, 3, 4, 10])
+def test_smoke(Mitigator, Constraints, Estimator, n_sensitive_feature_values):
     # This test case ensures that input validation doesn't remove metadata from the input
     # matrix X, as described at https://github.com/fairlearn/fairlearn/issues/312
     np.random.seed(0)
@@ -32,7 +33,7 @@ def test_smoke(Mitigator, Constraints, Estimator):
     X0 = np.random.normal(size=n)
     X1 = np.random.choice([1, 2, 3], size=n)
     Y = np.random.choice([0, 1], size=n)
-    A = np.random.choice([0, 1], size=n)
+    A = np.random.choice(list(range(n_sensitive_feature_values)), size=n)
     df = pd.DataFrame({"X0": X0, "X1": X1})
     # Set X1 as categorical
     df['X1'] = df['X1'].astype('category')


### PR DESCRIPTION
Closes #376 by removing the check for the number of sensitive features during input validation. To ensure that users still know that they shouldn't use GridSearch with many groups to avoid high-dimensional grids (which would be extremely costly to search thoroughly) we add a warning in the grid generation if `true_dim > 4` as an indication that the grid may get large. At the end of the day it should be up to the user to decide whether they want to explore it anyway, and this solution allows for that.

Signed-off-by: Roman Lutz <rolutz@microsoft.com>