### PR TITLE
Add grid offset to grid generator for grid search

### DIFF
--- a/fairlearn/reductions/_grid_search/_grid_generator.py
+++ b/fairlearn/reductions/_grid_search/_grid_generator.py
@@ -21,16 +21,35 @@ class _GridGenerator:
     """A generator of a grid of points with a bounded L1 norm."""
 
     def __init__(self, grid_size, grid_limit, pos_basis, neg_basis, neg_allowed, force_L1_norm,
-                 grid_center=None):
+                 grid_offset=None):
+        """Initialize with grid generator utility.
+
+        The `grid_size` is the number of columns to be generated in the grid.
+        :type grid_size: int
+
+        The `grid_limit` is the range of the values in the grid generated.
+        :type grid_limit: float
+
+        The `neg_allowed` ensures if we want to include negative values in the grid or not.
+        If True, the range is doubled.
+        :type neg_allowed: boolean
+
+        The `force_L1_norm`, if True, ensures that all points of the grid have the L1 norm equal
+        to grid_limit. If False, then grid consists of points whose L1 norm is less than equal to
+        grid_limit.
+        :type force_L1_norm: boolean
+
+        The `grid_offset` shifts the whole grid by that value.
+        :type grid_offset: float
+        """
         # grid parameters
         self.dim = len(pos_basis.columns)
         self.neg_allowed = neg_allowed
         self.force_L1_norm = force_L1_norm
-        if grid_center is None:
-            self.grid_center = pd.Series(np.zeros(pos_basis.shape[0], dtype=np.float64),
-                                         index=pos_basis.index)
+        if grid_offset is None:
+            self.grid_offset = pd.Series(0, index=pos_basis.index)
         else:
-            self.grid_center = grid_center
+            self.grid_offset = grid_offset
 
         # true dimensionality of the grid
         if self.force_L1_norm:
@@ -62,7 +81,7 @@ class _GridGenerator:
                 neg_coefs[neg_coefs < 0] = 0.0
                 # convert the grid of basis coefficients into a grid of lambda vectors
                 _grid = pos_basis.dot(pos_coefs) + neg_basis.dot(neg_coefs)
-                self.grid = _grid.add(self.grid_center, axis='index')
+                self.grid = _grid.add(self.grid_offset, axis='index')
                 break
             # if the grid size is not reached yet increase the scaling parameter
             n_units = n_units + 1

--- a/fairlearn/reductions/_grid_search/_grid_generator.py
+++ b/fairlearn/reductions/_grid_search/_grid_generator.py
@@ -40,7 +40,7 @@ class _GridGenerator:
         :type force_L1_norm: boolean
 
         The `grid_offset` shifts the whole grid by that value.
-        :type grid_offset: float
+        :type grid_offset: :class:`pandas:pandas.DataFrame`
         """
         # grid parameters
         self.dim = len(pos_basis.columns)

--- a/fairlearn/reductions/_grid_search/grid_search.py
+++ b/fairlearn/reductions/_grid_search/grid_search.py
@@ -53,7 +53,7 @@ class GridSearch(BaseEstimator, MetaEstimatorMixin):
 
     :param grid_offset: shifts the grid of Lagrangian multiplier by that value
          It is '0' by default
-    :type grid_offset: float
+    :type grid_offset: :class:`pandas:pandas.DataFrame`
 
     :param grid: Instead of supplying a size and limit for the grid, users may specify the exact
         set of Lagrange multipliers they desire using this argument.

--- a/fairlearn/reductions/_grid_search/grid_search.py
+++ b/fairlearn/reductions/_grid_search/grid_search.py
@@ -51,6 +51,10 @@ class GridSearch(BaseEstimator, MetaEstimatorMixin):
         distributed between :code:`-grid_limit` and :code:`grid_limit` by default
     :type grid_limit: float
 
+    :param grid_offset: shifts the grid of Lagrangian multiplier by that value
+         It is '0' by default
+    :type grid_offset: float
+
     :param grid: Instead of supplying a size and limit for the grid, users may specify the exact
         set of Lagrange multipliers they desire using this argument.
     """
@@ -62,6 +66,7 @@ class GridSearch(BaseEstimator, MetaEstimatorMixin):
                  constraint_weight=0.5,
                  grid_size=10,
                  grid_limit=2.0,
+                 grid_offset=0,
                  grid=None):
         """Construct a GridSearch object."""
         self.estimator = estimator
@@ -80,6 +85,7 @@ class GridSearch(BaseEstimator, MetaEstimatorMixin):
 
         self.grid_size = grid_size
         self.grid_limit = float(grid_limit)
+        self.grid_offset = float(grid_offset)
         self.grid = grid
 
         self._best_grid_index = None
@@ -137,7 +143,8 @@ class GridSearch(BaseEstimator, MetaEstimatorMixin):
                                   pos_basis,
                                   neg_basis,
                                   neg_allowed,
-                                  objective_in_the_span).grid
+                                  objective_in_the_span,
+                                  self.grid_offset).grid
         else:
             logger.debug("Using supplied grid")
             grid = self.grid

--- a/fairlearn/reductions/_grid_search/grid_search.py
+++ b/fairlearn/reductions/_grid_search/grid_search.py
@@ -66,7 +66,7 @@ class GridSearch(BaseEstimator, MetaEstimatorMixin):
                  constraint_weight=0.5,
                  grid_size=10,
                  grid_limit=2.0,
-                 grid_offset=0,
+                 grid_offset=None,
                  grid=None):
         """Construct a GridSearch object."""
         self.estimator = estimator
@@ -85,7 +85,7 @@ class GridSearch(BaseEstimator, MetaEstimatorMixin):
 
         self.grid_size = grid_size
         self.grid_limit = float(grid_limit)
-        self.grid_offset = float(grid_offset)
+        self.grid_offset = grid_offset
         self.grid = grid
 
         self._best_grid_index = None

--- a/test/unit/reductions/grid_search/test_grid_generator.py
+++ b/test/unit/reductions/grid_search/test_grid_generator.py
@@ -19,7 +19,7 @@ def test_grid_generator_demographic_parity(grid_size, grid_limit):
     disparity_moment = DemographicParity()
     events = [_ALL]
 
-    grid = calculate_grid(grid_limit, grid_size, disparity_moment, events)
+    grid = calculate_grid(grid_limit, grid_size, disparity_moment)
 
     expected_index = pd.MultiIndex.from_product([['+', '-'], events, [0, 1]],
                                                 names=[_SIGN, _EVENT, _GROUP_ID])
@@ -34,17 +34,18 @@ def test_grid_generator_demographic_parity(grid_size, grid_limit):
     assert np.isclose(expected_grid.values, grid.values).all()
 
 
-@pytest.mark.parametrize("grid_size", [5, 6, 10, 11, 100, 101, 102])
-@pytest.mark.parametrize("grid_limit", [1.0, 2.0, 4.0, 10.0])
-def test_grid_generator_demographic_parity_with_center(grid_size, grid_limit):
+@pytest.mark.parametrize("grid_size", [5, 6])
+@pytest.mark.parametrize("grid_limit", [1.0, 2.0])
+@pytest.mark.parametrize("grid_offset", [[0, 0, 0, 0], [0, 0, 0, 1], [0, 1, 0, 0],
+                                         [0, 0, 0, 0.2], [0, 0.2, 0, 0]])
+def test_grid_generator_demographic_parity_with_center(grid_size, grid_limit, grid_offset):
     disparity_moment = DemographicParity()
     events = [_ALL]
 
     _index = pd.MultiIndex.from_product([['+', '-'], events, [0, 1]],
                                         names=[_SIGN, _EVENT, _GROUP_ID])
-    add_val = 0.02
-    grid_center = pd.Series([0, 0, 0, add_val], index=_index)
-    grid = calculate_grid(grid_limit, grid_size, disparity_moment, events, grid_center)
+    grid_offset = pd.Series(grid_offset, _index)
+    grid = calculate_grid(grid_limit, grid_size, disparity_moment, grid_offset)
 
     expected_index = pd.MultiIndex.from_product([['+', '-'], events, [0, 1]],
                                                 names=[_SIGN, _EVENT, _GROUP_ID])
@@ -54,8 +55,10 @@ def test_grid_generator_demographic_parity_with_center(grid_size, grid_limit):
     step_size = 2 * grid_limit / grid_size_or_next_smaller_even_number
     for i in range(grid_size):
         expected_grid[i] = pd.Series(0.0, index=expected_index)
-        expected_grid[i]['-', _ALL, 1] = max(grid_limit - step_size * i, 0) + add_val
-        expected_grid[i]['+', _ALL, 1] = max(-grid_limit + step_size * i, 0)
+        expected_grid[i]['-', _ALL, 1] = max(grid_limit - step_size * i, 0) + \
+            grid_offset['-', _ALL, 1]
+        expected_grid[i]['+', _ALL, 1] = max(-grid_limit + step_size * i, 0) + \
+            grid_offset['+', _ALL, 1]
     assert np.isclose(expected_grid.values, grid.values).all()
 
 
@@ -70,7 +73,7 @@ def test_grid_generator_equalized_odds_basic(grid_limit):
     label1 = 'label=1'
     events = [label0, label1]
 
-    grid = calculate_grid(grid_limit, grid_size, disparity_moment, events)
+    grid = calculate_grid(grid_limit, grid_size, disparity_moment)
 
     expected_index = pd.MultiIndex.from_product([['+', '-'], events, [0, 1]],
                                                 names=[_SIGN, _EVENT, _GROUP_ID])
@@ -99,7 +102,7 @@ def test_grid_generator_equalized_odds(grid_limit, grid_size):
     label1 = 'label=1'
     events = [label0, label1]
 
-    grid = calculate_grid(grid_limit, grid_size, disparity_moment, events)
+    grid = calculate_grid(grid_limit, grid_size, disparity_moment)
 
     expected_index = pd.MultiIndex.from_product([['+', '-'], events, [0, 1]],
                                                 names=[_SIGN, _EVENT, _GROUP_ID])
@@ -117,9 +120,12 @@ def test_grid_generator_equalized_odds(grid_limit, grid_size):
     assert np.isclose(expected_grid.values, grid.values).all()
 
 
-@pytest.mark.parametrize("grid_limit", [0.1, 0.5, 1, 2, 5, 10, 99, 100])
+@pytest.mark.parametrize("grid_limit", [0.1, 2])
 @pytest.mark.parametrize("grid_size", [13])
-def test_grid_generator_equalized_odds_with_center(grid_limit, grid_size):
+@pytest.mark.parametrize("grid_offset", [[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0, 0, 0],
+                                         [0, 1, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0.2, 0, 0],
+                                         [0, 0, 0, 0, 0, 0, 0, 0.2]])
+def test_grid_generator_equalized_odds_with_center(grid_limit, grid_size, grid_offset):
     # Equalized odds has four rows with potential non-zero values in the grid.
     # With grid_size = 13 we get exactly one column with the grid_limit value per row,
     # one column with half the grid_limit value per row, and combinations of rows
@@ -131,9 +137,8 @@ def test_grid_generator_equalized_odds_with_center(grid_limit, grid_size):
 
     _index = pd.MultiIndex.from_product([['+', '-'], events, [0, 1]],
                                         names=[_SIGN, _EVENT, _GROUP_ID])
-    add_val = 0.02
-    grid_center = pd.Series([0, 0, 0, 0, 0, 0, 0, add_val], index=_index)
-    grid = calculate_grid(grid_limit, grid_size, disparity_moment, events, grid_center)
+    grid_offset = pd.Series(grid_offset, index=_index)
+    grid = calculate_grid(grid_limit, grid_size, disparity_moment, grid_offset)
 
     expected_index = pd.MultiIndex.from_product([['+', '-'], events, [0, 1]],
                                                 names=[_SIGN, _EVENT, _GROUP_ID])
@@ -143,21 +148,23 @@ def test_grid_generator_equalized_odds_with_center(grid_limit, grid_size):
         expected_grid[i] = pd.Series(0.0, index=expected_index)
 
     gl = grid_limit  # abbreviation for readibility
-    expected_grid.loc['+', label0, 1] = [0, 0, 0, 0, 0, 0, 0, 0, 0, gl/2, gl/2, gl/2, gl]
-    expected_grid.loc['+', label1, 1] = [0, 0, 0, gl/2, 0, 0, 0, gl/2, gl, 0, 0, gl/2, 0]
-    expected_grid.loc['-', label0, 1] = [gl, gl/2, gl/2, gl/2, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-    expected_grid.loc['-', label1, 1] = [add_val, gl/2 + add_val, add_val, add_val, gl + add_val,
-                                         gl/2 + add_val, add_val, add_val, add_val,
-                                         gl/2 + add_val, add_val, add_val, add_val]
+    expected_grid.loc['+', label0, 1] = [0, 0, 0, 0, 0, 0, 0, 0, 0, gl/2, gl/2, gl/2, gl] + \
+        grid_offset['+', label0, 1]
+    expected_grid.loc['+', label1, 1] = [0, 0, 0, gl/2, 0, 0, 0, gl/2, gl, 0, 0, gl/2, 0] + \
+        grid_offset['+', label1, 1]
+    expected_grid.loc['-', label0, 1] = [gl, gl/2, gl/2, gl/2, 0, 0, 0, 0, 0, 0, 0, 0, 0] + \
+        grid_offset['-', label0, 1]
+    expected_grid.loc['-', label1, 1] = [0, gl/2, 0, 0, gl, gl/2, 0, 0, 0, gl/2, 0, 0, 0] + \
+        grid_offset['-', label1, 1]
 
     assert np.isclose(expected_grid.values, grid.values).all()
 
 
-def calculate_grid(grid_limit, grid_size, disparity_moment, events, grid_center=None):
+def calculate_grid(grid_limit, grid_size, disparity_moment, grid_offset=None):
     X, y, A = _quick_data()
 
     disparity_moment.load_data(X, y, sensitive_features=A)
 
     return _GridGenerator(grid_size, grid_limit,
                           disparity_moment.pos_basis, disparity_moment.neg_basis,
-                          disparity_moment.neg_basis_present, False, grid_center).grid
+                          disparity_moment.neg_basis_present, False, grid_offset).grid

--- a/test/unit/reductions/grid_search/test_grid_generator.py
+++ b/test/unit/reductions/grid_search/test_grid_generator.py
@@ -36,8 +36,8 @@ def test_grid_generator_demographic_parity(grid_size, grid_limit):
 
 @pytest.mark.parametrize("grid_size", [5, 6])
 @pytest.mark.parametrize("grid_limit", [1.0, 2.0])
-@pytest.mark.parametrize("grid_offset", [[0, 0, 0, 0], [0, 0, 0, 1], [0, 1, 0, 0],
-                                         [0, 0, 0, 0.2], [0, 0.2, 0, 0]])
+@pytest.mark.parametrize("grid_offset", [[0, 0.2, 0, 0], [0, 0, 0, 1], [0, 1, 0, 0],
+                                         [0, 0, 0, 0.2]])
 def test_grid_generator_demographic_parity_with_center(grid_size, grid_limit, grid_offset):
     disparity_moment = DemographicParity()
     events = [_ALL]
@@ -122,9 +122,8 @@ def test_grid_generator_equalized_odds(grid_limit, grid_size):
 
 @pytest.mark.parametrize("grid_limit", [0.1, 2])
 @pytest.mark.parametrize("grid_size", [13])
-@pytest.mark.parametrize("grid_offset", [[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0, 0, 0],
-                                         [0, 1, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0.2, 0, 0],
-                                         [0, 0, 0, 0, 0, 0, 0, 0.2]])
+@pytest.mark.parametrize("grid_offset", [[0, 0, 0, 0, 0, 0, 0, 0.2], [0, 0, 0, 1, 0, 0, 0, 0],
+                                         [0, 1, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0.2, 0, 0]])
 def test_grid_generator_equalized_odds_with_center(grid_limit, grid_size, grid_offset):
     # Equalized odds has four rows with potential non-zero values in the grid.
     # With grid_size = 13 we get exactly one column with the grid_limit value per row,

--- a/test/unit/reductions/grid_search/test_grid_search_demographicparity.py
+++ b/test/unit/reductions/grid_search/test_grid_search_demographicparity.py
@@ -82,11 +82,9 @@ def test_demographicparity_fair_uneven_populations(A_two_dim):
     assert np.array_equal(sample_results, [1, 0])
 
 
-@pytest.mark.parametrize("A_two_dim", [False, True])
-def test_demographicparity_fair_uneven_populations_with_grid_offset(A_two_dim):
-    # Variant of test_demographicparity_already_fair, which has unequal
-    # populations in the two classes
-    # Also allow the threshold to be adjustable
+@pytest.mark.parametrize("A_two_dim", [False])
+@pytest.mark.parametrize("offset", [[0, 0.2, 0, 0]])
+def test_demographicparity_fair_uneven_populations_with_grid_offset(A_two_dim, offset):
     # Grid of Lagrangian multipliers has some initial offset
 
     score_threshold = 0.625
@@ -98,7 +96,9 @@ def test_demographicparity_fair_uneven_populations_with_grid_offset(A_two_dim):
     a1_label = 37
 
     grid_size = 11
-    grid_offset = 0.25
+    iterables = [['+', '-'], ['all'], [a0_label, a1_label]]
+    midx = pd.MultiIndex.from_product(iterables, names=['sign', 'event', 'group_id'])
+    grid_offset = pd.Series(offset, index=midx)
 
     X, Y, A = _simple_threshold_data(number_a0, number_a1,
                                      score_threshold, score_threshold,
@@ -120,7 +120,7 @@ def test_demographicparity_fair_uneven_populations_with_grid_offset(A_two_dim):
     assert np.array_equal(sample_results, [0, 1])
 
     sample_proba = grid_search.predict_proba(test_X)
-    assert np.allclose(sample_proba, [[0.53748641, 0.46251359], [0.46688736, 0.53311264]])
+    assert np.allclose(sample_proba, [[0.55069845, 0.44930155], [0.41546008, 0.58453992]])
 
     sample_results = grid_search._predictors[0].predict(test_X)
     assert np.array_equal(sample_results, [1, 0])


### PR DESCRIPTION
### What's in the PR?

- Addition of grid offset in the grid generator. This is required for grid search algorithm when we  want the grid to be shifted by a lambda vector provided by the user.

Tests:
- Added unit test for generation of grid around user defined lambda vector.
- Added grid search with grid offset test case.