### PR TITLE
Fix flake8

### DIFF
--- a/devops/templates/pip-freeze-to-artifact-steps-template.yml
+++ b/devops/templates/pip-freeze-to-artifact-steps-template.yml
@@ -7,7 +7,7 @@ parameters:
 
   
 steps:
-  - script: pip freeze > ${{parameters.freezeFile}}
+  - script: pip freeze --all > ${{parameters.freezeFile}}
     displayName: "Run pip freeze"
 
   - task: PublishPipelineArtifact@1

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ max-line-length = 99
 enable-extensions = G
 
 # An update to pip has resulted in `pip install .` leaving a 'build' directory around
-# Also: 'pip freeze' does not report the pip version
+# Also: 'pip freeze' does not report the pip version by default
 exclude =
     build/
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,10 @@
 max-line-length = 99
 enable-extensions = G
 
+# An update to pip has resulted in `pip install .` leaving a 'build' directory around
+exclude =
+    build/
+
 # Suppress particular flake8 warnings
 # Ideally for the fairlearn directory (which becomes the published wheel) we would have no
 # suppressions. For the following reasons, we still have some remaining:

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ max-line-length = 99
 enable-extensions = G
 
 # An update to pip has resulted in `pip install .` leaving a 'build' directory around
+# Also: 'pip freeze' does not report the pip version
 exclude =
     build/
 


### PR DESCRIPTION
An update to `pip` changed the behaviour of `pip install .` resulting in a copy of the code being left in a `build` directory. This did not match the `per-file-ignores` set for flake8.

This changeset applies two fixes:
- Have `build` in the ignore list for flake8
- Ensure that `pip freeze` also reports the `pip` version in future