### PR TITLE
Fix for Nightly-Fixed

### DIFF
--- a/devops/nightly-requirements-fixed.yml
+++ b/devops/nightly-requirements-fixed.yml
@@ -23,7 +23,7 @@ pool:
 jobs:
 - template: templates/all-tests-job-template.yml
   parameters:
-    platforms:  { Linux: ubuntu-latest, Windows: vs2017-win2016, MacOS: macos-latest }
+    platforms:  { Linux: ubuntu-latest, Windows: vs2017-win2016 }
     installationType: 'PipLocal'
     pyVersions: [3.6, 3.7, 3.8]
     freezeArtifactStem: $(FreezeArtifactStem)

--- a/devops/nightly-requirements-fixed.yml
+++ b/devops/nightly-requirements-fixed.yml
@@ -23,7 +23,7 @@ pool:
 jobs:
 - template: templates/all-tests-job-template.yml
   parameters:
-    platforms:  { Linux: ubuntu-latest, Windows: vs2017-win2016 }
+    platforms:  { Linux: ubuntu-latest, Windows: vs2017-win2016, MacOS: macos-latest }
     installationType: 'PipLocal'
     pyVersions: [3.6, 3.7, 3.8]
     freezeArtifactStem: $(FreezeArtifactStem)

--- a/devops/nightly-requirements-fixed.yml
+++ b/devops/nightly-requirements-fixed.yml
@@ -25,7 +25,7 @@ jobs:
   parameters:
     platforms:  { Linux: ubuntu-latest, Windows: vs2017-win2016 }
     installationType: 'PipLocal'
-    pyVersions: [3.5, 3.6, 3.7, 3.8]
+    pyVersions: [3.6, 3.7, 3.8]
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFileStem: $(FreezeFileStem)
     pinRequirements: True


### PR DESCRIPTION
Get the Nightly-Fixed build green again by dropping Python 3.5. Since several of our dependencies are dropping Python 3.5 support, it does not make sense to keep it in our builds if giving trouble.