### PR TITLE
Fix incorrect ADO string

### DIFF
--- a/devops/templates/all-tests-job-template.yml
+++ b/devops/templates/all-tests-job-template.yml
@@ -40,7 +40,7 @@ jobs:
           variables:
             ${{ if eq(parameters.targetType, 'Test') }}:
               pypiUrl: https://test.pypi.org/simple/
-            ${{ if eq(parameters.targetType, 'Prod') }}:
+            ${{ if eq(parameters.targetType, 'Production') }}:
               pypiUrl: https://pypi.org/simple/
             RequirementsFile: requirements-${{pyVer}}.txt
             FreezeArtifact: '${{parameters.freezeArtifactStem}}-${{plat.Key}}-${{testRunType}}-${{pyVer}}'


### PR DESCRIPTION
An incorrect match string for Production caused the final stage of our release pipeline to fail.

Signed-off-by: Richard Edgar <riedgar@microsoft.com>