### PR TITLE
Remove sklearn workaround for UCI Notebook

### DIFF
--- a/notebooks/Binary Classification with the UCI Credit-card Default Dataset.ipynb
+++ b/notebooks/Binary Classification with the UCI Credit-card Default Dataset.ipynb
@@ -248,10 +248,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# The following works around an incompatiblity between LightGBM and the latest sklearn\n",
-    "import sklearn\n",
-    "sklearn.set_config(print_changed_only=False)\n",
-    "\n",
     "model.fit(df_train, Y_train)"
    ]
   },
@@ -667,7 +663,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
An update to `scikit-learn` had required a workaround, but a subsequent release has removed this need.