### PR TITLE
Add ReadMe about notebook versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,12 @@ For instructions on how to install Fairlearn check out our [Quickstart guide](ht
 ## Usage
 
 For common usage refer to the [Jupyter notebooks](./notebooks) and our
-[user guide](https://fairlearn.github.io/user_guide/index.html)
+[user guide](https://fairlearn.github.io/user_guide/index.html).
+Please note that our APIs are subject to change, so notebooks downloaded
+from `master` may not be compatible with Fairlearn installed with `pip`.
+In this case, please navigate the tags in the repository
+(e.g. [v0.4.5](https://github.com/fairlearn/fairlearn/tree/v0.4.5))
+to locate the appropriate version of the notebook.
 
 ## Contributing
 

--- a/notebooks/ReadMe.md
+++ b/notebooks/ReadMe.md
@@ -3,10 +3,10 @@
 We are still exploring possibilities for the APIs in Fairlearn,
 meaning that we sometimes have breaking changes.
 As a result, notebooks taken from the `master` branch on GitHub may
-not always be compatible with a version of Fairlearn installed using `pip` (notebooks on `master` will always
-be compatible with `master`).
+not always be compatible with a version of Fairlearn installed using
+`pip` (notebooks on `master` will always be compatible with `master`).
 
-If you encounter compatibility problems with notebooks, go to your terminal and try running:
+If you encounter compatibility problems with notebooks, go to your terminal and run:
 ```
 pip show fairlearn
 ```
@@ -16,3 +16,6 @@ Then, on the GitHub page, navigate to that version
 (e.g. [v0.4.5](https://github.com/fairlearn/fairlearn/tree/v0.4.5) or
 [v0.4.6](https://github.com/fairlearn/fairlearn/tree/v0.4.6)),
 and download the notebooks from there.
+
+Alternatively, [install Fairlearn from a cloned repository](https://fairlearn.github.io/contributor_guide/development_process.html#advanced-installation-instructions)
+in order to use the notebooks from `master`.

--- a/notebooks/ReadMe.md
+++ b/notebooks/ReadMe.md
@@ -1,0 +1,18 @@
+# Notebooks and Fairlearn Versioning
+
+We are still exploring possibilities for the APIs in Fairlearn,
+meaning that we sometimes have breaking changes.
+As a result, notebooks taken from the `master` branch on GitHub may
+not always be compatible with a version of Fairlearn installed using `pip` (notebooks on `master` will always
+be compatible with `master`).
+
+If you encounter compatibility problems with notebooks, go to your terminal and try running:
+```
+pip show fairlearn
+```
+to show the version of Fairlean which you currently have
+installed.
+Then, on the GitHub page, navigate to that version
+(e.g. [v0.4.5](https://github.com/fairlearn/fairlearn/tree/v0.4.5) or
+[v0.4.6](https://github.com/fairlearn/fairlearn/tree/v0.4.6)),
+and download the notebooks from there.


### PR DESCRIPTION
Add a short ReadMe to the notebooks, explaining the need to keep the version aligned with whatever is `pip install`ed. This may help with things like #448 , but the real solution is to reduce our API breaks.