### PR TITLE
[theme support] Minor styling changes in the intro tab and header banner

### DIFF
--- a/fairlearn/widget/js/package.json
+++ b/fairlearn/widget/js/package.json
@@ -59,4 +59,4 @@
   "jupyterlab": {
     "extension": "lib/labplugin"
   }
-}
+} 

--- a/fairlearn/widget/js/package.json
+++ b/fairlearn/widget/js/package.json
@@ -51,7 +51,7 @@
     "@jupyter-widgets/base": "^1.1.10",
     "css-loader": "^2.1.1",
     "lodash": "^4.17.11",
-    "fairlearn-dashboard": "0.0.20",
+    "fairlearn-dashboard": "0.0.20-beta.3",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "style-loader": "^0.23.1"

--- a/fairlearn/widget/js/package.json
+++ b/fairlearn/widget/js/package.json
@@ -51,7 +51,7 @@
     "@jupyter-widgets/base": "^1.1.10",
     "css-loader": "^2.1.1",
     "lodash": "^4.17.11",
-    "fairlearn-dashboard": "0.0.20-beta.3",
+    "fairlearn-dashboard": "0.0.20",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "style-loader": "^0.23.1"

--- a/fairlearn/widget/js/package.json
+++ b/fairlearn/widget/js/package.json
@@ -59,4 +59,4 @@
   "jupyterlab": {
     "extension": "lib/labplugin"
   }
-} 
+}

--- a/visualization/FairnessDashboard/src/Controls/IntroTab.styles.ts
+++ b/visualization/FairnessDashboard/src/Controls/IntroTab.styles.ts
@@ -24,11 +24,13 @@ export const IntroTabStyles: () => IProcessedStyleSet<IIntroTabStyles> = () => {
         },
         firstSectionTitle: {
             fontSize: "60px",
-            fontWeight: FontWeights.light
+            fontWeight: FontWeights.light,
+            lineHeight: "50px"
         },
         firstSectionSubtitle: {
             fontSize: "60px",
-            fontWeight: FontWeights.semibold
+            fontWeight: FontWeights.semibold,
+            lineHeight: "50px"
         },
         firstSectionBody: {
             paddingTop: "30px",

--- a/visualization/FairnessDashboard/src/Controls/IntroTab.styles.ts
+++ b/visualization/FairnessDashboard/src/Controls/IntroTab.styles.ts
@@ -25,18 +25,19 @@ export const IntroTabStyles: () => IProcessedStyleSet<IIntroTabStyles> = () => {
         firstSectionTitle: {
             fontSize: "60px",
             fontWeight: FontWeights.light,
-            lineHeight: "50px"
+            lineHeight: "82px"
         },
         firstSectionSubtitle: {
             fontSize: "60px",
             fontWeight: FontWeights.semibold,
-            lineHeight: "50px"
+            lineHeight: "82px"
         },
         firstSectionBody: {
             paddingTop: "30px",
             paddingBottom: "70px",
             maxWidth: "500px",
             fontWeight: FontWeights.semilight,
+            lineHeight: "24px"
         },
         lowerSection: {
             padding: "50px 70px 90px 90px",
@@ -59,7 +60,8 @@ export const IntroTabStyles: () => IProcessedStyleSet<IIntroTabStyles> = () => {
         },
         numericLabel: {
             fontWeight: FontWeights.bold,
-            width: "30px"
+            width: "30px",
+            lineHeight: "24px"
         },
         explanatoryStep: {
             maxWidth: "300px",

--- a/visualization/FairnessDashboard/src/WizardReport.styles.ts
+++ b/visualization/FairnessDashboard/src/WizardReport.styles.ts
@@ -59,6 +59,7 @@ export const WizardReportStyles: () => IProcessedStyleSet<IWizardReportStyles> =
         },
         metricText: {
             color: theme.semanticColors.bodyText,
+            paddingTop: "8px",
             paddingRight: "12px",
             fontWeight: FontWeights.light
         },

--- a/visualization/FairnessDashboard/src/WizardReport.styles.ts
+++ b/visualization/FairnessDashboard/src/WizardReport.styles.ts
@@ -59,9 +59,11 @@ export const WizardReportStyles: () => IProcessedStyleSet<IWizardReportStyles> =
         },
         metricText: {
             color: theme.semanticColors.bodyText,
-            paddingTop: "8px",
+            //paddingTop: "8px",
+            lineHeight: "44px",
             paddingRight: "12px",
-            fontWeight: FontWeights.light
+            fontWeight: FontWeights.light,
+            fontSize: "36px"
         },
         firstMetricLabel: {
             color: theme.semanticColors.bodyText,
@@ -69,7 +71,8 @@ export const WizardReportStyles: () => IProcessedStyleSet<IWizardReportStyles> =
             maxWidth: "120px",
             borderRight: "1px solid",
             borderRightColor: theme.semanticColors.bodyDivider,
-            marginRight: "20px"
+            marginRight: "20px",
+            lineHeight: "16px"
         },
         metricLabel: {
             color: theme.semanticColors.bodyText,

--- a/visualization/FairnessDashboard/src/WizardReport.styles.ts
+++ b/visualization/FairnessDashboard/src/WizardReport.styles.ts
@@ -59,10 +59,9 @@ export const WizardReportStyles: () => IProcessedStyleSet<IWizardReportStyles> =
         },
         metricText: {
             color: theme.semanticColors.bodyText,
-            //paddingTop: "8px",
-            lineHeight: "44px",
             paddingRight: "12px",
             fontWeight: FontWeights.light,
+            lineHeight: "44px",
             fontSize: "36px"
         },
         firstMetricLabel: {

--- a/visualization/FairnessDashboard/src/WizardReport.tsx
+++ b/visualization/FairnessDashboard/src/WizardReport.tsx
@@ -364,9 +364,9 @@ export class WizardReport extends React.PureComponent<IReportProps, IState> {
                 <Text variant={"mediumPlus"} className={styles.headerTitle}>{localization.Report.title}</Text>
                 <div className={styles.bannerWrapper}>
                     <div className={styles.headerBanner}>
-                        <Text variant={"xxLargePlus"} className={styles.metricText} block>{globalAccuracyString}</Text>
+                        <Text className={styles.metricText} block>{globalAccuracyString}</Text>
                         <Text className={styles.firstMetricLabel} block>{localization.formatString(localization.Report.globalAccuracyText, selectedMetric.alwaysUpperCase ? selectedMetric.title : selectedMetric.title.toLowerCase())}</Text>
-                        <Text variant={"xxLargePlus"} className={styles.metricText} block>{disparityAccuracyString}</Text>
+                        <Text className={styles.metricText} block>{disparityAccuracyString}</Text>
                         <Text className={styles.metricLabel} block>{localization.formatString(localization.Report.accuracyDisparityText, selectedMetric.alwaysUpperCase ? selectedMetric.title : selectedMetric.title.toLowerCase())}</Text>
                     </div>
                     <ActionButton


### PR DESCRIPTION
Note: Only the banner change is a required style change. 
The "welcome" tab fix is needed only if the user does `pip install .` 
There will be no new pypi release to support theme 

related PRs: 
https://github.com/fairlearn/fairlearn/pull/453
https://github.com/fairlearn/fairlearn/pull/445

Screenshots from my local widget testing: 
![image](https://user-images.githubusercontent.com/16737404/84347191-e5092700-ab7f-11ea-903c-b1a25b91064e.png)

![image](https://user-images.githubusercontent.com/16737404/84347115-b8eda600-ab7f-11ea-857c-1724f02ecd5e.png)
![image](https://user-images.githubusercontent.com/16737404/84347124-c014b400-ab7f-11ea-851b-4e7caa9741ff.png)
![image](https://user-images.githubusercontent.com/16737404/84347148-ca36b280-ab7f-11ea-9e0f-26050fbbb3a0.png)
![image](https://user-images.githubusercontent.com/16737404/84347165-d1f65700-ab7f-11ea-8f26-47d69afe3b37.png)
![image](https://user-images.githubusercontent.com/16737404/84347184-dc185580-ab7f-11ea-804e-999abfc4ea3b.png)


