### PR TITLE
Website: Fix buttons on desktop layout

### DIFF
--- a/docs/_templates/index.html
+++ b/docs/_templates/index.html
@@ -51,7 +51,7 @@
 		        <div class="col-sm-12 col-lg-6 order-lg-1 text-center pt-5 pb-4 px-5">
 		          <img class="img-fluid rounded" src="_static/images/header-image.png" alt="">
 		        </div>
-		        <div class="col-11 col-lg-5 order-lg-0">
+		        <div class="col-11 col-lg-6 order-lg-0">
 		        	<div class="row">
 		        		<div class="col-12">
 		          			<h1 class="text-center text-md-left pb-2">Think fairness.<br>Build for everyone.</h1>


### PR DESCRIPTION
The main call to action buttons on the website overlap at ~1000px width.

I didn't look at the build failures, as I'm assuming they are being discussed in https://github.com/fairlearn/fairlearn/issues/472.

### before, 1000px width: the buttons overlap
![image](https://user-images.githubusercontent.com/1056957/84433521-67373100-abfc-11ea-869f-a575223b29c7.png)

### after, 1000px width: buttons are ok
![image](https://user-images.githubusercontent.com/1056957/84433617-9057c180-abfc-11ea-9363-f64905e7b0fd.png)


### after, iPhone6 ish
<img width="408" alt="Screen Shot 2020-06-11 at 3 56 58 PM" src="https://user-images.githubusercontent.com/1056957/84433559-77e7a700-abfc-11ea-86cf-da999da3ac27.png">
