### PR TITLE
Website: Change top navbar to link to documentation

### DIFF
--- a/docs/_templates/index.html
+++ b/docs/_templates/index.html
@@ -27,10 +27,10 @@
       		<div class="collapse navbar-collapse" id="navbarResponsive">
 		        <ul class="navbar-nav ml-auto text-center">
 		          <li class="nav-item pr-0 pr-lg-4">
-		            <a class="nav-link" href="#fairness-in-ai">Fairness in AI</a>
+		            <a class="nav-link" href="https://fairlearn.github.io/user_guide/index.html">User Guide</a>
 		          </li>
 		          <li class="nav-item pr-0 pr-lg-4">
-		            <a class="nav-link" href="#about-fairlearn">About Fairlearn</a>
+		            <a class="nav-link" href="https://fairlearn.github.io/api_reference/index.html">API Docs</a>
 		          </li>
 		          <li class="nav-item pr-0 pr-lg-4">
 		            <a class="nav-link" href="#contribute">Contribute</a>


### PR DESCRIPTION
The website has two links in the top navbar, but right now they just scroll down to a section on that page that doesn't correspond to what the links say.

This PR removes those links, and replaces them with links the User Guide and API Docs, with the assumption that people trying to get a sense of the project can scroll to scan, and that we sholud enable people who land here knowing what they to get to it directly.  Right now the only way to get to the website outside of the two main call-to-action buttons is the User Guide link buried in the footer.

### Now
"Fairness in AI" scrolls to "How Fairlearn Works" and "About Fairlearn" scrolls to "Why Fairlearn?"
<img width="1063" alt="Screen Shot 2020-06-12 at 3 08 29 PM" src="https://user-images.githubusercontent.com/1056957/84538045-e9882980-acbe-11ea-8faa-31c633fdb621.png">

## After this pull request
<img width="1065" alt="Screen Shot 2020-06-12 at 3 08 24 PM" src="https://user-images.githubusercontent.com/1056957/84538093-07558e80-acbf-11ea-9563-3c3c529a4fbc.png">

