### PR TITLE
Convert quickstart to use doctest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,12 @@ jobs:
           command: sudo pip install -r requirements.txt
       
       - run:
-          name: 'Build'
-          command: python -m sphinx -b html -j auto docs docs/_build/html
+          name: 'Build doctest'
+          command: python -m sphinx -b doctest -n -j auto docs docs/_build/html
+
+      - run:
+          name: 'Build html'
+          command: python -m sphinx -b html -n -j auto docs docs/_build/html
 
       - persist_to_workspace:
           root: docs/_build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,14 +38,14 @@ release = fairlearn.__version__
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "sphinx.ext.autodoc",
-    "sphinx.ext.napoleon",
-    "sphinx.ext.intersphinx",
-    "sphinx.ext.linkcode",
-    "sphinx.ext.extlinks",
-    "sphinx.ext.mathjax",
-    "sphinx_gallery.gen_gallery",
-    "sphinx.ext.doctest"
+    'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
+    'sphinx.ext.extlinks',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.linkcode',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.napoleon',
+    'sphinx_gallery.gen_gallery'
 ]
 
 intersphinx_mapping = {'python3': ('https://docs.python.org/3', None),
@@ -109,8 +109,8 @@ pygments_style = 'sphinx'
 # quickstart examples are only generated, but not shown in the gallery
 # since they are only needed for the quickstart page itself.
 sphinx_gallery_conf = {
-     'examples_dirs': ['../examples/quickstart', '../examples/notebooks'],
-     'gallery_dirs': ['auto_examples/quickstart', 'auto_examples/notebooks'],
+    'examples_dirs': ['../examples/quickstart', '../examples/notebooks'],
+    'gallery_dirs': ['auto_examples/quickstart', 'auto_examples/notebooks'],
 }
 
 
@@ -164,6 +164,6 @@ mathjax_config = {
             "E": '{\\mathbb{E}}',
             "P": '{\\mathbb{P}}',
             "given": '\\mathbin{\\vert}'
-            }
         }
     }
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,8 @@ extensions = [
     "sphinx.ext.linkcode",
     "sphinx.ext.extlinks",
     "sphinx.ext.mathjax",
-    "sphinx_gallery.gen_gallery"
+    "sphinx_gallery.gen_gallery",
+    "sphinx.ext.doctest"
 ]
 
 intersphinx_mapping = {'python3': ('https://docs.python.org/3', None),

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -99,7 +99,7 @@ we can evaluate metrics to get a group summary as below:
     DecisionTreeClassifier(...)
     >>> y_pred = classifier.predict(X)
     >>> group_summary(accuracy_score, y_true, y_pred, sensitive_features=sex)
-    {'overall': 0.9844..., 'by_group': {'female': 0.925..., 'male': 0.804...}}
+    {'overall': 0.844..., 'by_group': {'female': 0.925..., 'male': 0.804...}}
 
 Additionally, Fairlearn has lots of other standard metrics built-in, such as
 selection rate, i.e., the percentage of the population with label 1:

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -99,7 +99,7 @@ we can evaluate metrics to get a group summary as below:
     DecisionTreeClassifier(...)
     >>> y_pred = classifier.predict(X)
     >>> group_summary(accuracy_score, y_true, y_pred, sensitive_features=sex)
-    {'overall': 0.844..., 'by_group': {'female': 0.925..., 'male': 0.804...}}
+    {'overall': 0.9844..., 'by_group': {'female': 0.925..., 'male': 0.804...}}
 
 Additionally, Fairlearn has lots of other standard metrics built-in, such as
 selection rate, i.e., the percentage of the population with label 1:

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -99,7 +99,7 @@ we can evaluate metrics to get a group summary as below:
     DecisionTreeClassifier(...)
     >>> y_pred = classifier.predict(X)
     >>> group_summary(accuracy_score, y_true, y_pred, sensitive_features=sex)
-    {'overall': 0.8445686557538159, 'by_group': {'female': 0.9256336459010306, 'male': 0.8044974759063791}}
+    {'overall': 0.844..., 'by_group': {'female': 0.925..., 'male': 0.804...}}
 
 Additionally, Fairlearn has lots of other standard metrics built-in, such as
 selection rate, i.e., the percentage of the population with label 1:
@@ -108,7 +108,7 @@ selection rate, i.e., the percentage of the population with label 1:
 
     >>> from fairlearn.metrics import selection_rate_group_summary
     >>> selection_rate_group_summary(y_true, y_pred, sensitive_features=sex)
-    {'overall': 0.1615429501550935, 'by_group': {'female': 0.059418809766966854, 'male': 0.21202386415787058}}
+    {'overall': 0.161..., 'by_group': {'female': 0.059..., 'male': 0.212...}}
 
 For a visual representation of the metrics try out the Fairlearn dashboard.
 While this page shows only screenshots, the actual dashboard is interactive.
@@ -155,7 +155,7 @@ a vastly reduced difference in selection rate:
     >>> y_pred_mitigated = mitigator.predict(X)
     >>> 
     >>> selection_rate_group_summary(y_true, y_pred_mitigated, sensitive_features=sex)
-    {'overall': 0.15503209360891865, 'by_group': {'female': 0.142976511001764, 'male': 0.160991280403855}}
+    {'overall': 0.155..., 'by_group': {'female': 0.142..., 'male': 0.160...}}
 
 Similarly, we can explore the difference between the initial model and the
 mitigated model with respect to selection rate and accuracy in the dashboard

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -117,9 +117,9 @@ While this page shows only screenshots, the actual dashboard is interactive.
 
     >>> from fairlearn.widget import FairlearnDashboard
     >>> FairlearnDashboard(sensitive_features=sex,
-    ...                       sensitive_feature_names=['sex'],
-    ...                       y_true=y_true,
-    ...                       y_pred={"initial model": y_pred}) # doctest: +SKIP
+    ...                    sensitive_feature_names=['sex'],
+    ...                    y_true=y_true,
+    ...                    y_pred={"initial model": y_pred}) # doctest: +SKIP
 
 .. image:: ../img/fairlearn-dashboard-start.png
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -61,12 +61,18 @@ For this example we use the
 objective is to predict whether a person makes more (label 1) or less (0)
 than $50,000 a year.
 
+.. doctest::
+
     >>> import numpy as np 
     >>> import matplotlib.pyplot as plt 
     >>> from shap.datasets import adult  # shap is only used its dataset utility
     >>> X, y_true = adult()
     >>> y_true = y_true * 1
     >>> sex = X['Sex'].apply(lambda sex: "female" if sex == 0 else "male")
+    >>> sex.value_counts()
+    male      21790
+    female    10771
+    Name: Sex, dtype: int64
 
 .. figure:: auto_examples/quickstart/images/sphx_glr_plot_adult_dataset_001.png
    :target: auto_examples/quickstart/plot_adult_dataset.html
@@ -82,19 +88,23 @@ definitions from
 `scikit-learn <https://scikit-learn.org/stable/modules/classes.html#module-sklearn.metrics>`_
 we can evaluate metrics to get a group summary as below:
 
+.. doctest::
+
     >>> from fairlearn.metrics import group_summary
     >>> from sklearn.metrics import accuracy_score
     >>> from sklearn.tree import DecisionTreeClassifier
     >>> 
     >>> classifier = DecisionTreeClassifier(min_samples_leaf=10, max_depth=4)
     >>> classifier.fit(X, y_true)
-    >>> 
+    DecisionTreeClassifier(...)
     >>> y_pred = classifier.predict(X)
     >>> group_summary(accuracy_score, y_true, y_pred, sensitive_features=sex)
     {'overall': 0.8445686557538159, 'by_group': {'female': 0.9256336459010306, 'male': 0.8044974759063791}}
 
 Additionally, Fairlearn has lots of other standard metrics built-in, such as
 selection rate, i.e., the percentage of the population with label 1:
+
+.. doctest::
 
     >>> from fairlearn.metrics import selection_rate_group_summary
     >>> selection_rate_group_summary(y_true, y_pred, sensitive_features=sex)
@@ -103,11 +113,13 @@ selection rate, i.e., the percentage of the population with label 1:
 For a visual representation of the metrics try out the Fairlearn dashboard.
 While this page shows only screenshots, the actual dashboard is interactive.
 
+.. doctest::
+
     >>> from fairlearn.widget import FairlearnDashboard
     >>> FairlearnDashboard(sensitive_features=sex,
-                           sensitive_feature_names=['sex'],
-                           y_true=y_true,
-                           y_pred={"initial model": y_pred})
+    ...                       sensitive_feature_names=['sex'],
+    ...                       y_true=y_true,
+    ...                       y_pred={"initial model": y_pred}) # doctest: +SKIP
 
 .. image:: ../img/fairlearn-dashboard-start.png
 
@@ -150,9 +162,9 @@ mitigated model with respect to selection rate and accuracy in the dashboard
 through a multi-model comparison:
 
     >>> FairlearnDashboard(sensitive_features=sex,
-                           sensitive_feature_names=['sex'],
-                           y_true=y_true,
-                           y_pred={"initial model": y_pred, "mitigated model": y_pred_mitigated})
+    ...                    sensitive_feature_names=['sex'],
+    ...                    y_true=y_true,
+    ...                    y_pred={"initial model": y_pred, "mitigated model": y_pred_mitigated}) # doctest: +SKIP
 
 .. image:: ../img/fairlearn-dashboard-comparison.png
 


### PR DESCRIPTION
The `quickstart.rst` document contains Python code which a user ought to be able to run. Use the `doctest` extension for Sphinx to enable this.