### PR TITLE
Add doctest to metric section in userguide

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       
       - run:
           name: 'Build doctest'
-          command: python -m sphinx -b doctest -n -j auto docs docs/_build/html
+          command: python -m sphinx -v -b doctest -n -j auto docs docs/_build/html
 
       - run:
           name: 'Build html'

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -61,7 +61,7 @@ For this example we use the
 objective is to predict whether a person makes more (label 1) or less (0)
 than $50,000 a year.
 
-.. doctest::
+.. doctest:: quickstart
 
     >>> import numpy as np 
     >>> import matplotlib.pyplot as plt 
@@ -88,7 +88,7 @@ definitions from
 `scikit-learn <https://scikit-learn.org/stable/modules/classes.html#module-sklearn.metrics>`_
 we can evaluate metrics to get a group summary as below:
 
-.. doctest::
+.. doctest:: quickstart
 
     >>> from fairlearn.metrics import group_summary
     >>> from sklearn.metrics import accuracy_score
@@ -104,7 +104,7 @@ we can evaluate metrics to get a group summary as below:
 Additionally, Fairlearn has lots of other standard metrics built-in, such as
 selection rate, i.e., the percentage of the population with label 1:
 
-.. doctest::
+.. doctest:: quickstart
 
     >>> from fairlearn.metrics import selection_rate_group_summary
     >>> selection_rate_group_summary(y_true, y_pred, sensitive_features=sex)
@@ -113,7 +113,7 @@ selection rate, i.e., the percentage of the population with label 1:
 For a visual representation of the metrics try out the Fairlearn dashboard.
 While this page shows only screenshots, the actual dashboard is interactive.
 
-.. doctest::
+.. doctest:: quickstart
 
     >>> from fairlearn.widget import FairlearnDashboard
     >>> FairlearnDashboard(sensitive_features=sex,
@@ -145,6 +145,8 @@ such decisions. The Exponentiated Gradient mitigation technique used fits the
 provided classifier using Demographic Parity as the objective, leading to
 a vastly reduced difference in selection rate:
 
+.. doctest:: quickstart
+
     >>> from fairlearn.reductions import ExponentiatedGradient, DemographicParity
     >>> np.random.seed(0)  # set seed for consistent results with ExponentiatedGradient
     >>> 
@@ -160,6 +162,8 @@ a vastly reduced difference in selection rate:
 Similarly, we can explore the difference between the initial model and the
 mitigated model with respect to selection rate and accuracy in the dashboard
 through a multi-model comparison:
+
+.. doctest:: quickstart
 
     >>> FairlearnDashboard(sensitive_features=sex,
     ...                    sensitive_feature_names=['sex'],

--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -58,8 +58,6 @@ the following set of labels:
     >>> import pandas as pd
     >>> group_membership_data = ['d', 'a', 'c', 'b', 'b', 'c', 'c', 'c',
     ...                          'b', 'd', 'c', 'a', 'b', 'd', 'c', 'c']
-    >>> pd.set_option('expand_frame_repr', True)
-    >>> pd.set_option('display.max_columns', 20)
     >>> pd.set_option('display.width', 80)
     >>> pd.DataFrame({ 'Y_true': Y_true,
     ...                'Y_pred': Y_pred,

--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -136,8 +136,8 @@ is called :py:func:`fairlearn.metrics.make_metric_group_summary`:
     >>> recall_score_group_summary = flm.make_metric_group_summary(skm.recall_score)
     >>> results = recall_score_group_summary(Y_true, Y_pred, sensitive_features=group_membership_data)
     >>> print("Overall recall = ", results.overall)
-    >>> print("recall by groups = ", results.by_group)
     Overall recall =  0.5
+    >>> print("recall by groups = ", results.by_group)
     recall by groups =  {'a': 0.0, 'b': 0.5, 'c': 0.75, 'd': 0.0}
 
 .. _dashboard:

--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -78,6 +78,7 @@ the following set of labels:
     13       1       0                     d
     14       1       0                     c
     15       1       1                     c
+    <BLANKLINE>
 
 We then calculate a group metric:
 

--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -32,7 +32,7 @@ input data. The `scikit-learn` package implements this in
 Suppose we have the following data we can see that the prediction is `1` in five
 of the ten cases where the true value is `1`, so we expect the recall to be 0.5:
 
-.. doctest::
+.. doctest:: assessment_metrics
 
     >>> import sklearn.metrics as skm
     >>> Y_true = [0, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 1, 1, 1]
@@ -52,7 +52,7 @@ set of data.
 Suppose in addition to the :math:`Y_{true}` and :math:`Y_{pred}` above, we had
 the following set of labels:
 
-.. doctest::
+.. doctest:: assessment_metrics
     :options: +NORMALIZE_WHITESPACE
 
     >>> import pandas as pd
@@ -76,6 +76,10 @@ the following set of labels:
     14       1       0                     c
     15       1       1                     c
 
+We then calculate a group metric:
+
+.. doctest:: assessment_metrics
+
     >>> import fairlearn.metrics as flm
     >>> group_metrics = flm.group_summary(skm.recall_score, 
     ...                                   Y_true, Y_pred,
@@ -93,6 +97,8 @@ we calculated by inspection from the table above.
 In addition to these basic scores, :py:func:`fairlearn.metrics` also provides
 convenience functions to recover the maximum and minimum values of the metric
 across groups and also the difference and ratio between the maximum and minimum:
+
+.. doctest:: assessment_metrics
 
     >>> print("min recall over groups = ", flm.group_min_from_summary(group_metrics))
     min recall over groups =  0.0
@@ -124,6 +130,8 @@ Convenience Wrapper
 Rather than require a call to :code:`group_summary` each time, Fairlearn also
 provides a function which turns an ungrouped metric into a grouped one. This
 is called :py:func:`fairlearn.metrics.make_metric_group_summary`:
+
+.. doctest:: assessment_metrics
 
     >>> recall_score_group_summary = flm.make_metric_group_summary(skm.recall_score)
     >>> results = recall_score_group_summary(Y_true, Y_pred, sensitive_features=group_membership_data)

--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -59,6 +59,8 @@ the following set of labels:
     >>> group_membership_data = ['d', 'a', 'c', 'b', 'b', 'c', 'c', 'c',
     ...                          'b', 'd', 'c', 'a', 'b', 'd', 'c', 'c']
     >>> pd.set_option('expand_frame_repr', True)
+    >>> pd.set_option('display.max_columns', 20)
+    >>> pd.set_option('display.width', 80)
     >>> pd.DataFrame({ 'Y_true': Y_true,
     ...                'Y_pred': Y_pred,
     ...                'group_membership_data': group_membership_data})

--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -86,8 +86,8 @@ We then calculate a group metric:
     ...                                   sensitive_features=group_membership_data,
     ...                                   sample_weight=None)
     >>> print("Overall recall = ", group_metrics.overall)
-    >>> print("recall by groups = ", group_metrics.by_group)
     Overall recall =  0.5
+    >>> print("recall by groups = ", group_metrics.by_group)
     recall by groups =  {'a': 0.0, 'b': 0.5, 'c': 0.75, 'd': 0.0}
 
 Note that the overall recall is the same as that calculated above in the

--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -58,6 +58,7 @@ the following set of labels:
     >>> import pandas as pd
     >>> group_membership_data = ['d', 'a', 'c', 'b', 'b', 'c', 'c', 'c',
     ...                          'b', 'd', 'c', 'a', 'b', 'd', 'c', 'c']
+    >>> pd.set_option('display.max_columns', 20)
     >>> pd.set_option('display.width', 80)
     >>> pd.DataFrame({ 'Y_true': Y_true,
     ...                'Y_pred': Y_pred,

--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -32,6 +32,8 @@ input data. The `scikit-learn` package implements this in
 Suppose we have the following data we can see that the prediction is `1` in five
 of the ten cases where the true value is `1`, so we expect the recall to be 0.5:
 
+.. doctest::
+
     >>> import sklearn.metrics as skm
     >>> Y_true = [0, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 1, 1, 1]
     >>> Y_pred = [0, 0, 1, 0, 1, 1, 1, 0, 0, 1, 1, 1, 1, 0, 0, 1]
@@ -49,6 +51,9 @@ set of data.
 
 Suppose in addition to the :math:`Y_{true}` and :math:`Y_{pred}` above, we had
 the following set of labels:
+
+.. doctest::
+    :options: +NORMALIZE_WHITESPACE
 
     >>> import pandas as pd
     >>> group_membership_data = ['d', 'a', 'c', 'b', 'b', 'c', 'c', 'c', 'b', 'd', 'c', 'a', 'b', 'd', 'c', 'c']
@@ -72,10 +77,13 @@ the following set of labels:
     15       1       1                     c
 
     >>> import fairlearn.metrics as flm
-    >>> group_metrics = flm.group_summary(skm.recall_score, Y_true, Y_pred, sensitive_features=group_membership_data, sample_weight=None)
+    >>> group_metrics = flm.group_summary(skm.recall_score, 
+    ...                                   Y_true, Y_pred,
+    ...                                   sensitive_features=group_membership_data,
+    ...                                   sample_weight=None)
     >>> print("Overall recall = ", group_metrics.overall)
-    Overall recall =  0.5
     >>> print("recall by groups = ", group_metrics.by_group)
+    Overall recall =  0.5
     recall by groups =  {'a': 0.0, 'b': 0.5, 'c': 0.75, 'd': 0.0}
 
 Note that the overall recall is the same as that calculated above in the

--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -61,23 +61,23 @@ the following set of labels:
     >>> pd.DataFrame({ 'Y_true': Y_true,
     ...                'Y_pred': Y_pred,
     ...                'group_membership_data': group_membership_data})
-             Y_true  Y_pred     group_membership_data
-    0        0       0          d
-    1        1       0          a
-    2        1       1          c
-    3        1       0          b
-    4        1       1          b
-    5        0       1          c
-    6        1       1          c
-    7        0       0          c
-    8        1       0          b
-    9        0       1          d
-    10       0       1          c
-    11       0       1          a
-    12       1       1          b
-    13       1       0          d
-    14       1       0          c
-    15       1       1          c
+        Y_true  Y_pred group_membership_data
+    0        0       0                     d
+    1        1       0                     a
+    2        1       1                     c
+    3        1       0                     b
+    4        1       1                     b
+    5        0       1                     c
+    6        1       1                     c
+    7        0       0                     c
+    8        1       0                     b
+    9        0       1                     d
+    10       0       1                     c
+    11       0       1                     a
+    12       1       1                     b
+    13       1       0                     d
+    14       1       0                     c
+    15       1       1                     c
 
 We then calculate a group metric:
 

--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -56,25 +56,28 @@ the following set of labels:
     :options: +NORMALIZE_WHITESPACE
 
     >>> import pandas as pd
-    >>> group_membership_data = ['d', 'a', 'c', 'b', 'b', 'c', 'c', 'c', 'b', 'd', 'c', 'a', 'b', 'd', 'c', 'c']
-    >>> pd.DataFrame({ 'Y_true': Y_true, 'Y_pred': Y_pred, 'group_membership_data': group_membership_data})
-    Y_true  Y_pred group_membership_data
-    0        0       0                     d
-    1        1       0                     a
-    2        1       1                     c
-    3        1       0                     b
-    4        1       1                     b
-    5        0       1                     c
-    6        1       1                     c
-    7        0       0                     c
-    8        1       0                     b
-    9        0       1                     d
-    10       0       1                     c
-    11       0       1                     a
-    12       1       1                     b
-    13       1       0                     d
-    14       1       0                     c
-    15       1       1                     c
+    >>> group_membership_data = ['d', 'a', 'c', 'b', 'b', 'c', 'c', 'c',
+    ...                          'b', 'd', 'c', 'a', 'b', 'd', 'c', 'c']
+    >>> pd.DataFrame({ 'Y_true': Y_true,
+    ...                'Y_pred': Y_pred,
+    ...                'group_membership_data': group_membership_data})
+             Y_true  Y_pred     group_membership_data
+    0        0       0          d
+    1        1       0          a
+    2        1       1          c
+    3        1       0          b
+    4        1       1          b
+    5        0       1          c
+    6        1       1          c
+    7        0       0          c
+    8        1       0          b
+    9        0       1          d
+    10       0       1          c
+    11       0       1          a
+    12       1       1          b
+    13       1       0          d
+    14       1       0          c
+    15       1       1          c
 
 We then calculate a group metric:
 

--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -58,6 +58,7 @@ the following set of labels:
     >>> import pandas as pd
     >>> group_membership_data = ['d', 'a', 'c', 'b', 'b', 'c', 'c', 'c',
     ...                          'b', 'd', 'c', 'a', 'b', 'd', 'c', 'c']
+    >>> pd.set_option('expand_frame_repr', True)
     >>> pd.DataFrame({ 'Y_true': Y_true,
     ...                'Y_pred': Y_pred,
     ...                'group_membership_data': group_membership_data})

--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -53,7 +53,7 @@ Suppose in addition to the :math:`Y_{true}` and :math:`Y_{pred}` above, we had
 the following set of labels:
 
 .. doctest:: assessment_metrics
-    :options: +NORMALIZE_WHITESPACE
+    :options:  +NORMALIZE_WHITESPACE
 
     >>> import pandas as pd
     >>> group_membership_data = ['d', 'a', 'c', 'b', 'b', 'c', 'c', 'c',


### PR DESCRIPTION
The "metrics" portion of the Assessment user guide page was originally a notebook. Convert the embedded code snippets to `doctest` blocks, so that Sphinx can verify that they execute correctly.