### PR TITLE
Documentation: Add microrubric for critiques

### DIFF
--- a/docs/contributor_guide/contributing_example_notebooks.rst
+++ b/docs/contributor_guide/contributing_example_notebooks.rst
@@ -6,7 +6,7 @@ We'd love to collaborate with anyone interested in describing scenarios for usin
 When discussing and critiquing examples, here are some lenses to consider:
 
 Microrubric for critiques:
-"""""""""""""""""""""
+"""""""""""""""""""""""""""""""""""
 1. **Deployment context**: Describes a real deployment context, not just a dataset.
 2. **For developers**: Speaks the language of developers and data scientists.  Considers real practitioner needs.  Fits within the lifecycle of real practioner work.  See `Holstein et al (2019) <https://arxiv.org/pdf/1812.05239.pdf>`_, `Madaio et al. (2020) <http://www.jennwv.com/papers/checklists.pdf>`_.
 3. **Sociotechnical**: Models the team's value that fairness as a sociotechnical challenge.    Avoids abstraction traps.  See `Selbst et al. (2020) <https://andrewselbst.files.wordpress.com/2019/10/selbst-et-al-fairness-and-abstraction-in-sociotechnical-systems.pdf>`_.

--- a/docs/contributor_guide/contributing_example_notebooks.rst
+++ b/docs/contributor_guide/contributing_example_notebooks.rst
@@ -8,9 +8,9 @@ When discussing and critiquing examples, here are some lenses to consider:
 Microrubric for critiques:
 """""""""""""""""""""""""""""""""""
 1. **Deployment context**: Describes a real deployment context, not just a dataset.
-2. **For developers**: Speaks the language of developers and data scientists.  Considers real practitioner needs.  Fits within the lifecycle of real practioner work.  See `Holstein et al (2019) <https://arxiv.org/pdf/1812.05239.pdf>`_, `Madaio et al. (2020) <http://www.jennwv.com/papers/checklists.pdf>`_.
+2. **Real harms**: Focuses on real harms to real people.  See `Blodget et al. (2020) <https://arxiv.org/abs/2005.14050>`_.
 3. **Sociotechnical**: Models the team's value that fairness as a sociotechnical challenge.    Avoids abstraction traps.  See `Selbst et al. (2020) <https://andrewselbst.files.wordpress.com/2019/10/selbst-et-al-fairness-and-abstraction-in-sociotechnical-systems.pdf>`_.
 4. **Substantiated**: Discusses trade-offs and compares alternatives. Describes why using particular Fairlearn functionalities makes sense.
-5. **Real harms**: Focuses on real harms to real people.  See `Blodget et al. (2020) <https://arxiv.org/abs/2005.14050>`_.
+5. **For developers**: Speaks the language of developers and data scientists.  Considers real practitioner needs.  Fits within the lifecycle of real practioner work.  See `Holstein et al (2019) <https://arxiv.org/pdf/1812.05239.pdf>`_, `Madaio et al. (2020) <http://www.jennwv.com/papers/checklists.pdf>`_.
 
 If you'd like to collaborate, please :ref:`reach out <communication>`.

--- a/docs/contributor_guide/contributing_example_notebooks.rst
+++ b/docs/contributor_guide/contributing_example_notebooks.rst
@@ -1,7 +1,7 @@
 Contributing example notebooks
 ------------------------------
 
-We'd love to collaborate with anyone interested in describing scenarios for using fairlearn!
+We'd love to collaborate with anyone interested in describing scenarios for using Fairlearn!
 
 When discussing and critiquing examples, here are some lenses to consider:
 
@@ -10,7 +10,7 @@ Microrubric for critiques:
 1. **Deployment context**: Describes a real deployment context, not just a dataset.
 2. **For developers**: Speaks the language of developers and data scientists.  Considers real practitioner needs.  Fits within the lifecycle of real practioner work.  See `Holstein et al (2019) <https://arxiv.org/pdf/1812.05239.pdf>`_, `Madaio et al. (2020) <http://www.jennwv.com/papers/checklists.pdf>`_.
 3. **Sociotechnical**: Models the team's value that fairness as a sociotechnical challenge.    Avoids abstraction traps.  See `Selbst et al. (2020) <https://andrewselbst.files.wordpress.com/2019/10/selbst-et-al-fairness-and-abstraction-in-sociotechnical-systems.pdf>`_.
-4. **Open**:  Discusses tradeoffs and compares alternatives.  Illustrates how fairlearn contributes.
+4. **Open**:  Discusses tradeoffs and compares alternatives.  Illustrates how Fairlearn contributes.
 5. **Real harms**: Focuses on real harms to real people.  See `Blodget et al. (2020) <https://arxiv.org/abs/2005.14050>`_.
 
-If you'd like to collaborate, please reach out in gitter or open an issue!
+If you'd like to collaborate, please :ref:`reach out <communication>`.

--- a/docs/contributor_guide/contributing_example_notebooks.rst
+++ b/docs/contributor_guide/contributing_example_notebooks.rst
@@ -1,16 +1,16 @@
 Contributing example notebooks
 ------------------------------
 
-To contribute new example notebooks please submit a pull request. We have
-certain requirements that need to be satisfied to contribute a notebook. Those
-include:
+We'd love to collaborate with anyone interested in describing scenarios for using fairlearn!
 
-* Clear structure
-* Appropriate framing of the problem while respecting that fairness is a
-  fundamentally sociotechnical challenge
-* Usage of at least some part of Fairlearn
+When discussing and critiquing examples, here are some lenses to consider:
 
-Good examples of existing notebooks that abide by these requirements are:
+Microrubric for critiques:
+"""""""""""""""""""""
+1. **Deployment context**: Describes a real deployment context, not just a dataset.
+2. **For developers**: Speaks the language of developers and data scientists.  Considers real practitioner needs.  Fits within the lifecycle of real practioner work.  See `Holstein et al (2019) <https://arxiv.org/pdf/1812.05239.pdf>`_, `Madaio et al. (2020) <http://www.jennwv.com/papers/checklists.pdf>`_.
+3. **Sociotechnical**: Models the team's value that fairness as a sociotechnical challenge.    Avoids abstraction traps.  See `Selbst et al. (2020) <https://andrewselbst.files.wordpress.com/2019/10/selbst-et-al-fairness-and-abstraction-in-sociotechnical-systems.pdf>`_.
+4. **Open**:  Discusses tradeoffs and compares alternatives.  Illustrates how fairlearn contributes.
+5. **Real harms**: Focuses on real harms to real people.  See `Blodget et al. (2020) <https://arxiv.org/abs/2005.14050>`_.
 
-* `Mitigating Disparities in Ranking from Binary Data <https://github.com/fairlearn/fairlearn/blob/master/notebooks/Mitigating%20Disparities%20in%20Ranking%20from%20Binary%20Data.ipynb>`_
-* `Binary Classification with the UCI Credit-card Default Dataset <https://github.com/fairlearn/fairlearn/blob/master/notebooks/Binary%20Classification%20with%20the%20UCI%20Credit-card%20Default%20Dataset.ipynb>`_
+If you'd like to collaborate, please reach out in gitter or open an issue!

--- a/docs/contributor_guide/contributing_example_notebooks.rst
+++ b/docs/contributor_guide/contributing_example_notebooks.rst
@@ -3,14 +3,14 @@ Contributing example notebooks
 
 We'd love to collaborate with anyone interested in describing scenarios for using Fairlearn!
 
-When discussing and critiquing examples, here are some lenses to consider:
+A good example notebook exhibits the following attributes:
 
-Microrubric for critiques:
-"""""""""""""""""""""""""""""""""""
 1. **Deployment context**: Describes a real deployment context, not just a dataset.
 2. **Real harms**: Focuses on real harms to real people.  See `Blodget et al. (2020) <https://arxiv.org/abs/2005.14050>`_.
-3. **Sociotechnical**: Models the team's value that fairness as a sociotechnical challenge.    Avoids abstraction traps.  See `Selbst et al. (2020) <https://andrewselbst.files.wordpress.com/2019/10/selbst-et-al-fairness-and-abstraction-in-sociotechnical-systems.pdf>`_.
+3. **Sociotechnical**: Models the Fairlearn team's value that fairness is a sociotechnical challenge.    Avoids abstraction traps.  See `Selbst et al. (2020) <https://andrewselbst.files.wordpress.com/2019/10/selbst-et-al-fairness-and-abstraction-in-sociotechnical-systems.pdf>`_.
 4. **Substantiated**: Discusses trade-offs and compares alternatives. Describes why using particular Fairlearn functionalities makes sense.
 5. **For developers**: Speaks the language of developers and data scientists.  Considers real practitioner needs.  Fits within the lifecycle of real practioner work.  See `Holstein et al (2019) <https://arxiv.org/pdf/1812.05239.pdf>`_, `Madaio et al. (2020) <http://www.jennwv.com/papers/checklists.pdf>`_.
+
+Please keep these in mind when creating, discussing, and critiquing examples.
 
 If you'd like to collaborate, please :ref:`reach out <communication>`.

--- a/docs/contributor_guide/contributing_example_notebooks.rst
+++ b/docs/contributor_guide/contributing_example_notebooks.rst
@@ -10,7 +10,7 @@ Microrubric for critiques:
 1. **Deployment context**: Describes a real deployment context, not just a dataset.
 2. **For developers**: Speaks the language of developers and data scientists.  Considers real practitioner needs.  Fits within the lifecycle of real practioner work.  See `Holstein et al (2019) <https://arxiv.org/pdf/1812.05239.pdf>`_, `Madaio et al. (2020) <http://www.jennwv.com/papers/checklists.pdf>`_.
 3. **Sociotechnical**: Models the team's value that fairness as a sociotechnical challenge.    Avoids abstraction traps.  See `Selbst et al. (2020) <https://andrewselbst.files.wordpress.com/2019/10/selbst-et-al-fairness-and-abstraction-in-sociotechnical-systems.pdf>`_.
-4. **Open**:  Discusses tradeoffs and compares alternatives.  Illustrates how Fairlearn contributes.
+4. **Substantiated**: Discusses trade-offs and compares alternatives. Describes why using particular Fairlearn functionalities makes sense.
 5. **Real harms**: Focuses on real harms to real people.  See `Blodget et al. (2020) <https://arxiv.org/abs/2005.14050>`_.
 
 If you'd like to collaborate, please :ref:`reach out <communication>`.


### PR DESCRIPTION
## Microrubric for critiques
This updates the page about contributing notebooks to include a short rubric for guiding critiques with five points:

1. Deployment context
2. For developers
3. Sociotechnical
4. Substantiated
5. Real harms

The intention is that this reflects the rough consensus about the team's aspirations from the meeting on 6/18 and discussion afterward.  While the [How to talk and write about fairness in AI](https://fairlearn.github.io/contributor_guide/how_to_talk_about_fairness.html) guide is awesome, in practice it's harder to refer to during a discussion.  So this minirubric is trying to be small enough that the team might practically use it within a meeting or discussion.
