### PR TITLE
Added a Resources section

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -3,6 +3,7 @@
 All names are sorted alphabetically by last name. Contributors, please add your name to the list when you submit a patch to the project.
 
 - [Sarah Bird](https://github.com/slbird)
+- [Rishit Dagli](https://github.com/Rishit-dagli)
 - [Miro Dudik](https://github.com/MiroDudik)
 - [Richard Edgar](https://github.com/riedgar-ms)
 - [Andra Fehmiu](https://github.com/afehmiu)

--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ to locate the appropriate version of the notebook.
 
 ## Resources
 
+- [fairlearn.github.io](https://fairlearn.github.io/)
+- [FairLearn Whitepaper](https://www.microsoft.com/en-us/research/uploads/prod/2020/05/Fairlearn_whitepaper.pdf)
+- [FairLearn Documentation](https://fairlearn.github.io/auto_examples/notebooks/index.html)
+- [Fairlearn Examples](https://fairlearn.github.io/auto_examples/notebooks/index.html)
+- [Building fairer AI Systems with Fairlearn on Channel 9](https://channel9.msdn.com/Shows/AI-Show/Building-fairer-AI-Systems-with-Fairlearn)
+- [How to Test Models for Fairness with Fairlearn Deep-Dive on Channel 9](https://channel9.msdn.com/Shows/AI-Show/How-to-Test-Models-for-Fairness-with-Fairlearn-Deep-Dive)
+- [Fairlearn in Practice at EY on Channel 9](https://channel9.msdn.com/Shows/AI-Show/Fairlearn-in-Practice-at-EY)
+
 ## Contributing
 
 To contribute please check our

--- a/README.md
+++ b/README.md
@@ -70,16 +70,6 @@ In this case, please navigate the tags in the repository
 (e.g. [v0.4.5](https://github.com/fairlearn/fairlearn/tree/v0.4.5))
 to locate the appropriate version of the notebook.
 
-## Resources
-
-- [fairlearn.github.io](https://fairlearn.github.io/)
-- [FairLearn Whitepaper](https://www.microsoft.com/en-us/research/uploads/prod/2020/05/Fairlearn_whitepaper.pdf)
-- [FairLearn Documentation](https://fairlearn.github.io/auto_examples/notebooks/index.html)
-- [Fairlearn Examples](https://fairlearn.github.io/auto_examples/notebooks/index.html)
-- [Building fairer AI Systems with Fairlearn on Channel 9](https://channel9.msdn.com/Shows/AI-Show/Building-fairer-AI-Systems-with-Fairlearn)
-- [How to Test Models for Fairness with Fairlearn Deep-Dive on Channel 9](https://channel9.msdn.com/Shows/AI-Show/How-to-Test-Models-for-Fairness-with-Fairlearn-Deep-Dive)
-- [Fairlearn in Practice at EY on Channel 9](https://channel9.msdn.com/Shows/AI-Show/Fairlearn-in-Practice-at-EY)
-
 ## Contributing
 
 To contribute please check our

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ In this case, please navigate the tags in the repository
 (e.g. [v0.4.5](https://github.com/fairlearn/fairlearn/tree/v0.4.5))
 to locate the appropriate version of the notebook.
 
+## Resources
+
 ## Contributing
 
 To contribute please check our

--- a/docs/user_guide/further_resources.rst
+++ b/docs/user_guide/further_resources.rst
@@ -18,6 +18,7 @@ Books
 Papers
 ------
 
+- `Fairlearn: A toolkit for assessing and improving fairness in AI <https://www.microsoft.com/en-us/research/uploads/prod/2020/05/Fairlearn_whitepaper.pdf>`_ (Sarah Bird, Miroslav Dudík, Hanna Wallach and Kathleen Walker, 2020)
 - `Fairness through Awareness <https://arxiv.org/abs/1104.3913>`_ (Dwork et al., 2011)
 - `Big Data's Disparate Impact <https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2477899##>`_ (Barocas & Selbst, 2016)
 - `Measures and Mismeasures of Fairness <https://5harad.com/papers/fair-ml.pdf>`_ (Corbett-Davies & Goel, 2018)

--- a/docs/user_guide/further_resources.rst
+++ b/docs/user_guide/further_resources.rst
@@ -18,7 +18,7 @@ Books
 Papers
 ------
 
-- `Fairlearn: A toolkit for assessing and improving fairness in AI <https://www.microsoft.com/en-us/research/uploads/prod/2020/05/Fairlearn_whitepaper.pdf>`_ (Sarah Bird, Miroslav Dudík, Hanna Wallach and Kathleen Walker, 2020)
+- `Fairlearn: A toolkit for assessing and improving fairness in AI <https://www.microsoft.com/en-us/research/uploads/prod/2020/05/Fairlearn_whitepaper.pdf>`_ (Bird et al., 2020)
 - `Fairness through Awareness <https://arxiv.org/abs/1104.3913>`_ (Dwork et al., 2011)
 - `Big Data's Disparate Impact <https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2477899##>`_ (Barocas & Selbst, 2016)
 - `Measures and Mismeasures of Fairness <https://5harad.com/papers/fair-ml.pdf>`_ (Corbett-Davies & Goel, 2018)


### PR DESCRIPTION
Added a Resources section in README with the following-

- [fairlearn.github.io](https://fairlearn.github.io/)
- [FairLearn Whitepaper](https://www.microsoft.com/en-us/research/uploads/prod/2020/05/Fairlearn_whitepaper.pdf)
- [FairLearn Documentation](https://fairlearn.github.io/auto_examples/notebooks/index.html)
- [Fairlearn Examples](https://fairlearn.github.io/auto_examples/notebooks/index.html)
- [Building fairer AI Systems with Fairlearn on Channel 9](https://channel9.msdn.com/Shows/AI-Show/Building-fairer-AI-Systems-with-Fairlearn)
- [How to Test Models for Fairness with Fairlearn Deep-Dive on Channel 9](https://channel9.msdn.com/Shows/AI-Show/How-to-Test-Models-for-Fairness-with-Fairlearn-Deep-Dive)
- [Fairlearn in Practice at EY on Channel 9](https://channel9.msdn.com/Shows/AI-Show/Fairlearn-in-Practice-at-EY)