### PR TITLE
remove datasets module usage until it is part of a released version

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -66,15 +66,8 @@ than $50,000 a year.
     >>> import numpy as np 
     >>> import pandas as pd
     >>> import matplotlib.pyplot as plt 
-    >>> import pathlib
     >>> from sklearn.datasets import fetch_openml
-    >>> data = fetch_openml(data_id=1590,
-    ...     data_home=pathlib.Path().home() / ".fairlearn-data",
-    ...     cache=True,
-    ...     as_frame=True)
-    >>> # In the future this will be available as follows:
-    >>> # from fairlearn.datasets import fetch_adult
-    >>> # data = fetch_adult(as_frame=True)
+    >>> data = fetch_openml(data_id=1590, as_frame=True)
     >>> X = pd.get_dummies(data.data)
     >>> y_true = (data.target == '>50K') * 1
     >>> sex = data.data['sex']

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -66,8 +66,15 @@ than $50,000 a year.
     >>> import numpy as np 
     >>> import pandas as pd
     >>> import matplotlib.pyplot as plt 
-    >>> from fairlearn.datasets import fetch_adult
-    >>> data = fetch_adult(as_frame=True)
+    >>> import pathlib
+    >>> from sklearn.datasets import fetch_openml
+    >>> data = fetch_openml(data_id=1590,
+    ...     data_home=pathlib.Path().home() / ".fairlearn-data",
+    ...     cache=True,
+    ...     as_frame=True)
+    >>> # In the future this will be available as follows:
+    >>> # from fairlearn.datasets import fetch_adult
+    >>> # data = fetch_adult(as_frame=True)
     >>> X = pd.get_dummies(data.data)
     >>> y_true = (data.target == '>50K') * 1
     >>> sex = data.data['sex']

--- a/examples/notebooks/plot_grid_search_census.py
+++ b/examples/notebooks/plot_grid_search_census.py
@@ -41,16 +41,8 @@ import pandas as pd
 # %%
 # We can now load and inspect the data by using the `fairlearn.datasets` module:
 
-import pathlib
 from sklearn.datasets import fetch_openml
-data = fetch_openml(
-    data_id=1590,
-    data_home=pathlib.Path().home() / ".fairlearn-data",
-    cache=True,
-    as_frame=True)
-# In the future this will be available as follows:
-# from fairlearn.datasets import fetch_adult
-# data = fetch_adult(as_frame=True)
+data = fetch_openml(data_id=1590, as_frame=True)
 X_raw = data.data
 Y = (data.target == '>50K') * 1
 X_raw

--- a/examples/notebooks/plot_grid_search_census.py
+++ b/examples/notebooks/plot_grid_search_census.py
@@ -33,7 +33,6 @@ from fairlearn.widget import FairlearnDashboard
 from sklearn.model_selection import train_test_split
 from fairlearn.reductions import GridSearch
 from fairlearn.reductions import DemographicParity, ErrorRate
-from fairlearn.datasets import fetch_adult
 
 from sklearn.preprocessing import LabelEncoder, StandardScaler
 from sklearn.linear_model import LogisticRegression
@@ -42,7 +41,16 @@ import pandas as pd
 # %%
 # We can now load and inspect the data by using the `fairlearn.datasets` module:
 
-data = fetch_adult(as_frame=True)
+import pathlib
+from sklearn.datasets import fetch_openml
+data = fetch_openml(
+    data_id=1590,
+    data_home=pathlib.Path().home() / ".fairlearn-data",
+    cache=True,
+    as_frame=True)
+# In the future this will be available as follows:
+# from fairlearn.datasets import fetch_adult
+# data = fetch_adult(as_frame=True)
 X_raw = data.data
 Y = (data.target == '>50K') * 1
 X_raw


### PR DESCRIPTION
The latest Fairlearn version (v0.4.6) doesn't have the datasets module and users are hitting this issue frequently. To mitigate the problem this PR replaces the datasets module usage with the direct `fetch_openml` call until the next version is released.

closes #530 

Signed-off-by: Roman Lutz <rolutz@microsoft.com>