### PR TITLE
Improve job rerun

### DIFF
--- a/devops/templates/pip-freeze-to-artifact-steps-template.yml
+++ b/devops/templates/pip-freeze-to-artifact-steps-template.yml
@@ -14,4 +14,4 @@ steps:
     displayName: "Publish pip freeze file to artifact ${{parameters.freezeArtifact}}"
     inputs:
       path: '$(System.DefaultWorkingDirectory)/${{parameters.freezeFile}}'
-      artifact: ${{parameters.freezeArtifact}}
+      artifact: '${{parameters.freezeArtifact}}.$(System.JobAttempt)'

--- a/devops/templates/pip-freeze-to-artifact-steps-template.yml
+++ b/devops/templates/pip-freeze-to-artifact-steps-template.yml
@@ -14,4 +14,4 @@ steps:
     displayName: "Publish pip freeze file to artifact ${{parameters.freezeArtifact}}"
     inputs:
       path: '$(System.DefaultWorkingDirectory)/${{parameters.freezeFile}}'
-      artifact: '${{parameters.freezeArtifact}}.$(System.JobAttempt)'
+      artifact: '${{parameters.freezeArtifact}}-Attempt-$(System.JobAttempt)'


### PR DESCRIPTION
There can be problems rerunning failed jobs due to build Artifacts being immutable. This is a particular issue for the 'freeze' artifacts, so append `System.JobAttempt` to the Artifact names, making the name for each retry distinct.

Signed-off-by: Richard Edgar <riedgar@microsoft.com>