### PR TITLE
Tweaks to show_versions()

### DIFF
--- a/fairlearn/show_versions.py
+++ b/fairlearn/show_versions.py
@@ -34,7 +34,7 @@ def _get_deps_info():
     :return: version information on relevant Python libraries
     :rtype: dict
     """
-    deps = [
+    deps = sorted([
         "pip",
         "setuptools",
         "sklearn",
@@ -44,7 +44,7 @@ def _get_deps_info():
         "pandas",
         "matplotlib",
         "tempeh"
-        ]
+        ])
 
     def get_version(module):
         return module.__version__

--- a/test/unit/test_show_versions.py
+++ b/test/unit/test_show_versions.py
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation and contributors.
+# Licensed under the MIT License.
+
+import fairlearn
+
+
+def test_smoke(capsys):
+    fairlearn.show_versions()
+    captured = capsys.readouterr()
+    # The following are not comprehensive
+    assert "System:" in captured.out
+    assert "    python:" in captured.out
+    assert "executable:" in captured.out
+    assert "   machine:" in captured.out
+    assert "Python dependencies:" in captured.out
+    assert "   sklearn:" in captured.out
+    assert "     scipy:" in captured.out
+    assert "    pandas:" in captured.out


### PR DESCRIPTION
Some minor changes to `show_versions()`:

- Have the python dependencies sorted alphabetically
- Add a smoke test of the `show_versions()` subroutine

The test is very much a smoke test; it verifies that the `show_versions()` subroutine does not throw any errors, and also that a few expected strings are present in the output. It does not verify that the version information itself has been fetched correctly.