### PR TITLE
Fix double datasets entry in docs

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -21,5 +21,6 @@ All names are sorted alphabetically by last name. Contributors, please add your 
 - [Mehrnoosh Sameki](https://github.com/mesameki)
 - [Chinmay Singh](https://www.microsoft.com/en-us/research/people/chsingh/)
 - [Hanna Wallach](https://www.microsoft.com/en-us/research/people/wallach/)
+- [Hilde Weerts](https://github.com/hildeweerts)
 - [Vincent Xu](https://github.com/vingu)
 - [Beth Zeranski](https://github.com/bethz)

--- a/docs/api_reference/index.rst
+++ b/docs/api_reference/index.rst
@@ -6,7 +6,6 @@ API Reference
 .. toctree::
    :maxdepth: 1
 
-   fairlearn.datasets
    fairlearn.metrics
    fairlearn.postprocessing
    fairlearn.reductions


### PR DESCRIPTION
Fix double datasets entry in API Reference menu in the documentation.