### PR TITLE
Fix link to the examples

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -181,5 +181,5 @@ What's next?
 Please refer to our :ref:`user_guide` for a comprehensive view on Fairness in
 Machine Learning and how Fairlearn fits in, as well as an exhaustive guide on
 all parts of the toolkit. For concrete examples check out the
-:fairlearn:ref:`sphx_glr_auto_examples` section. Finally, we also have a collection
+:ref:`sphx_glr_auto_examples_notebooks` section. Finally, we also have a collection
 of :ref:`faq`.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -181,5 +181,5 @@ What's next?
 Please refer to our :ref:`user_guide` for a comprehensive view on Fairness in
 Machine Learning and how Fairlearn fits in, as well as an exhaustive guide on
 all parts of the toolkit. For concrete examples check out the
-:ref:`fairlearn:sphx_glr_auto_examples` section. Finally, we also have a collection
+:fairlearn:ref:`sphx_glr_auto_examples` section. Finally, we also have a collection
 of :ref:`faq`.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -181,5 +181,5 @@ What's next?
 Please refer to our :ref:`user_guide` for a comprehensive view on Fairness in
 Machine Learning and how Fairlearn fits in, as well as an exhaustive guide on
 all parts of the toolkit. For concrete examples check out the
-:Fairlearn:`sphx_glr_auto_examples` section. Finally, we also have a collection
+:ref:`Fairlearn:sphx_glr_auto_examples` section. Finally, we also have a collection
 of :ref:`faq`.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -181,5 +181,5 @@ What's next?
 Please refer to our :ref:`user_guide` for a comprehensive view on Fairness in
 Machine Learning and how Fairlearn fits in, as well as an exhaustive guide on
 all parts of the toolkit. For concrete examples check out the
-:ref:`sphx_glr_auto_examples` section. Finally, we also have a collection
+:ref:Fairlearn:`sphx_glr_auto_examples` section. Finally, we also have a collection
 of :ref:`faq`.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -181,5 +181,5 @@ What's next?
 Please refer to our :ref:`user_guide` for a comprehensive view on Fairness in
 Machine Learning and how Fairlearn fits in, as well as an exhaustive guide on
 all parts of the toolkit. For concrete examples check out the
-:ref:Fairlearn:`sphx_glr_auto_examples` section. Finally, we also have a collection
+:Fairlearn:`sphx_glr_auto_examples` section. Finally, we also have a collection
 of :ref:`faq`.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -181,5 +181,5 @@ What's next?
 Please refer to our :ref:`user_guide` for a comprehensive view on Fairness in
 Machine Learning and how Fairlearn fits in, as well as an exhaustive guide on
 all parts of the toolkit. For concrete examples check out the
-:ref:`Fairlearn:sphx_glr_auto_examples` section. Finally, we also have a collection
+:ref:`fairlearn:sphx_glr_auto_examples` section. Finally, we also have a collection
 of :ref:`faq`.


### PR DESCRIPTION
Closes #549  by making updating the link to the right target. When the examples were moved to nested directories, the required reference changed. To see this run ` python -m sphinx.ext.intersphinx build/html/objects.inv` (substituting the appropriate directory for the sphinx build).