### PR TITLE
Remove Windows 3.8 from Nightly-Fixed

### DIFF
--- a/devops/nightly-requirements-fixed.yml
+++ b/devops/nightly-requirements-fixed.yml
@@ -23,7 +23,7 @@ pool:
 jobs:
 - template: templates/all-tests-job-template.yml
   parameters:
-    platforms:  { Linux: ubuntu-latest, Windows: vs2017-win2016 }
+    platforms:  { Linux: ubuntu-latest, Windows: windows-latest }
     installationType: 'PipLocal'
     pyVersions: [3.6, 3.7, 3.8]
     freezeArtifactStem: $(FreezeArtifactStem)

--- a/devops/nightly-requirements-fixed.yml
+++ b/devops/nightly-requirements-fixed.yml
@@ -23,9 +23,18 @@ pool:
 jobs:
 - template: templates/all-tests-job-template.yml
   parameters:
-    platforms:  { Linux: ubuntu-latest, Windows: windows-latest }
+    platforms:  { Linux: ubuntu-latest }
     installationType: 'PipLocal'
     pyVersions: [3.6, 3.7, 3.8]
+    freezeArtifactStem: $(FreezeArtifactStem)
+    freezeFileStem: $(FreezeFileStem)
+    pinRequirements: True
+
+- template: templates/all-tests-job-template.yml
+  parameters:
+    platforms:  { Windows: windows-latest }
+    installationType: 'PipLocal'
+    pyVersions: [3.6, 3.7]
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFileStem: $(FreezeFileStem)
     pinRequirements: True

--- a/devops/nightly-requirements-fixed.yml
+++ b/devops/nightly-requirements-fixed.yml
@@ -30,6 +30,11 @@ jobs:
     freezeFileStem: $(FreezeFileStem)
     pinRequirements: True
 
+# There is some issue with the Python 3.8 installation on Windows
+# It appears related to this:
+# https://github.com/pypa/setuptools/issues/2368
+# Unfortunately, just putting an upper bound on setuptools is not
+# resolving it
 - template: templates/all-tests-job-template.yml
   parameters:
     platforms:  { Windows: windows-latest }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ ipywidgets>=7.5.0
 pandas>=0.25.1
 scikit-learn>=0.22.1
 scipy>=1.4.1
+# Following from https://github.com/pypa/setuptools/issues/2368
+# This affects Nightly Fixed on Windows 3.8
+setuptools<49.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,3 @@ ipywidgets>=7.5.0
 pandas>=0.25.1
 scikit-learn>=0.22.1
 scipy>=1.4.1
-# Following from https://github.com/pypa/setuptools/issues/2368
-# This affects Nightly Fixed on Windows 3.8
-setuptools<49.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ scikit-learn>=0.22.1
 scipy>=1.4.1
 # Following from https://github.com/pypa/setuptools/issues/2368
 # This affects Nightly Fixed on Windows 3.8
-setuptools<50.0
+setuptools<49.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ ipywidgets>=7.5.0
 pandas>=0.25.1
 scikit-learn>=0.22.1
 scipy>=1.4.1
+# Following from https://github.com/pypa/setuptools/issues/2368
+setuptools<50.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ pandas>=0.25.1
 scikit-learn>=0.22.1
 scipy>=1.4.1
 # Following from https://github.com/pypa/setuptools/issues/2368
+# This affects Nightly Fixed on Windows 3.8
 setuptools<50.0


### PR DESCRIPTION
For reasons which are somewhat obscure but appear [related to a recent `setuptools` update](https://github.com/pypa/setuptools/issues/2368), the `Nightly-Fixed` build for Python 3.8 on Windows is failing to install. Since placing an upper bound on `setuptools` does not mitigate the issue, temporarily remove the `Nightly-Fixed` builds for Python 3.8 on Windows.