### PR TITLE
Fix for notebook builds

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,8 +12,7 @@ requirements-parser
 
 # Required for test
 nbformat
-# Pin papermill due to notebook test issue on Windows with python 3.6
-papermill #<2.0.0
+papermill
 # Pin pytest due to VS Code issue
 pytest==5.0.1
 pytest-cov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ requirements-parser
 # Required for test
 nbformat
 # Pin papermill due to notebook test issue on Windows with python 3.6
-papermill<2.0.0
+papermill #<2.0.0
 # Pin pytest due to VS Code issue
 pytest==5.0.1
 pytest-cov


### PR DESCRIPTION
Another fix for the notebook builds. Releases the upper bound on `papermill` which was causing trouble with the latest version of `nbconvert`.