### PR TITLE
Add flake8 check for copyright header

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
     MIT License
 
-    Copyright (c) Microsoft Corporation and contributors.
+    Copyright (c) Microsoft Corporation and Fairlearn contributors.
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation and contributors.
+# Licensed under the MIT License.
+
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 # Configuration file for the Sphinx documentation builder.

--- a/docs/quickstart_plot.py
+++ b/docs/quickstart_plot.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
+# Licensed under the MIT License.
+
 """Produce plot of selection rates for the quickstart guide."""
 from bokeh.plotting import figure, show
 from fairlearn.metrics import selection_rate_group_summary

--- a/examples/plot_grid_search_census.py
+++ b/examples/plot_grid_search_census.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
+# Licensed under the MIT License.
 
 """
 ===========================

--- a/fairlearn/__init__.py
+++ b/fairlearn/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 """Tools for analyzing and mitigating disparity in Machine Learning models."""

--- a/fairlearn/_input_validation.py
+++ b/fairlearn/_input_validation.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import logging

--- a/fairlearn/metrics/__init__.py
+++ b/fairlearn/metrics/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 """Functionality for computing metrics, with a particular focus on group metrics.

--- a/fairlearn/metrics/_balanced_root_mean_squared_error.py
+++ b/fairlearn/metrics/_balanced_root_mean_squared_error.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import math

--- a/fairlearn/metrics/_disparities.py
+++ b/fairlearn/metrics/_disparities.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 """Metrics for measuring disparity."""

--- a/fairlearn/metrics/_extra_metrics.py
+++ b/fairlearn/metrics/_extra_metrics.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 """A variety of extra metrics useful for assessing fairness.

--- a/fairlearn/metrics/_group_metric_set.py
+++ b/fairlearn/metrics/_group_metric_set.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 from sklearn import preprocessing

--- a/fairlearn/metrics/_input_manipulations.py
+++ b/fairlearn/metrics/_input_manipulations.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import numpy as np

--- a/fairlearn/metrics/_mean_predictions.py
+++ b/fairlearn/metrics/_mean_predictions.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import numpy as np

--- a/fairlearn/metrics/_metrics_engine.py
+++ b/fairlearn/metrics/_metrics_engine.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import numpy as np

--- a/fairlearn/metrics/_selection_rate.py
+++ b/fairlearn/metrics/_selection_rate.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import numpy as np

--- a/fairlearn/postprocessing/__init__.py
+++ b/fairlearn/postprocessing/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 """This module contains methods which operate on a predictor, rather than an estimator.

--- a/fairlearn/postprocessing/_constants.py
+++ b/fairlearn/postprocessing/_constants.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 SCORE_KEY = "score"

--- a/fairlearn/postprocessing/_interpolated_thresholder.py
+++ b/fairlearn/postprocessing/_interpolated_thresholder.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import numpy as np

--- a/fairlearn/postprocessing/_plotting.py
+++ b/fairlearn/postprocessing/_plotting.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 """Utilities for plotting curves."""

--- a/fairlearn/postprocessing/_threshold_operation.py
+++ b/fairlearn/postprocessing/_threshold_operation.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 

--- a/fairlearn/postprocessing/_threshold_optimizer.py
+++ b/fairlearn/postprocessing/_threshold_optimizer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 """Threshold Optimization Post Processing algorithm.

--- a/fairlearn/postprocessing/_tradeoff_curve_utilities.py
+++ b/fairlearn/postprocessing/_tradeoff_curve_utilities.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import numpy as np

--- a/fairlearn/reductions/__init__.py
+++ b/fairlearn/reductions/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 """This module contains algorithms implementing the reductions approach to disparity mitigation.

--- a/fairlearn/reductions/_exponentiated_gradient/__init__.py
+++ b/fairlearn/reductions/_exponentiated_gradient/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 """Package for Exponentiated Gradient."""

--- a/fairlearn/reductions/_exponentiated_gradient/_constants.py
+++ b/fairlearn/reductions/_exponentiated_gradient/_constants.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 _PRECISION = 1e-8

--- a/fairlearn/reductions/_exponentiated_gradient/_lagrangian.py
+++ b/fairlearn/reductions/_exponentiated_gradient/_lagrangian.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import logging

--- a/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
+++ b/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import logging

--- a/fairlearn/reductions/_grid_search/__init__.py
+++ b/fairlearn/reductions/_grid_search/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 """Package for Grid Search."""

--- a/fairlearn/reductions/_grid_search/_grid_generator.py
+++ b/fairlearn/reductions/_grid_search/_grid_generator.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import logging

--- a/fairlearn/reductions/_grid_search/grid_search.py
+++ b/fairlearn/reductions/_grid_search/grid_search.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import copy

--- a/fairlearn/reductions/_moments/__init__.py
+++ b/fairlearn/reductions/_moments/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 """Holds the various Moments."""

--- a/fairlearn/reductions/_moments/bounded_group_loss.py
+++ b/fairlearn/reductions/_moments/bounded_group_loss.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import pandas as pd

--- a/fairlearn/reductions/_moments/error_rate.py
+++ b/fairlearn/reductions/_moments/error_rate.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import pandas as pd

--- a/fairlearn/reductions/_moments/moment.py
+++ b/fairlearn/reductions/_moments/moment.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import pandas as pd

--- a/fairlearn/reductions/_moments/utility_parity.py
+++ b/fairlearn/reductions/_moments/utility_parity.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import pandas as pd

--- a/fairlearn/show_versions.py
+++ b/fairlearn/show_versions.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 """Utility methods to print system info for debugging.

--- a/fairlearn/widget/__init__.py
+++ b/fairlearn/widget/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 """Package for the fairlearn Dashboard widget."""

--- a/fairlearn/widget/_fairlearn_dashboard.py
+++ b/fairlearn/widget/_fairlearn_dashboard.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 """Defines the fairlearn dashboard class."""

--- a/fairlearn/widget/_fairlearn_widget.py
+++ b/fairlearn/widget/_fairlearn_widget.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 """Defines the python side of the shared state of the fairlearn widget."""

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ autopep8
 flake8
 flake8-blind-except
 flake8-builtins
+flake8-copyright
 flake8-docstrings
 flake8-logging-format
 flake8-rst-docstrings

--- a/scripts/_utils.py
+++ b/scripts/_utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
+# Licensed under the MIT License.
+
 import logging
 import os
 

--- a/scripts/build_wheels.py
+++ b/scripts/build_wheels.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
+# Licensed under the MIT License.
+
 import argparse
 import logging
 import subprocess

--- a/scripts/build_widget.py
+++ b/scripts/build_widget.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
+# Licensed under the MIT License.
+
 """Fairlearn dashboard widget build scripts.
 
 To build the widget in order to validate local changes to the visualizations

--- a/scripts/install_requirements.py
+++ b/scripts/install_requirements.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
+# Licensed under the MIT License.
+
 """Script to install the requirements files, optionally pinning versions."""
 
 import argparse

--- a/scripts/process_readme.py
+++ b/scripts/process_readme.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
+# Licensed under the MIT License.
+
 """Script to dynamically update the ReadMe file for a particular release
 
 Since PyPI and GitHub have slightly different ideas about markdown, we have to update

--- a/scripts/set-variable-from-file.ps1
+++ b/scripts/set-variable-from-file.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
+# Licensed under the MIT License.
+
 # Script to set a pipeline variable from the contents of a file
 # This script is only required for Azure DevOps pipelines.
 param(

--- a/scripts/widget-build-validation.ps1
+++ b/scripts/widget-build-validation.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
+# Licensed under the MIT License.
+
 # Validates that the checked in files required for the widget are up to date.
 # Specifically, this means that they were regenerated after changes
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ max-line-length = 99
 enable-extensions = C, G
 
 copyright-check = True
-copyright-regexp = # Copyright \(c\) Microsoft Corporation and contributors.\n# Licensed under the MIT license.
+copyright-regexp = # Copyright \(c\) Microsoft Corporation and Fairlearn contributors.\n# Licensed under the MIT license.
 
 # An update to pip has resulted in `pip install .` leaving a 'build' directory around
 # Also: 'pip freeze' does not report the pip version by default

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [flake8]
 max-line-length = 99
-enable-extensions = G
+enable-extensions = C, G
+
+copyright-check = True
+copyright-regexp = # Copyright \(c\) Microsoft Corporation and contributors.\n# Licensed under the MIT license.
 
 # An update to pip has resulted in `pip install .` leaving a 'build' directory around
 # Also: 'pip freeze' does not report the pip version by default

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import setuptools

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.

--- a/test/install/test_no_matplotlib.py
+++ b/test/install/test_no_matplotlib.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import numpy as np

--- a/test/notebooks/__init__.py
+++ b/test/notebooks/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.

--- a/test/notebooks/test_notebooks.py
+++ b/test/notebooks/test_notebooks.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import nbformat as nbf

--- a/test/unit/__init__.py
+++ b/test/unit/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 # The following pytest configurations are meant to allow silent skipping of tests for scenarios

--- a/test/unit/constants.py
+++ b/test/unit/constants.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 

--- a/test/unit/datasets/__init__.py
+++ b/test/unit/datasets/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.

--- a/test/unit/datasets/test_datasets.py
+++ b/test/unit/datasets/test_datasets.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import pandas as pd

--- a/test/unit/fixes.py
+++ b/test/unit/fixes.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import sklearn

--- a/test/unit/input_convertors.py
+++ b/test/unit/input_convertors.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import numpy as np

--- a/test/unit/metrics/__init__.py
+++ b/test/unit/metrics/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.

--- a/test/unit/metrics/sample_loader.py
+++ b/test/unit/metrics/sample_loader.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import json

--- a/test/unit/metrics/test_balanced_root_mean_squared_error.py
+++ b/test/unit/metrics/test_balanced_root_mean_squared_error.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import math

--- a/test/unit/metrics/test_create_group_metric_set.py
+++ b/test/unit/metrics/test_create_group_metric_set.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import pytest

--- a/test/unit/metrics/test_extra_metrics.py
+++ b/test/unit/metrics/test_extra_metrics.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import numpy as np

--- a/test/unit/metrics/test_group_sklearn_wrappers.py
+++ b/test/unit/metrics/test_group_sklearn_wrappers.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import pytest

--- a/test/unit/metrics/test_input_manipulations.py
+++ b/test/unit/metrics/test_input_manipulations.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import numpy as np

--- a/test/unit/metrics/test_mean_predictions.py
+++ b/test/unit/metrics/test_mean_predictions.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import fairlearn.metrics as metrics

--- a/test/unit/metrics/test_metrics_engine.py
+++ b/test/unit/metrics/test_metrics_engine.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import numpy as np

--- a/test/unit/metrics/test_metrics_engine_dicts.py
+++ b/test/unit/metrics/test_metrics_engine_dicts.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import pytest

--- a/test/unit/metrics/test_selection_rate.py
+++ b/test/unit/metrics/test_selection_rate.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import pytest

--- a/test/unit/postprocessing/__init__.py
+++ b/test/unit/postprocessing/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.

--- a/test/unit/postprocessing/conftest.py
+++ b/test/unit/postprocessing/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 from collections import defaultdict, namedtuple

--- a/test/unit/postprocessing/test_curve_utilities.py
+++ b/test/unit/postprocessing/test_curve_utilities.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import numpy as np

--- a/test/unit/postprocessing/test_plots.py
+++ b/test/unit/postprocessing/test_plots.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import pkg_resources

--- a/test/unit/postprocessing/test_smoke.py
+++ b/test/unit/postprocessing/test_smoke.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import numpy as np

--- a/test/unit/postprocessing/test_threshold_operation.py
+++ b/test/unit/postprocessing/test_threshold_operation.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import pytest

--- a/test/unit/postprocessing/test_threshold_optimization.py
+++ b/test/unit/postprocessing/test_threshold_optimization.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 from sklearn.base import BaseEstimator

--- a/test/unit/reductions/__init__.py
+++ b/test/unit/reductions/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.

--- a/test/unit/reductions/conftest.py
+++ b/test/unit/reductions/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 from test.unit.input_convertors import ensure_list, ensure_series

--- a/test/unit/reductions/exponentiated_gradient/__init__.py
+++ b/test/unit/reductions/exponentiated_gradient/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.

--- a/test/unit/reductions/exponentiated_gradient/simple_learners.py
+++ b/test/unit/reductions/exponentiated_gradient/simple_learners.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import numpy as np

--- a/test/unit/reductions/exponentiated_gradient/test_exponentiatedgradient_arguments.py
+++ b/test/unit/reductions/exponentiated_gradient/test_exponentiatedgradient_arguments.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 import numpy as np
 

--- a/test/unit/reductions/exponentiated_gradient/test_exponentiatedgradient_smoke.py
+++ b/test/unit/reductions/exponentiated_gradient/test_exponentiatedgradient_smoke.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 from copy import deepcopy

--- a/test/unit/reductions/exponentiated_gradient/test_lagrangian.py
+++ b/test/unit/reductions/exponentiated_gradient/test_lagrangian.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 from copy import deepcopy

--- a/test/unit/reductions/exponentiated_gradient/test_utilities.py
+++ b/test/unit/reductions/exponentiated_gradient/test_utilities.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import numpy as np

--- a/test/unit/reductions/grid_search/__init__.py
+++ b/test/unit/reductions/grid_search/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.

--- a/test/unit/reductions/grid_search/test_grid_generator.py
+++ b/test/unit/reductions/grid_search/test_grid_generator.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import numpy as np

--- a/test/unit/reductions/grid_search/test_grid_search_arguments.py
+++ b/test/unit/reductions/grid_search/test_grid_search_arguments.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import logging

--- a/test/unit/reductions/grid_search/test_grid_search_demographicparity.py
+++ b/test/unit/reductions/grid_search/test_grid_search_demographicparity.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 from fairlearn.reductions import GridSearch, DemographicParity

--- a/test/unit/reductions/grid_search/test_grid_search_regression.py
+++ b/test/unit/reductions/grid_search/test_grid_search_regression.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 from fairlearn.reductions import GridSearch

--- a/test/unit/reductions/grid_search/utilities.py
+++ b/test/unit/reductions/grid_search/utilities.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import numpy as np

--- a/test/unit/reductions/moments/__init__.py
+++ b/test/unit/reductions/moments/__init__.py
@@ -1,2 +1,2 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.

--- a/test/unit/reductions/moments/data_generator.py
+++ b/test/unit/reductions/moments/data_generator.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import numpy as np

--- a/test/unit/reductions/moments/test_moments_bounded_group_loss.py
+++ b/test/unit/reductions/moments/test_moments_bounded_group_loss.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import numpy as np

--- a/test/unit/reductions/moments/test_moments_demographic_parity.py
+++ b/test/unit/reductions/moments/test_moments_demographic_parity.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import numpy as np

--- a/test/unit/reductions/moments/test_moments_equalized_odds.py
+++ b/test/unit/reductions/moments/test_moments_equalized_odds.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import numpy as np

--- a/test/unit/reductions/test_smoke.py
+++ b/test/unit/reductions/test_smoke.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import numpy as np

--- a/test/unit/test_show_versions.py
+++ b/test/unit/test_show_versions.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import fairlearn

--- a/test/unit/utility_functions.py
+++ b/test/unit/utility_functions.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation and contributors.
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
 import numpy as np


### PR DESCRIPTION
Add the `flake8-copyright` package, and enable checking for the presence of a copyright header.

As a result of this:
- Pick 'Fairlearn' contributors' as the standard (rather than just 'contributors')
- Add missing header to some files