### PR TITLE
fix selection_rate for y_pred of length 0 or 1

### DIFF
--- a/fairlearn/metrics/_selection_rate.py
+++ b/fairlearn/metrics/_selection_rate.py
@@ -9,7 +9,18 @@ def selection_rate(y_true, y_pred, *, pos_label=1, sample_weight=None):
 
     The argument `pos_label` specifies the 'good' outcome.
     """
-    selected = (np.squeeze(np.asarray(y_pred)) == pos_label)
+    y_pred_arr = np.asarray(y_pred)
+
+    if y_pred_arr.shape == (0,):
+        raise ValueError("Empty y_pred passed to selection_rate function.")
+
+    y_pred_arr = np.squeeze(y_pred_arr)
+    if y_pred_arr.shape == ():
+        # not actually an array, but rather a single entry that was compressed
+        # into a scalar by the squeeze call
+        return (y_pred_arr == pos_label) * 1.0
+
+    selected = (y_pred_arr == pos_label)
     s_w = np.ones(len(selected))
     if sample_weight is not None:
         s_w = np.squeeze(np.asarray(sample_weight))

--- a/fairlearn/metrics/_selection_rate.py
+++ b/fairlearn/metrics/_selection_rate.py
@@ -16,7 +16,7 @@ def selection_rate(y_true, y_pred, *, pos_label=1, sample_weight=None):
     """
     if len(y_pred) == 0:
         raise ValueError(_EMPTY_INPUT_PREDICTIONS_ERROR_MESSAGE)
-    
+
     selected = (_convert_to_ndarray_and_squeeze(y_pred) == pos_label)
     s_w = np.ones(len(selected))
     if sample_weight is not None:

--- a/fairlearn/metrics/_selection_rate.py
+++ b/fairlearn/metrics/_selection_rate.py
@@ -3,24 +3,21 @@
 
 import numpy as np
 
+from fairlearn.metrics._input_manipulations import _convert_to_ndarray_and_squeeze
+
+
+_EMPTY_INPUT_PREDICTIONS_ERROR_MESSAGE = "Empty y_pred passed to selection_rate function."
+
 
 def selection_rate(y_true, y_pred, *, pos_label=1, sample_weight=None):
     """Calculate the fraction of predicted labels matching the 'good' outcome.
 
     The argument `pos_label` specifies the 'good' outcome.
     """
-    y_pred_arr = np.asarray(y_pred)
-
-    if y_pred_arr.shape == (0,):
-        raise ValueError("Empty y_pred passed to selection_rate function.")
-
-    y_pred_arr = np.squeeze(y_pred_arr)
-    if y_pred_arr.shape == ():
-        # not actually an array, but rather a single entry that was compressed
-        # into a scalar by the squeeze call
-        return (y_pred_arr == pos_label) * 1.0
-
-    selected = (y_pred_arr == pos_label)
+    if len(y_pred) == 0:
+        raise ValueError(_EMPTY_INPUT_PREDICTIONS_ERROR_MESSAGE)
+    
+    selected = (_convert_to_ndarray_and_squeeze(y_pred) == pos_label)
     s_w = np.ones(len(selected))
     if sample_weight is not None:
         s_w = np.squeeze(np.asarray(sample_weight))

--- a/test/unit/metrics/test_selection_rate.py
+++ b/test/unit/metrics/test_selection_rate.py
@@ -4,6 +4,20 @@
 import pytest
 
 import fairlearn.metrics as metrics
+from fairlearn.metrics._selection_rate import _EMPTY_INPUT_PREDICTIONS_ERROR_MESSAGE
+
+
+def test_selection_rate_empty():
+    with pytest.raises(ValueError) as exc:
+        _ = metrics.selection_rate([], [])
+    assert _EMPTY_INPUT_PREDICTIONS_ERROR_MESSAGE == exc.value.args[0]
+
+
+def test_selection_rate_single_element():
+    assert 1 == metrics.selection_rate([1], [1])
+    assert 1 == metrics.selection_rate([0], [1])
+    assert 0 == metrics.selection_rate([1], [0])
+    assert 0 == metrics.selection_rate([0], [0])
 
 
 def test_selection_rate_unweighted():


### PR DESCRIPTION
Currently the squeeze call causes an issue for `y_pred` of length 1. Additionally, I've added a check to ensure it's not empty either.

Signed-off-by: Roman Lutz <rolutz@microsoft.com>