### PR TITLE
Smoke tests for TensorFlow

### DIFF
--- a/devops/other-ml-packages.yml
+++ b/devops/other-ml-packages.yml
@@ -2,7 +2,13 @@
 
 trigger: none # No CI build
 
-pr: none # Not for pull requests
+pr:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - test_othermlpackages/*
 
 schedules:
 - cron: "0 8 * * *" # Time is UTC

--- a/devops/templates/other-ml-job-template.yml
+++ b/devops/templates/other-ml-job-template.yml
@@ -4,7 +4,7 @@ parameters:
   envInfoArtifactBase: Environment
   envInfoDir: environment
   envInfoFileBase: env
-  packages: { LightGBM: lightgbm, XGBoost: xgboost }
+  packages: { LightGBM: lightgbm, XGBoost: xgboost, TensorFlow: tensorflow }
   poolImage: ubuntu-latest
   pythonVersion: 3.8
 

--- a/fairlearn/postprocessing/_threshold_optimizer.py
+++ b/fairlearn/postprocessing/_threshold_optimizer.py
@@ -198,7 +198,9 @@ class ThresholdOptimizer(BaseEstimator, MetaEstimatorMixin):
             y = [int(y_val) for y_val in y]
 
         if not self.prefit:
-            self.estimator_ = clone(self.estimator).fit(X, y, **kwargs)
+            # Following is on two lines due to issue when estimator comes from TensorFlow
+            self.estimator_ = clone(self.estimator)
+            self.estimator_.fit(X, y, **kwargs)
         else:
             try:
                 check_is_fitted(self.estimator)

--- a/fairlearn/reductions/_moments/error_rate.py
+++ b/fairlearn/reductions/_moments/error_rate.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
+import numpy as np
 import pandas as pd
 from .moment import ClassificationMoment
 from .moment import _ALL, _LABEL
@@ -19,6 +20,11 @@ class ErrorRate(ClassificationMoment):
     def gamma(self, predictor):
         """Return the gamma values for the given predictor."""
         pred = predictor(self.X)
+        if isinstance(pred, np.ndarray):
+            # TensorFlow is returning an (n,1) array, which results
+            # in the subtraction in the 'error =' line generating an
+            # (n,n) array
+            pred = np.squeeze(pred)
         error = pd.Series(data=(self.tags[_LABEL] - pred).abs().mean(),
                           index=self.index)
         self._gamma_descr = str(error)

--- a/fairlearn/reductions/_moments/utility_parity.py
+++ b/fairlearn/reductions/_moments/utility_parity.py
@@ -106,7 +106,7 @@ class UtilityParity(ClassificationMoment):
         self.tags[_EVENT] = event
         if utilities is None:
             utilities = np.vstack([np.zeros(y.shape, dtype=np.float64),
-                                  np.ones(y.shape, dtype=np.float64)]).T
+                                   np.ones(y.shape, dtype=np.float64)]).T
         self.utilities = utilities
         self.prob_event = self.tags.groupby(_EVENT).size() / self.total_samples
         self.prob_group_event = self.tags.groupby(
@@ -142,7 +142,11 @@ class UtilityParity(ClassificationMoment):
     def gamma(self, predictor):
         """Calculate the degree to which constraints are currently violated by the predictor."""
         utility_diff = self.utilities[:, 1] - self.utilities[:, 0]
-        pred = utility_diff.T * predictor(self.X) + self.utilities[:, 0]
+        predictions = predictor(self.X)
+        if isinstance(predictions, np.ndarray):
+            # TensorFlow seems to return an (n,1) array instead of an (n) array
+            predictions = np.squeeze(predictions)
+        pred = utility_diff.T * predictions + self.utilities[:, 0]
         self.tags[_PREDICTION] = pred
         expect_event = self.tags.groupby(_EVENT).mean()
         expect_group_event = self.tags.groupby(

--- a/test_othermlpackages/conda-tensorflow.yaml
+++ b/test_othermlpackages/conda-tensorflow.yaml
@@ -1,0 +1,9 @@
+name: fairlearn-tensorflow
+channels:
+- defaults
+- conda-forge
+dependencies:
+- python==3.8
+- pip>=19.1.1
+- pytest
+- tensorflow

--- a/test_othermlpackages/conda-tensorflow.yaml
+++ b/test_othermlpackages/conda-tensorflow.yaml
@@ -3,7 +3,7 @@ channels:
 - defaults
 - conda-forge
 dependencies:
-- python==3.8
+- python==3.6
 - pip>=19.1.1
 - pytest
 - tensorflow

--- a/test_othermlpackages/package_test_common.py
+++ b/test_othermlpackages/package_test_common.py
@@ -6,6 +6,7 @@
 import pandas as pd
 
 from sklearn.datasets import fetch_openml
+from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelEncoder, StandardScaler
 
 from fairlearn.postprocessing import ThresholdOptimizer
@@ -29,7 +30,13 @@ def fetch_adult():
     X_scaled = sc.fit_transform(X)
     X_scaled = pd.DataFrame(X_scaled, columns=X.columns)
 
-    return X_scaled, Y, A
+    X_train, X_test, Y_train, Y_test, A_train, A_test = \
+        train_test_split(X_scaled, Y, A,
+                         test_size=0.3,
+                         random_state=12345,
+                         stratify=Y)
+
+    return X_train, Y_train, A_train
 
 
 def run_expgrad_classification(estimator, moment):

--- a/test_othermlpackages/test_tensorflow.py
+++ b/test_othermlpackages/test_tensorflow.py
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
+# Licensed under the MIT License.
+
+from . import package_test_common as ptc
+
+from fairlearn.reductions import DemographicParity
+
+from tensorflow.keras.layers import Dense
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.wrappers.scikit_learn import KerasClassifier
+
+
+def create_model():
+    # create model
+    model = Sequential()
+    model.add(Dense(12, input_dim=8, activation='relu'))
+    model.add(Dense(8, activation='relu'))
+    model.add(Dense(1, activation='sigmoid'))
+    # Compile model
+    model.compile(loss='binary_crossentropy', optimizer='adam', metrics=['accuracy'])
+    return model
+
+
+def test_expgrad_classification():
+    estimator = KerasClassifier(build_fn=create_model)
+    disparity_moment = DemographicParity()
+
+    ptc.run_expgrad_classification(estimator, disparity_moment)

--- a/test_othermlpackages/test_tensorflow.py
+++ b/test_othermlpackages/test_tensorflow.py
@@ -13,6 +13,7 @@ from tensorflow.keras.wrappers.scikit_learn import KerasClassifier
 def create_model():
     # create model
     model = Sequential()
+    # 103 is the number of X columns after the get_dummies() call
     model.add(Dense(12, input_dim=103, activation='relu'))
     model.add(Dense(8, activation='relu'))
     model.add(Dense(1, activation='sigmoid'))

--- a/test_othermlpackages/test_tensorflow.py
+++ b/test_othermlpackages/test_tensorflow.py
@@ -13,7 +13,7 @@ from tensorflow.keras.wrappers.scikit_learn import KerasClassifier
 def create_model():
     # create model
     model = Sequential()
-    model.add(Dense(12, input_dim=8, activation='relu'))
+    model.add(Dense(12, input_dim=103, activation='relu'))
     model.add(Dense(8, activation='relu'))
     model.add(Dense(1, activation='sigmoid'))
     # Compile model
@@ -26,3 +26,16 @@ def test_expgrad_classification():
     disparity_moment = DemographicParity()
 
     ptc.run_expgrad_classification(estimator, disparity_moment)
+
+
+def test_gridsearch_classification():
+    estimator = KerasClassifier(build_fn=create_model)
+    disparity_moment = DemographicParity()
+
+    ptc.run_gridsearch_classification(estimator, disparity_moment)
+
+
+def test_thresholdoptimizer_classification():
+    estimator = KerasClassifier(build_fn=create_model)
+
+    ptc.run_thresholdoptimizer_classification(estimator)


### PR DESCRIPTION
Add TensorFlow to the `test_othermlpackages/` directory. Some product code modifications were required, since it appears that:

- `KerasClassifier.fit()` doesn't return `self`
- `KerasClassifier.predict()` returns an array of shape (n,1) and not of shape (n). This is important when subtracting from a pandas Series

Also tweak the pipeline so that changes to the `test_othermlpackages/` directory should trigger it as a gate.