### PR TITLE
Fix pypandoc warning in doc build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,10 @@ jobs:
       - checkout
 
       - run:
+          name: Install pandoc
+          command: sudo apt-get install pandoc pandoc-citeproc
+
+      - run:
           name: Upgrade pip, setuptools, and wheel before installing other dependencies
           command: sudo python -m pip install --upgrade pip setuptools wheel
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,10 @@ jobs:
     steps:
       # check out PR branch
       - checkout
+      
+      - run:
+          name: Install pandoc
+          command: sudo apt-get install pandoc pandoc-citeproc
 
       - run:
           name: Upgrade pip, setuptools, and wheel before installing other dependencies

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -31,6 +31,7 @@ nbval
 
 # Required for documentation
 bokeh
+pypandoc
 sphinx
 sphinx-gallery>=0.8.1
 pydata-sphinx-theme


### PR DESCRIPTION
The documentation builds have a warning about the `pypandoc` package being missing. Add it to the `requirements-dev.txt` file, and also ensure that `pandoc` itself is installed on the machines which build the documentation.

Closes #589 