### PR TITLE
Improve notebook contributing guide

### DIFF
--- a/docs/contributor_guide/contributing_example_notebooks.rst
+++ b/docs/contributor_guide/contributing_example_notebooks.rst
@@ -39,7 +39,7 @@ This allows them to be rendered properly with output from all cells.
 
     Rendering the Fairlearn dashboard is still an outstanding issue.
 
-These notebooks are generated based on `.py` files in
+These notebooks are generated based on `plot_*.py` files in
 `percent format <https://jupytext.readthedocs.io/en/latest/formats.html#the-percent-format>`_
 in the
 `examples/notebooks directory <https://github.com/fairlearn/fairlearn/tree/master/examples/notebooks>`_
@@ -47,6 +47,7 @@ of the repository.
 To do this yourself make sure to install sphinx and its
 add-ons by running :code:`python scripts/install_requirements.py --pinned False` in the repository
 root directory. You may also need to `install Pandoc <https://pandoc.org/installing.html>`_.
+The filename *must* begin with `plot_` for the cell output to be rendered as a webpage.
 
 To build the webpage run the following command from the repository root
 directory:

--- a/docs/contributor_guide/contributing_example_notebooks.rst
+++ b/docs/contributor_guide/contributing_example_notebooks.rst
@@ -44,7 +44,7 @@ These notebooks are generated based on `.py` files in
 in the
 `examples/notebooks directory <https://github.com/fairlearn/fairlearn/tree/master/examples/notebooks>`_
 of the repository. To do this yourself make sure to install sphinx and its
-add-ons by running :code:`pip install -r requirements.txt` in the repository
+add-ons by running :code:`python scripts/install_requirements.py --pinned False` in the repository
 root directory.
 
 To build the webpage run the following command from the repository root

--- a/docs/contributor_guide/contributing_example_notebooks.rst
+++ b/docs/contributor_guide/contributing_example_notebooks.rst
@@ -43,9 +43,10 @@ These notebooks are generated based on `.py` files in
 `percent format <https://jupytext.readthedocs.io/en/latest/formats.html#the-percent-format>`_
 in the
 `examples/notebooks directory <https://github.com/fairlearn/fairlearn/tree/master/examples/notebooks>`_
-of the repository. To do this yourself make sure to install sphinx and its
+of the repository.
+To do this yourself make sure to install sphinx and its
 add-ons by running :code:`python scripts/install_requirements.py --pinned False` in the repository
-root directory.
+root directory. You may also need to `install Pandoc <https://pandoc.org/installing.html>`_.
 
 To build the webpage run the following command from the repository root
 directory:

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,8 @@ exclude =
 # RST304 is about "unknown text roles" in sphinx. Unfortunately, things like :class: appear to be unknown
 # RST902 is from trouble parsing the __all__ entry. This only happens in a single file
 # D413 requires an empty line at the end of every docstring.
+# The suppressions on examples/plot_*.py are on files which are turned into notebooks.
+# These files have particular syntax requirements.
 per-file-ignores = 
     setup.py:D100
     docs/*.py:D100,A001
@@ -28,4 +30,4 @@ per-file-ignores =
     test/*.py:D104
     test/*/*.py:D100,D101,D102,D103,D104,D105,D107
     test_othermlpackages/*.py:D100,D101,D102,D103,D104,D105,D107
-    **/plot_*.py:E501,E402,D101,D102,D103,D107,D205,D400
+    examples/plot_*.py:E501,E402,D101,D102,D103,D107,D205,D400


### PR DESCRIPTION
Correct the developer setup command in the notebook contributing guide. Also highlight the need to prefix the filenames with `plot_` in order to have the outputs rendered on the webpage.

Make the flake8 suppressions for these files more targeted.