### PR TITLE
Start adding PEP484 annotations

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,7 @@ release = fairlearn.__version__
 extensions = [
     'bokeh.sphinxext.bokeh_plot',
     'sphinx.ext.autodoc',
+    'sphinx_autodoc_typehints',
     'sphinx.ext.doctest',
     'sphinx.ext.extlinks',
     'sphinx.ext.intersphinx',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,14 +43,14 @@ release = fairlearn.__version__
 extensions = [
     'bokeh.sphinxext.bokeh_plot',
     'sphinx.ext.autodoc',
-    'sphinx_autodoc_typehints',
     'sphinx.ext.doctest',
     'sphinx.ext.extlinks',
     'sphinx.ext.intersphinx',
     'sphinx.ext.linkcode',
     'sphinx.ext.mathjax',
     'sphinx.ext.napoleon',
-    'sphinx_gallery.gen_gallery'
+    'sphinx_gallery.gen_gallery',
+    'sphinx_autodoc_typehints',  # Has to load after Napoleon
 ]
 
 intersphinx_mapping = {'python3': ('https://docs.python.org/3', None),
@@ -115,10 +115,10 @@ pygments_style = 'sphinx'
 # included in the gallery, but its plot is available for
 # the quickstart
 sphinx_gallery_conf = {
-     'examples_dirs': '../examples',
-     'gallery_dirs': 'auto_examples',
-     # pypandoc enables rst to md conversion in downloadable notebooks
-     'pypandoc': True,
+    'examples_dirs': '../examples',
+    'gallery_dirs': 'auto_examples',
+    # pypandoc enables rst to md conversion in downloadable notebooks
+    'pypandoc': True,
 }
 
 

--- a/fairlearn/metrics/_disparities.py
+++ b/fairlearn/metrics/_disparities.py
@@ -2,6 +2,9 @@
 # Licensed under the MIT License.
 
 """Metrics for measuring disparity."""
+import numpy as np
+import pandas as pd
+from typing import Optional, Union
 
 from ._metrics_engine import (
     selection_rate_difference,
@@ -12,14 +15,29 @@ from ._metrics_engine import (
     false_positive_rate_ratio)
 
 
-def demographic_parity_difference(y_true, y_pred, *, sensitive_features, sample_weight=None):
+def demographic_parity_difference(
+        y_true: Union[list, np.ndarray, pd.Series, pd.DataFrame],
+        y_pred: Union[list, np.ndarray, pd.Series, pd.DataFrame],
+        *,
+        sensitive_features: Union[list, np.ndarray, pd.Series, pd.DataFrame],
+        sample_weight: Optional[Union[list, np.ndarray, pd.Series, pd.DataFrame]]) -> float:
     """Calculate the demographic parity difference.
 
-    :param 1D-array y_true: Ground truth (correct) labels.
-    :param 1D-array y_pred: Predicted labels :math:`h(X)` returned by the classifier.
-    :param 1D-array sensitive_features: Sensitive features.
-    :param 1D-array sample_weight: Sample weights.
-    :return: The difference between the largest and the smallest group-level selection rate,
+    Parameters
+    ----------
+    y_true :
+        Ground truth (correct) labels.
+    y_pred :
+        Predicted labels :math:`h(X)` returned by the classifier.
+    sensitive_features :
+        Sensitive features.
+    sample_weight :
+        Sample weights.
+
+    Returns
+    -------
+    float
+        The difference between the largest and the smallest group-level selection rate,
         :math:`E[h(X) | A=a]`, across all values :math:`a` of the sensitive feature.
         The demographic parity difference of 0 means that all groups have the same selection rate.
     """

--- a/fairlearn/metrics/_disparities.py
+++ b/fairlearn/metrics/_disparities.py
@@ -20,7 +20,7 @@ def demographic_parity_difference(
         y_pred: Union[list, np.ndarray, pd.Series, pd.DataFrame],
         *,
         sensitive_features: Union[list, np.ndarray, pd.Series, pd.DataFrame],
-        sample_weight: Optional[Union[list, np.ndarray, pd.Series, pd.DataFrame]]) -> float:
+        sample_weight: Optional[Union[list, np.ndarray, pd.Series, pd.DataFrame]] = None) -> float:
     """Calculate the demographic parity difference.
 
     Parameters

--- a/fairlearn/metrics/_extra_metrics.py
+++ b/fairlearn/metrics/_extra_metrics.py
@@ -7,7 +7,9 @@ These are metrics which are not part of `scikit-learn`.
 """
 
 import numpy as np
+import pandas as pd
 import sklearn.metrics as skm
+from typing import Any, List, Optional, Union
 
 from ._balanced_root_mean_squared_error import _balanced_root_mean_squared_error  # noqa: F401
 from ._mean_predictions import mean_prediction, _mean_overprediction, _mean_underprediction  # noqa: F401,E501
@@ -18,7 +20,7 @@ _RESTRICTED_VALS_IF_POS_LABEL_NONE = "If pos_label is not specified, values must
 _NEED_POS_LABEL_IN_Y_VALS = "Must have pos_label in y values"
 
 
-def _get_labels_for_confusion_matrix(labels, pos_label):
+def _get_labels_for_confusion_matrix(labels, pos_label) -> List[Any]:
     r"""Figure out the labels argument for skm.confusion_matrix.
 
     This is an internal method used by the true/false positive/negative
@@ -76,22 +78,26 @@ def _get_labels_for_confusion_matrix(labels, pos_label):
     return unique_labels
 
 
-def true_positive_rate(y_true, y_pred, sample_weight=None, pos_label=None):
+def true_positive_rate(
+        y_true: Union[list, np.ndarray, pd.Series, pd.DataFrame],
+        y_pred: Union[list, np.ndarray, pd.Series, pd.DataFrame],
+        sample_weight: Optional[Union[list, np.ndarray, pd.Series, pd.DataFrame]] = None,
+        pos_label: Optional[Any] = None) -> float:
     r"""Calculate the true positive rate (also called sensitivity, recall, or hit rate).
 
     Parameters
     ----------
-    y_true : array-like
+    y_true :
         The list of true values
 
-    y_pred : array-like
+    y_pred :
         The list of predicted values
 
-    sample_weight : array-like, optional
+    sample_weight :
         A list of weights to apply to each sample. By default all samples are weighted
         equally
 
-    pos_label : scalar, optional
+    pos_label :
         The value to treat as the 'positive' label in the samples. If `None` (the default)
         then the largest unique value of the y arrays will be used.
 
@@ -107,22 +113,26 @@ def true_positive_rate(y_true, y_pred, sample_weight=None, pos_label=None):
     return tpr
 
 
-def true_negative_rate(y_true, y_pred, sample_weight=None, pos_label=None):
+def true_negative_rate(
+        y_true: Union[list, np.ndarray, pd.Series, pd.DataFrame],
+        y_pred: Union[list, np.ndarray, pd.Series, pd.DataFrame],
+        sample_weight: Optional[Union[list, np.ndarray, pd.Series, pd.DataFrame]] = None,
+        pos_label: Optional[Any] = None) -> float:
     r"""Calculate the true negative rate (also called specificity or selectivity).
 
     Parameters
     ----------
-    y_true : array-like
+    y_true :
         The list of true values
 
-    y_pred : array-like
+    y_pred :
         The list of predicted values
 
-    sample_weight : array-like, optional
+    sample_weight :
         A list of weights to apply to each sample. By default all samples are weighted
         equally
 
-    pos_label : scalar, optional
+    pos_label :
         The value to treat as the 'positive' label in the samples. If `None` (the default)
         then the largest unique value of the y arrays will be used.
 
@@ -138,22 +148,26 @@ def true_negative_rate(y_true, y_pred, sample_weight=None, pos_label=None):
     return tnr
 
 
-def false_positive_rate(y_true, y_pred, sample_weight=None, pos_label=None):
+def false_positive_rate(
+        y_true: Union[list, np.ndarray, pd.Series, pd.DataFrame],
+        y_pred: Union[list, np.ndarray, pd.Series, pd.DataFrame],
+        sample_weight: Optional[Union[list, np.ndarray, pd.Series, pd.DataFrame]] = None,
+        pos_label: Optional[Any] = None) -> float:
     r"""Calculate the false positive rate (also called fall-out).
 
     Parameters
     ----------
-    y_true : array-like
+    y_true :
         The list of true values
 
-    y_pred : array-like
+    y_pred :
         The list of predicted values
 
-    sample_weight : array-like, optional
+    sample_weight :
         A list of weights to apply to each sample. By default all samples are weighted
         equally
 
-    pos_label : scalar, optional
+    pos_label :
         The value to treat as the 'positive' label in the samples. If `None` (the default)
         then the largest unique value of the y arrays will be used.
 
@@ -169,22 +183,26 @@ def false_positive_rate(y_true, y_pred, sample_weight=None, pos_label=None):
     return fpr
 
 
-def false_negative_rate(y_true, y_pred, sample_weight=None, pos_label=None):
+def false_negative_rate(
+        y_true: Union[list, np.ndarray, pd.Series, pd.DataFrame],
+        y_pred: Union[list, np.ndarray, pd.Series, pd.DataFrame],
+        sample_weight: Optional[Union[list, np.ndarray, pd.Series, pd.DataFrame]] = None,
+        pos_label: Optional[Any] = None) -> float:
     r"""Calculate the false negative rate (also called miss rate).
 
     Parameters
     ----------
-    y_true : array-like
+    y_true :
         The list of true values
 
-    y_pred : array-like
+    y_pred :
         The list of predicted values
 
-    sample_weight : array-like, optional
+    sample_weight :
         A list of weights to apply to each sample. By default all samples are weighted
         equally
 
-    pos_label : scalar, optional
+    pos_label :
         The value to treat as the 'positive' label in the samples. If `None` (the default)
         then the largest unique value of the y arrays will be used.
 
@@ -200,6 +218,6 @@ def false_negative_rate(y_true, y_pred, sample_weight=None, pos_label=None):
     return fnr
 
 
-def _root_mean_squared_error(y_true, y_pred, **kwargs):
+def _root_mean_squared_error(y_true, y_pred, **kwargs) -> float:
     r"""Calculate the root mean squared error."""
     return skm.mean_squared_error(y_true, y_pred, squared=False, **kwargs)

--- a/fairlearn/reductions/__init__.py
+++ b/fairlearn/reductions/__init__.py
@@ -43,4 +43,4 @@ _moments = [
     "ZeroOneLoss"
 ]
 
-__all__ = [] + _exponentiated_gradient + _grid_search + _moments
+__all__ = _exponentiated_gradient + _grid_search + _moments

--- a/fairlearn/reductions/__init__.py
+++ b/fairlearn/reductions/__init__.py
@@ -43,4 +43,4 @@ _moments = [
     "ZeroOneLoss"
 ]
 
-__all__ = _exponentiated_gradient + _grid_search + _moments
+__all__ = [] + _exponentiated_gradient + _grid_search + _moments

--- a/fairlearn/reductions/_grid_search/grid_search.py
+++ b/fairlearn/reductions/_grid_search/grid_search.py
@@ -49,7 +49,7 @@ class GridSearch(BaseEstimator, MetaEstimatorMixin):
         the relative weight put on the constraint violation when selecting the
         best model. The weight placed on the error rate will be
         :code:`1-constraint_weight`
-    grid_size : 
+    grid_size :
         The number of Lagrange multipliers to generate in the grid
     grid_limit : float
         The largest Lagrange multiplier to generate. The grid will contain

--- a/fairlearn/reductions/_grid_search/grid_search.py
+++ b/fairlearn/reductions/_grid_search/grid_search.py
@@ -9,6 +9,7 @@ from sklearn.base import BaseEstimator, MetaEstimatorMixin
 from sklearn.dummy import DummyClassifier
 from sklearn.utils.validation import check_is_fitted
 from time import time
+from typing import Optional, Union
 
 from fairlearn._input_validation import _validate_and_reformat_input, _KW_SENSITIVE_FEATURES
 from fairlearn.reductions._moments import Moment, ClassificationMoment
@@ -36,27 +37,27 @@ class GridSearch(BaseEstimator, MetaEstimatorMixin):
         In binary classification labels `y` and predictions returned by
         :code:`predict(X)` are either 0 or 1.
         In regression values `y` and predictions are continuous.
-    constraints : fairlearn.reductions.Moment
+    constraints :
         The disparity constraints expressed as moments
-    selection_rule : str
+    selection_rule :
         Specifies the procedure for selecting the best model found by the grid
         search. At the present time, the only valid value is
         "tradeoff_optimization" which minimizes a weighted sum of the error
         rate and constraint violation.
-    constraint_weight : float
+    constraint_weight :
         When the `selection_rule` is "tradeoff_optimization" this specifies
         the relative weight put on the constraint violation when selecting the
         best model. The weight placed on the error rate will be
         :code:`1-constraint_weight`
-    grid_size : int
+    grid_size : 
         The number of Lagrange multipliers to generate in the grid
     grid_limit : float
         The largest Lagrange multiplier to generate. The grid will contain
         values distributed between :code:`-grid_limit` and :code:`grid_limit`
         by default
-    grid_offset : :class:`pandas:pandas.DataFrame`
-        Shifts the grid of Lagrangian multiplier by that value.
-        It is '0' by default
+    grid_offset :
+        Shifts the grid of Lagrangian multipliers by that value.
+        If not specified, the grid is left untouched.
     grid :
         Instead of supplying a size and limit for the grid, users may specify
         the exact set of Lagrange multipliers they desire using this argument.
@@ -64,12 +65,12 @@ class GridSearch(BaseEstimator, MetaEstimatorMixin):
 
     def __init__(self,
                  estimator,
-                 constraints,
-                 selection_rule=TRADEOFF_OPTIMIZATION,
-                 constraint_weight=0.5,
-                 grid_size=10,
-                 grid_limit=2.0,
-                 grid_offset=None,
+                 constraints: Moment,
+                 selection_rule: str = TRADEOFF_OPTIMIZATION,
+                 constraint_weight: float = 0.5,
+                 grid_size: int = 10,
+                 grid_limit: float = 2.0,
+                 grid_offset: Optional[pd.DataFrame] = None,
                  grid=None):
         """Construct a GridSearch object."""
         self.estimator = estimator
@@ -91,22 +92,27 @@ class GridSearch(BaseEstimator, MetaEstimatorMixin):
         self.grid_offset = grid_offset
         self.grid = grid
 
-    def fit(self, X, y, **kwargs):
+    def fit(self,
+            X: Union[np.ndarray, pd.DataFrame],
+            y: Union[list, np.ndarray, pd.Series, pd.DataFrame],
+            **kwargs):
         """Run the grid search.
 
         This will result in multiple copies of the
         estimator being made, and the :code:`fit(X)` method
         of each one called.
 
-        :param X: The feature matrix
-        :type X: numpy.ndarray or pandas.DataFrame
+        Parameters
+        ----------
+        X:
+            The feature matrix
 
-        :param y: The label vector
-        :type y: numpy.ndarray, pandas.DataFrame, pandas.Series, or list
+        y:
+            The label vector
 
-        :param sensitive_features: A (currently) required keyword argument listing the
+        sensitive_features:
+            A (currently) required keyword argument listing the
             feature used by the constraints object
-        :type sensitive_features: numpy.ndarray, pandas.DataFrame, pandas.Series, or list (for now)
         """
         self.predictors_ = []
         self.lambda_vecs_ = pd.DataFrame(dtype=np.float64)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ flake8-copyright
 flake8-docstrings
 flake8-logging-format
 flake8-rst-docstrings
+mypy
 requirements-parser
 
 # Required for test

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -33,5 +33,6 @@ nbval
 bokeh
 pypandoc
 sphinx
+sphinx-autodoc-typehints
 sphinx-gallery>=0.8.1
 pydata-sphinx-theme

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,3 +31,27 @@ per-file-ignores =
     test/*/*.py:D100,D101,D102,D103,D104,D105,D107
     test_othermlpackages/*.py:D100,D101,D102,D103,D104,D105,D107
     examples/plot_*.py:E501,E402,D101,D102,D103,D107,D205,D400
+
+# ==============================
+# MyPy
+
+[mypy-IPython.*]
+ignore_missing_imports = True
+
+[mypy-matplotlib.*]
+ignore_missing_imports = True
+
+[mypy-numpy.*]
+ignore_missing_imports = True
+
+[mypy-pandas.*]
+ignore_missing_imports = True
+
+[mypy-rai_core_flask.*]
+ignore_missing_imports = True
+
+[mypy-scipy.*]
+ignore_missing_imports = True
+
+[mypy-sklearn.*]
+ignore_missing_imports = True


### PR DESCRIPTION
Experimenting with [PEP 484](https://www.python.org/dev/peps/pep-0484) annotations to some routines within Fairlearn. Eventually, this will allow us to run a tools such as [`mypy`](https://mypy.readthedocs.io/en/stable/) which can perform static type checking, and could be run as part of our gates.