### PR TITLE
Add sample_weight_name argument to Reductions

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -3,6 +3,7 @@
 All names are sorted alphabetically by last name. Contributors, please add your name to the list when you submit a patch to the project.
 
 - [Sarah Bird](https://github.com/slbird)
+- [Frederic Branchaud-Charron](https://github.com/Dref360)
 - [Rishit Dagli](https://github.com/Rishit-dagli)
 - [Miro Dudik](https://github.com/MiroDudik)
 - [Richard Edgar](https://github.com/riedgar-ms)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,8 @@
 * Add class `InterpolatedThresholder` to represent the fitted `ThresholdOptimizer`
 * Add `fairlearn.datasets` module.
 * Change the method to make copies of the estimator in `ExponentiatedGradient` from `pickle.dump` to `sklearn.clone`. 
+* Add an argument to GridSearch and ExponentialGradient `sample_weight_name` to control
+  how `sample_weight` is supplied to `estimator.fit`.
 
 ### v0.4.6
 

--- a/fairlearn/reductions/_exponentiated_gradient/_lagrangian.py
+++ b/fairlearn/reductions/_exponentiated_gradient/_lagrangian.py
@@ -38,9 +38,12 @@ class _Lagrangian:
     opt_lambda : bool
         indicates whether to optimize lambda during the calculation of the
         Lagrangian; optional with default value True
+    sample_weight_key : str
+        Argument to supply `sample_weight` in `estimator.fit`.
     """
 
-    def __init__(self, X, sensitive_features, y, estimator, constraints, B, opt_lambda=True):
+    def __init__(self, X, sensitive_features, y, estimator, constraints, B, opt_lambda=True,
+                 sample_weight_key='sample_weight'):
         self.X = X
         self.n = self.X.shape[0]
         self.y = y
@@ -61,6 +64,7 @@ class _Lagrangian:
         self.n_oracle_calls_dummy_returned = 0
         self.last_linprog_n_hs = 0
         self.last_linprog_result = None
+        self.sample_weight_key = sample_weight_key
 
     def _eval(self, Q, lambda_vec):
         """Return the value of the Lagrangian.
@@ -170,7 +174,7 @@ class _Lagrangian:
             estimator = clone(estimator=self.estimator, safe=False)
 
         oracle_call_start_time = time()
-        estimator.fit(self.X, redY, sample_weight=redW)
+        estimator.fit(self.X, redY, **{self.sample_weight_key: redW})
         self.oracle_execution_times.append(time() - oracle_call_start_time)
         self.n_oracle_calls += 1
 

--- a/fairlearn/reductions/_exponentiated_gradient/_lagrangian.py
+++ b/fairlearn/reductions/_exponentiated_gradient/_lagrangian.py
@@ -39,7 +39,8 @@ class _Lagrangian:
         indicates whether to optimize lambda during the calculation of the
         Lagrangian; optional with default value True
     sample_weight_key : str
-        Argument to supply `sample_weight` in `estimator.fit`.
+        Name of the argument to `estimator.fit()` which supplies the sample weights
+        (defaults to `sample_weight`)
     """
 
     def __init__(self, X, sensitive_features, y, estimator, constraints, B, opt_lambda=True,

--- a/fairlearn/reductions/_exponentiated_gradient/_lagrangian.py
+++ b/fairlearn/reductions/_exponentiated_gradient/_lagrangian.py
@@ -38,13 +38,13 @@ class _Lagrangian:
     opt_lambda : bool
         indicates whether to optimize lambda during the calculation of the
         Lagrangian; optional with default value True
-    sample_weight_key : str
+    sample_weight_name : str
         Name of the argument to `estimator.fit()` which supplies the sample weights
         (defaults to `sample_weight`)
     """
 
     def __init__(self, X, sensitive_features, y, estimator, constraints, B, opt_lambda=True,
-                 sample_weight_key='sample_weight'):
+                 sample_weight_name='sample_weight'):
         self.X = X
         self.n = self.X.shape[0]
         self.y = y
@@ -65,7 +65,7 @@ class _Lagrangian:
         self.n_oracle_calls_dummy_returned = 0
         self.last_linprog_n_hs = 0
         self.last_linprog_result = None
-        self.sample_weight_key = sample_weight_key
+        self.sample_weight_name = sample_weight_name
 
     def _eval(self, Q, lambda_vec):
         """Return the value of the Lagrangian.
@@ -175,7 +175,7 @@ class _Lagrangian:
             estimator = clone(estimator=self.estimator, safe=False)
 
         oracle_call_start_time = time()
-        estimator.fit(self.X, redY, **{self.sample_weight_key: redW})
+        estimator.fit(self.X, redY, **{self.sample_weight_name: redW})
         self.oracle_execution_times.append(time() - oracle_call_start_time)
         self.n_oracle_calls += 1
 

--- a/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
+++ b/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
@@ -51,10 +51,13 @@ class ExponentiatedGradient(BaseEstimator, MetaEstimatorMixin):
         if True each step of exponentiated gradient is followed by the saddle
         point optimization over the convex hull of classifiers returned so
         far; default True
+    sample_weight_key : str
+        Argument to supply `sample_weight` in `estimator.fit`.
     """
 
     def __init__(self, estimator, constraints, eps=0.01, max_iter=50, nu=None,
-                 eta0=2.0, run_linprog_step=True):  # noqa: D103
+                 eta0=2.0, run_linprog_step=True,
+                 sample_weight_key='sample_weight'):  # noqa: D103
         self.estimator = estimator
         self.constraints = constraints
         self.eps = eps
@@ -62,6 +65,7 @@ class ExponentiatedGradient(BaseEstimator, MetaEstimatorMixin):
         self.nu = nu
         self.eta0 = eta0
         self.run_linprog_step = run_linprog_step
+        self.sample_weight_key = sample_weight_key
 
     def fit(self, X, y, **kwargs):
         """Return a fair classifier under specified fairness constraints.
@@ -93,7 +97,8 @@ class ExponentiatedGradient(BaseEstimator, MetaEstimatorMixin):
 
         B = 1 / self.eps
         lagrangian = _Lagrangian(X, sensitive_features, y_train, self.estimator,
-                                 self.constraints, B)
+                                 self.constraints, B,
+                                 sample_weight_key=self.sample_weight_key)
 
         theta = pd.Series(0, lagrangian.constraints.index)
         Qsum = pd.Series(dtype="float64")

--- a/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
+++ b/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
@@ -52,7 +52,8 @@ class ExponentiatedGradient(BaseEstimator, MetaEstimatorMixin):
         point optimization over the convex hull of classifiers returned so
         far; default True
     sample_weight_key : str
-        Argument to supply `sample_weight` in `estimator.fit`.
+        Name of the argument to `estimator.fit()` which supplies the sample weights
+        (defaults to `sample_weight`)
     """
 
     def __init__(self, estimator, constraints, eps=0.01, max_iter=50, nu=None,

--- a/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
+++ b/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
@@ -51,14 +51,14 @@ class ExponentiatedGradient(BaseEstimator, MetaEstimatorMixin):
         if True each step of exponentiated gradient is followed by the saddle
         point optimization over the convex hull of classifiers returned so
         far; default True
-    sample_weight_key : str
+    sample_weight_name : str
         Name of the argument to `estimator.fit()` which supplies the sample weights
         (defaults to `sample_weight`)
     """
 
     def __init__(self, estimator, constraints, eps=0.01, max_iter=50, nu=None,
                  eta0=2.0, run_linprog_step=True,
-                 sample_weight_key='sample_weight'):  # noqa: D103
+                 sample_weight_name='sample_weight'):  # noqa: D103
         self.estimator = estimator
         self.constraints = constraints
         self.eps = eps
@@ -66,7 +66,7 @@ class ExponentiatedGradient(BaseEstimator, MetaEstimatorMixin):
         self.nu = nu
         self.eta0 = eta0
         self.run_linprog_step = run_linprog_step
-        self.sample_weight_key = sample_weight_key
+        self.sample_weight_name = sample_weight_name
 
     def fit(self, X, y, **kwargs):
         """Return a fair classifier under specified fairness constraints.
@@ -99,7 +99,7 @@ class ExponentiatedGradient(BaseEstimator, MetaEstimatorMixin):
         B = 1 / self.eps
         lagrangian = _Lagrangian(X, sensitive_features, y_train, self.estimator,
                                  self.constraints, B,
-                                 sample_weight_key=self.sample_weight_key)
+                                 sample_weight_name=self.sample_weight_name)
 
         theta = pd.Series(0, lagrangian.constraints.index)
         Qsum = pd.Series(dtype="float64")

--- a/fairlearn/reductions/_grid_search/grid_search.py
+++ b/fairlearn/reductions/_grid_search/grid_search.py
@@ -60,7 +60,7 @@ class GridSearch(BaseEstimator, MetaEstimatorMixin):
     grid :
         Instead of supplying a size and limit for the grid, users may specify
         the exact set of Lagrange multipliers they desire using this argument.
-    sample_weight_key : str
+    sample_weight_name : str
         Name of the argument to `estimator.fit()` which supplies the sample weights
         (defaults to `sample_weight`)
     """
@@ -74,7 +74,7 @@ class GridSearch(BaseEstimator, MetaEstimatorMixin):
                  grid_limit=2.0,
                  grid_offset=None,
                  grid=None,
-                 sample_weight_key="sample_weight"):
+                 sample_weight_name="sample_weight"):
         """Construct a GridSearch object."""
         self.estimator = estimator
         if not isinstance(constraints, Moment):
@@ -94,7 +94,7 @@ class GridSearch(BaseEstimator, MetaEstimatorMixin):
         self.grid_limit = float(grid_limit)
         self.grid_offset = grid_offset
         self.grid = grid
-        self.sample_weight_key = sample_weight_key
+        self.sample_weight_name = sample_weight_name
 
     def fit(self, X, y, **kwargs):
         """Run the grid search.
@@ -182,7 +182,7 @@ class GridSearch(BaseEstimator, MetaEstimatorMixin):
                 current_estimator = copy.deepcopy(self.estimator)
 
             oracle_call_start_time = time()
-            current_estimator.fit(X, y_reduction, **{self.sample_weight_key: weights})
+            current_estimator.fit(X, y_reduction, **{self.sample_weight_name: weights})
             oracle_call_execution_time = time() - oracle_call_start_time
             logger.debug("Call to estimator complete")
 

--- a/fairlearn/reductions/_grid_search/grid_search.py
+++ b/fairlearn/reductions/_grid_search/grid_search.py
@@ -60,6 +60,8 @@ class GridSearch(BaseEstimator, MetaEstimatorMixin):
     grid :
         Instead of supplying a size and limit for the grid, users may specify
         the exact set of Lagrange multipliers they desire using this argument.
+    sample_weight_key : str
+        Argument to supply `sample_weight` in `estimator.fit`.
     """
 
     def __init__(self,
@@ -70,7 +72,8 @@ class GridSearch(BaseEstimator, MetaEstimatorMixin):
                  grid_size=10,
                  grid_limit=2.0,
                  grid_offset=None,
-                 grid=None):
+                 grid=None,
+                 sample_weight_key="sample_weight"):
         """Construct a GridSearch object."""
         self.estimator = estimator
         if not isinstance(constraints, Moment):
@@ -90,6 +93,7 @@ class GridSearch(BaseEstimator, MetaEstimatorMixin):
         self.grid_limit = float(grid_limit)
         self.grid_offset = grid_offset
         self.grid = grid
+        self.sample_weight_key = sample_weight_key
 
     def fit(self, X, y, **kwargs):
         """Run the grid search.
@@ -177,7 +181,7 @@ class GridSearch(BaseEstimator, MetaEstimatorMixin):
                 current_estimator = copy.deepcopy(self.estimator)
 
             oracle_call_start_time = time()
-            current_estimator.fit(X, y_reduction, sample_weight=weights)
+            current_estimator.fit(X, y_reduction, **{self.sample_weight_key: weights})
             oracle_call_execution_time = time() - oracle_call_start_time
             logger.debug("Call to estimator complete")
 

--- a/fairlearn/reductions/_grid_search/grid_search.py
+++ b/fairlearn/reductions/_grid_search/grid_search.py
@@ -61,7 +61,8 @@ class GridSearch(BaseEstimator, MetaEstimatorMixin):
         Instead of supplying a size and limit for the grid, users may specify
         the exact set of Lagrange multipliers they desire using this argument.
     sample_weight_key : str
-        Argument to supply `sample_weight` in `estimator.fit`.
+        Name of the argument to `estimator.fit()` which supplies the sample weights
+        (defaults to `sample_weight`)
     """
 
     def __init__(self,

--- a/test/unit/reductions/exponentiated_gradient/test_exponentiatedgradient_arguments.py
+++ b/test/unit/reductions/exponentiated_gradient/test_exponentiatedgradient_arguments.py
@@ -5,6 +5,8 @@ import numpy as np
 import pandas as pd
 import pytest
 from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
 
 from fairlearn.reductions import ExponentiatedGradient
 from fairlearn.reductions import DemographicParity
@@ -161,3 +163,24 @@ class TestExponentiatedGradientArguments:
         with pytest.raises(ValueError) as execInfo:
             expgrad.fit(X, y, sensitive_features=(A))
         assert _LABELS_NOT_0_1_ERROR_MESSAGE == execInfo.value.args[0]
+
+    def test_sample_weights_argument(self):
+        estimator = Pipeline(
+            [('scaler', StandardScaler()),
+             ('logistic', LogisticRegression(solver='liblinear'))])
+
+        X, y, A = _get_data()
+
+        expgrad = ExponentiatedGradient(estimator,
+                                        constraints=DemographicParity(),
+                                        max_iter=1)
+
+        with pytest.raises(ValueError) as execInfo:
+            expgrad.fit(X, y, sensitive_features=(A))
+        assert 'Pipeline.fit does not accept the sample_weight parameter' in execInfo.value.args[0]
+
+        expgrad = ExponentiatedGradient(estimator,
+                                        constraints=DemographicParity(),
+                                        max_iter=1,
+                                        sample_weight_key='logistic__sample_weight')
+        expgrad.fit(X, y, sensitive_features=(A))

--- a/test/unit/reductions/exponentiated_gradient/test_exponentiatedgradient_arguments.py
+++ b/test/unit/reductions/exponentiated_gradient/test_exponentiatedgradient_arguments.py
@@ -182,5 +182,5 @@ class TestExponentiatedGradientArguments:
         expgrad = ExponentiatedGradient(estimator,
                                         constraints=DemographicParity(),
                                         max_iter=1,
-                                        sample_weight_key='logistic__sample_weight')
+                                        sample_weight_name='logistic__sample_weight')
         expgrad.fit(X, y, sensitive_features=(A))

--- a/test/unit/reductions/grid_search/test_grid_search_arguments.py
+++ b/test/unit/reductions/grid_search/test_grid_search_arguments.py
@@ -9,6 +9,9 @@ from sklearn.linear_model import LogisticRegression, LinearRegression
 
 
 from sklearn.exceptions import NotFittedError
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
 from fairlearn._input_validation import \
     (_MESSAGE_Y_NONE,
      _LABELS_NOT_0_1_ERROR_MESSAGE)
@@ -46,7 +49,8 @@ class ArgumentTests:
     @pytest.mark.parametrize("A_two_dim", [False, True])
     @pytest.mark.uncollect_if(func=is_invalid_transformation)
     def test_valid_inputs(self, transformX, transformY, transformA, A_two_dim):
-        gs = GridSearch(self.estimator, self.disparity_criterion, grid_size=2)
+        gs = GridSearch(self.estimator, self.disparity_criterion, grid_size=2,
+                        sample_weight_key=self.sample_weight_key)
         X, Y, A = _quick_data(A_two_dim)
         gs.fit(transformX(X),
                transformY(Y),
@@ -60,7 +64,8 @@ class ArgumentTests:
     @pytest.mark.parametrize("A_two_dim", [False, True])
     @pytest.mark.uncollect_if(func=is_invalid_transformation)
     def test_X_is_None(self, transformY, transformA, A_two_dim):
-        gs = GridSearch(self.estimator, self.disparity_criterion, grid_size=3)
+        gs = GridSearch(self.estimator, self.disparity_criterion, grid_size=3,
+                        sample_weight_key=self.sample_weight_key)
         _, Y, A = _quick_data(A_two_dim)
 
         with pytest.raises(ValueError) as execInfo:
@@ -75,7 +80,8 @@ class ArgumentTests:
     @pytest.mark.parametrize("A_two_dim", [False, True])
     @pytest.mark.uncollect_if(func=is_invalid_transformation)
     def test_Y_is_None(self, transformX, transformA, A_two_dim):
-        gs = GridSearch(self.estimator, self.disparity_criterion)
+        gs = GridSearch(self.estimator, self.disparity_criterion,
+                        sample_weight_key=self.sample_weight_key)
         X, _, A = _quick_data()
 
         with pytest.raises(ValueError) as execInfo:
@@ -93,7 +99,8 @@ class ArgumentTests:
     @pytest.mark.parametrize("A_two_dim", [False, True])
     @pytest.mark.uncollect_if(func=is_invalid_transformation)
     def test_X_Y_different_rows(self, transformX, transformY, transformA, A_two_dim):
-        gs = GridSearch(self.estimator, self.disparity_criterion)
+        gs = GridSearch(self.estimator, self.disparity_criterion,
+                        sample_weight_key=self.sample_weight_key)
         X, _, A = _quick_data()
         Y = np.random.randint(2, size=len(A)+1)
 
@@ -111,7 +118,8 @@ class ArgumentTests:
     @pytest.mark.parametrize("A_two_dim", [False, True])
     @pytest.mark.uncollect_if(func=is_invalid_transformation)
     def test_X_A_different_rows(self, transformX, transformY, transformA, A_two_dim):
-        gs = GridSearch(self.estimator, self.disparity_criterion)
+        gs = GridSearch(self.estimator, self.disparity_criterion,
+                        sample_weight_key=self.sample_weight_key)
         X, Y, _ = _quick_data(A_two_dim)
         A = np.random.randint(2, size=len(Y)+1)
         if A_two_dim:
@@ -137,7 +145,8 @@ class ArgumentTests:
         # The purpose of this test case is to create enough groups to trigger certain expected
         # warnings. The scenario should still work and succeed.
         grid_size = 10
-        gs = GridSearch(self.estimator, self.disparity_criterion, grid_size=grid_size)
+        gs = GridSearch(self.estimator, self.disparity_criterion, grid_size=grid_size,
+                        sample_weight_key=self.sample_weight_key)
         X, Y, A = _quick_data(A_two_dim)
 
         if A_two_dim:
@@ -198,7 +207,8 @@ class ArgumentTests:
                         'dimensionality.')
 
         grid_size = 10
-        gs = GridSearch(self.estimator, self.disparity_criterion, grid_size=grid_size)
+        gs = GridSearch(self.estimator, self.disparity_criterion, grid_size=grid_size,
+                        sample_weight_key=self.sample_weight_key)
         X, Y, A = _quick_data(A_two_dim, n_groups=n_groups)
 
         caplog.set_level(logging.WARNING)
@@ -228,7 +238,8 @@ class ArgumentTests:
     @pytest.mark.parametrize("A_two_dim", [False, True])
     @pytest.mark.uncollect_if(func=is_invalid_transformation)
     def test_Y_df_bad_columns(self, transformX, transformA, A_two_dim):
-        gs = GridSearch(self.estimator, self.disparity_criterion)
+        gs = GridSearch(self.estimator, self.disparity_criterion,
+                        sample_weight_key=self.sample_weight_key)
         X, Y, A = _quick_data(A_two_dim)
 
         Y_two_col_df = pd.DataFrame({"a": Y, "b": Y})
@@ -243,7 +254,8 @@ class ArgumentTests:
     @pytest.mark.parametrize("A_two_dim", [False, True])
     @pytest.mark.uncollect_if(func=is_invalid_transformation)
     def test_Y_ndarray_bad_columns(self, transformX, transformA, A_two_dim):
-        gs = GridSearch(self.estimator, self.disparity_criterion)
+        gs = GridSearch(self.estimator, self.disparity_criterion,
+                        sample_weight_key=self.sample_weight_key)
         X, Y, A = _quick_data(A_two_dim)
 
         Y_two_col_ndarray = np.stack((Y, Y), -1)
@@ -256,7 +268,8 @@ class ArgumentTests:
     # ----------------------------
 
     def test_no_predict_before_fit(self):
-        gs = GridSearch(self.estimator, self.disparity_criterion)
+        gs = GridSearch(self.estimator, self.disparity_criterion,
+                        sample_weight_key=self.sample_weight_key)
         X, _, _ = _quick_data()
 
         with pytest.raises(NotFittedError) as execInfo:
@@ -265,7 +278,8 @@ class ArgumentTests:
         assert not_fitted_error_msg.format(GridSearch.__name__) == execInfo.value.args[0]
 
     def test_no_predict_proba_before_fit(self):
-        gs = GridSearch(self.estimator, self.disparity_criterion)
+        gs = GridSearch(self.estimator, self.disparity_criterion,
+                        sample_weight_key=self.sample_weight_key)
         X, _, _ = _quick_data()
 
         with pytest.raises(NotFittedError) as execInfo:
@@ -282,7 +296,8 @@ class ConditionalOpportunityTests(ArgumentTests):
     @pytest.mark.parametrize("A_two_dim", [False, True])
     @pytest.mark.uncollect_if(func=is_invalid_transformation)
     def test_Y_ternary(self, transformX, transformY, transformA, A_two_dim):
-        gs = GridSearch(self.estimator, self.disparity_criterion)
+        gs = GridSearch(self.estimator, self.disparity_criterion,
+                        sample_weight_key=self.sample_weight_key)
         X, Y, A = _quick_data(A_two_dim)
         Y[0] = 0
         Y[1] = 1
@@ -301,7 +316,8 @@ class ConditionalOpportunityTests(ArgumentTests):
     @pytest.mark.parametrize("A_two_dim", [False, True])
     @pytest.mark.uncollect_if(func=is_invalid_transformation)
     def test_Y_not_0_1(self, transformX, transformY, transformA, A_two_dim):
-        gs = GridSearch(self.estimator, self.disparity_criterion)
+        gs = GridSearch(self.estimator, self.disparity_criterion,
+                        sample_weight_key=self.sample_weight_key)
         X, Y, A = _quick_data(A_two_dim)
         Y = Y + 1
 
@@ -313,11 +329,21 @@ class ConditionalOpportunityTests(ArgumentTests):
         assert _LABELS_NOT_0_1_ERROR_MESSAGE == execInfo.value.args[0]
 
 
+# Set up Pipeline estimator
+class TestPipelineEstimator(ConditionalOpportunityTests):
+    def setup_method(self, method):
+        self.estimator = Pipeline([('scaler', StandardScaler()),
+                                   ('logistic', LogisticRegression(solver='liblinear'))])
+        self.disparity_criterion = DemographicParity()
+        self.sample_weight_key = 'logistic__sample_weight'
+
+
 # Set up DemographicParity
 class TestDemographicParity(ConditionalOpportunityTests):
     def setup_method(self, method):
         self.estimator = LogisticRegression(solver='liblinear')
         self.disparity_criterion = DemographicParity()
+        self.sample_weight_key = 'sample_weight'
 
 
 # Test EqualizedOdds
@@ -325,6 +351,7 @@ class TestEqualizedOdds(ConditionalOpportunityTests):
     def setup_method(self, method):
         self.estimator = LogisticRegression(solver='liblinear')
         self.disparity_criterion = EqualizedOdds()
+        self.sample_weight_key = 'sample_weight'
 
 
 # Tests specific to BoundedGroupLoss
@@ -333,3 +360,4 @@ class TestBoundedGroupLoss(ArgumentTests):
         self.estimator = LinearRegression()
         eps = 0.01
         self.disparity_criterion = BoundedGroupLoss(ZeroOneLoss(), upper_bound=eps)
+        self.sample_weight_key = 'sample_weight'

--- a/test/unit/reductions/grid_search/test_grid_search_arguments.py
+++ b/test/unit/reductions/grid_search/test_grid_search_arguments.py
@@ -50,7 +50,7 @@ class ArgumentTests:
     @pytest.mark.uncollect_if(func=is_invalid_transformation)
     def test_valid_inputs(self, transformX, transformY, transformA, A_two_dim):
         gs = GridSearch(self.estimator, self.disparity_criterion, grid_size=2,
-                        sample_weight_key=self.sample_weight_key)
+                        sample_weight_name=self.sample_weight_name)
         X, Y, A = _quick_data(A_two_dim)
         gs.fit(transformX(X),
                transformY(Y),
@@ -65,7 +65,7 @@ class ArgumentTests:
     @pytest.mark.uncollect_if(func=is_invalid_transformation)
     def test_X_is_None(self, transformY, transformA, A_two_dim):
         gs = GridSearch(self.estimator, self.disparity_criterion, grid_size=3,
-                        sample_weight_key=self.sample_weight_key)
+                        sample_weight_name=self.sample_weight_name)
         _, Y, A = _quick_data(A_two_dim)
 
         with pytest.raises(ValueError) as execInfo:
@@ -81,7 +81,7 @@ class ArgumentTests:
     @pytest.mark.uncollect_if(func=is_invalid_transformation)
     def test_Y_is_None(self, transformX, transformA, A_two_dim):
         gs = GridSearch(self.estimator, self.disparity_criterion,
-                        sample_weight_key=self.sample_weight_key)
+                        sample_weight_name=self.sample_weight_name)
         X, _, A = _quick_data()
 
         with pytest.raises(ValueError) as execInfo:
@@ -100,7 +100,7 @@ class ArgumentTests:
     @pytest.mark.uncollect_if(func=is_invalid_transformation)
     def test_X_Y_different_rows(self, transformX, transformY, transformA, A_two_dim):
         gs = GridSearch(self.estimator, self.disparity_criterion,
-                        sample_weight_key=self.sample_weight_key)
+                        sample_weight_name=self.sample_weight_name)
         X, _, A = _quick_data()
         Y = np.random.randint(2, size=len(A)+1)
 
@@ -119,7 +119,7 @@ class ArgumentTests:
     @pytest.mark.uncollect_if(func=is_invalid_transformation)
     def test_X_A_different_rows(self, transformX, transformY, transformA, A_two_dim):
         gs = GridSearch(self.estimator, self.disparity_criterion,
-                        sample_weight_key=self.sample_weight_key)
+                        sample_weight_name=self.sample_weight_name)
         X, Y, _ = _quick_data(A_two_dim)
         A = np.random.randint(2, size=len(Y)+1)
         if A_two_dim:
@@ -146,7 +146,7 @@ class ArgumentTests:
         # warnings. The scenario should still work and succeed.
         grid_size = 10
         gs = GridSearch(self.estimator, self.disparity_criterion, grid_size=grid_size,
-                        sample_weight_key=self.sample_weight_key)
+                        sample_weight_name=self.sample_weight_name)
         X, Y, A = _quick_data(A_two_dim)
 
         if A_two_dim:
@@ -208,7 +208,7 @@ class ArgumentTests:
 
         grid_size = 10
         gs = GridSearch(self.estimator, self.disparity_criterion, grid_size=grid_size,
-                        sample_weight_key=self.sample_weight_key)
+                        sample_weight_name=self.sample_weight_name)
         X, Y, A = _quick_data(A_two_dim, n_groups=n_groups)
 
         caplog.set_level(logging.WARNING)
@@ -239,7 +239,7 @@ class ArgumentTests:
     @pytest.mark.uncollect_if(func=is_invalid_transformation)
     def test_Y_df_bad_columns(self, transformX, transformA, A_two_dim):
         gs = GridSearch(self.estimator, self.disparity_criterion,
-                        sample_weight_key=self.sample_weight_key)
+                        sample_weight_name=self.sample_weight_name)
         X, Y, A = _quick_data(A_two_dim)
 
         Y_two_col_df = pd.DataFrame({"a": Y, "b": Y})
@@ -255,7 +255,7 @@ class ArgumentTests:
     @pytest.mark.uncollect_if(func=is_invalid_transformation)
     def test_Y_ndarray_bad_columns(self, transformX, transformA, A_two_dim):
         gs = GridSearch(self.estimator, self.disparity_criterion,
-                        sample_weight_key=self.sample_weight_key)
+                        sample_weight_name=self.sample_weight_name)
         X, Y, A = _quick_data(A_two_dim)
 
         Y_two_col_ndarray = np.stack((Y, Y), -1)
@@ -269,7 +269,7 @@ class ArgumentTests:
 
     def test_no_predict_before_fit(self):
         gs = GridSearch(self.estimator, self.disparity_criterion,
-                        sample_weight_key=self.sample_weight_key)
+                        sample_weight_name=self.sample_weight_name)
         X, _, _ = _quick_data()
 
         with pytest.raises(NotFittedError) as execInfo:
@@ -279,7 +279,7 @@ class ArgumentTests:
 
     def test_no_predict_proba_before_fit(self):
         gs = GridSearch(self.estimator, self.disparity_criterion,
-                        sample_weight_key=self.sample_weight_key)
+                        sample_weight_name=self.sample_weight_name)
         X, _, _ = _quick_data()
 
         with pytest.raises(NotFittedError) as execInfo:
@@ -297,7 +297,7 @@ class ConditionalOpportunityTests(ArgumentTests):
     @pytest.mark.uncollect_if(func=is_invalid_transformation)
     def test_Y_ternary(self, transformX, transformY, transformA, A_two_dim):
         gs = GridSearch(self.estimator, self.disparity_criterion,
-                        sample_weight_key=self.sample_weight_key)
+                        sample_weight_name=self.sample_weight_name)
         X, Y, A = _quick_data(A_two_dim)
         Y[0] = 0
         Y[1] = 1
@@ -317,7 +317,7 @@ class ConditionalOpportunityTests(ArgumentTests):
     @pytest.mark.uncollect_if(func=is_invalid_transformation)
     def test_Y_not_0_1(self, transformX, transformY, transformA, A_two_dim):
         gs = GridSearch(self.estimator, self.disparity_criterion,
-                        sample_weight_key=self.sample_weight_key)
+                        sample_weight_name=self.sample_weight_name)
         X, Y, A = _quick_data(A_two_dim)
         Y = Y + 1
 
@@ -335,7 +335,7 @@ class TestPipelineEstimator(ConditionalOpportunityTests):
         self.estimator = Pipeline([('scaler', StandardScaler()),
                                    ('logistic', LogisticRegression(solver='liblinear'))])
         self.disparity_criterion = DemographicParity()
-        self.sample_weight_key = 'logistic__sample_weight'
+        self.sample_weight_name = 'logistic__sample_weight'
 
 
 # Set up DemographicParity
@@ -343,7 +343,7 @@ class TestDemographicParity(ConditionalOpportunityTests):
     def setup_method(self, method):
         self.estimator = LogisticRegression(solver='liblinear')
         self.disparity_criterion = DemographicParity()
-        self.sample_weight_key = 'sample_weight'
+        self.sample_weight_name = 'sample_weight'
 
 
 # Test EqualizedOdds
@@ -351,7 +351,7 @@ class TestEqualizedOdds(ConditionalOpportunityTests):
     def setup_method(self, method):
         self.estimator = LogisticRegression(solver='liblinear')
         self.disparity_criterion = EqualizedOdds()
-        self.sample_weight_key = 'sample_weight'
+        self.sample_weight_name = 'sample_weight'
 
 
 # Tests specific to BoundedGroupLoss
@@ -360,4 +360,4 @@ class TestBoundedGroupLoss(ArgumentTests):
         self.estimator = LinearRegression()
         eps = 0.01
         self.disparity_criterion = BoundedGroupLoss(ZeroOneLoss(), upper_bound=eps)
-        self.sample_weight_key = 'sample_weight'
+        self.sample_weight_name = 'sample_weight'


### PR DESCRIPTION
Allow the user to supply sample_weight_key to better control the call to estimator.fit.

Fixes #580