### PR TITLE
Add developer call notes to index

### DIFF
--- a/docs/contributor_guide/developer_call_notes/index.rst
+++ b/docs/contributor_guide/developer_call_notes/index.rst
@@ -8,6 +8,7 @@ Developer call notes
 .. toctree::
    :maxdepth: 1
 
+   2020_10_08
    2020_09_17
    2020_08_13
    2020_07_09


### PR DESCRIPTION
Had overlooked adding the latest developer call notes to the index.

Closes #606 

Signed-off-by: Richard Edgar <riedgar@microsoft.com>