### PR TITLE
Fix widgets docs by making class attributes private, convert to numpydoc

### DIFF
--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -157,6 +157,7 @@ in a dictionary via the ``sample_params`` argument.:
     c        0.714286
     d               0
     Name: recall_score, dtype: object
+
 If mutiple metrics are being evaluated, then ``sample_params`` becomes a dictionary of
 dictionaries, with the first key corresponding matching that in the dictionary holding
 the desired underlying metric functions.

--- a/fairlearn/widget/fairness_dashboard.py
+++ b/fairlearn/widget/fairness_dashboard.py
@@ -32,16 +32,16 @@ class FairlearnDashboard(object):
 
     Parameters
     ----------
-    sensitive_features : {:class:`numpy.ndarray`, list[][], :class:`pandas.DataFrame`, :class:`pandas.Series`}  # noqa: E501
+    sensitive_features : numpy.ndarray, list[][], pandas.DataFrame, pandas.Series
         A matrix of feature vector examples (# examples x # features),
         these can be from the initial dataset, or reserved from training.
-    y_true : {:class:`numpy.ndarray`, list[]}
+    y_true : numpy.ndarray, list[]
         The true labels or values for the provided dataset.
-    y_pred : {:class:`numpy.ndarray`, list[][], list[], dict {string: list[]}}
+    y_pred : numpy.ndarray, list[][], list[], dict {string: list[]}
         Array of output predictions from models to be evaluated. Can be a single
         array of predictions, or a 2D list over multiple models. Can be a dictionary
         of named model predictions.
-    sensitive_feature_names : {:class:`numpy.ndarray`, list[]}
+    sensitive_feature_names : numpy.ndarray, list[]
         Feature names
     """
 


### PR DESCRIPTION
The public (not prefixed with underscore) attributes of the `FairlearnDashboard` class showed up in the documentation, and evidently the values from some use cases carried over, leading to a massive unintended data output. This PR fixes this problem by making the class attributes private. At the same time I took the liberty to convert the docs to numpydoc format.

Signed-off-by: Roman Lutz <rolutz@microsoft.com>