### PR TITLE
Add note about dashboard moving to raiwidgets after 0.5.0

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -128,6 +128,13 @@ their label:
 For a visual representation of the metrics try out the Fairlearn dashboard.
 While this page shows only screenshots, the actual dashboard is interactive.
 
+.. note::
+
+    The :code:`FairlearnDashboard` will move from Fairlearn to the
+    `raiwidgets` package after the v0.5.0 release. Instead, Fairlearn will
+    provide some of the existing functionality through
+    :code:`matplotlib`-based visualizations.
+
 .. doctest:: quickstart
 
     >>> from fairlearn.widget import FairlearnDashboard

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -131,8 +131,8 @@ While this page shows only screenshots, the actual dashboard is interactive.
 .. note::
 
     The :code:`FairlearnDashboard` will move from Fairlearn to the
-    `raiwidgets` package after the v0.5.0 release. Instead, Fairlearn will
-    provide some of the existing functionality through
+    :code:`raiwidgets` package after the v0.5.0 release. Instead, Fairlearn
+    will provide some of the existing functionality through
     :code:`matplotlib`-based visualizations.
 
 .. doctest:: quickstart

--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -228,6 +228,13 @@ model's predictions impact different groups (e.g., different ethnicities), and
 also for comparing multiple models along different fairness and performance
 metrics.
 
+.. note::
+
+    The :code:`FairlearnDashboard` will move from Fairlearn to the
+    :code:`raiwidgets` package after the v0.5.0 release. Instead, Fairlearn
+    will provide some of the existing functionality through
+    :code:`matplotlib`-based visualizations.
+
 Setup and a single-model assessment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/examples/plot_grid_search_census.py
+++ b/examples/plot_grid_search_census.py
@@ -30,6 +30,13 @@ GridSearch with Census Data
 # --------------------------------
 # We download the data set using `fetch_adult` function in `fairlearn.datasets`.
 # We start by importing the various modules we're going to use:
+# 
+# .. note::
+#
+#     The :code:`FairlearnDashboard` will move from Fairlearn to the
+#     :code:`raiwidgets` package after the v0.5.0 release. Instead, Fairlearn
+#     will provide some of the existing functionality through
+#     :code:`matplotlib`-based visualizations.
 
 from fairlearn.widget import FairlearnDashboard
 from sklearn.model_selection import train_test_split

--- a/examples/plot_grid_search_census.py
+++ b/examples/plot_grid_search_census.py
@@ -30,7 +30,7 @@ GridSearch with Census Data
 # --------------------------------
 # We download the data set using `fetch_adult` function in `fairlearn.datasets`.
 # We start by importing the various modules we're going to use:
-# 
+#
 # .. note::
 #
 #     The :code:`FairlearnDashboard` will move from Fairlearn to the

--- a/notebooks/ReadMe.md
+++ b/notebooks/ReadMe.md
@@ -10,7 +10,7 @@ If you encounter compatibility problems with notebooks, go to your terminal and 
 ```
 pip show fairlearn
 ```
-to show the version of Fairlean which you currently have
+to show the version of Fairlearn which you currently have
 installed.
 Then, on the GitHub page, navigate to that version
 (e.g. [v0.4.5](https://github.com/fairlearn/fairlearn/tree/v0.4.5) or


### PR DESCRIPTION
I would have liked to provide more details, such as the link to the migration guide for the version after 0.5.0. However, that would require knowing the version number at that point. I suspect it's 0.6.0 if we actually manage to remove the dashboard & add the matplotlib-based plots quickly. Linking forwards to a page that doesn't exist yet is kind of odd, though. Users of the dashboard can happily keep using it in 0.5.0 without any change, but once the version after that comes out the documentation/website will detail exactly how to migrate (because `raiwidgets` will actually be available) and replace the dashboard usage in quickstart, notebooks etc. where it's possible to replace the functionality (which will also address #608).


Signed-off-by: Roman Lutz <rolutz@microsoft.com>