### PR TITLE
Set default of MetricFrame difference and ratio to be 'between_groups'

### DIFF
--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -360,7 +360,7 @@ class MetricFrame:
             return result
 
     def difference(self,
-                   method: str) -> Union[Any, pd.Series, pd.DataFrame]:
+                   method: str = 'between_groups') -> Union[Any, pd.Series, pd.DataFrame]:
         """Return the maximum absolute difference between groups for each metric.
 
         This method calculates a scalar value for each underlying metric by
@@ -380,6 +380,11 @@ class MetricFrame:
         features, then :attr:`.overall` is multivalued for each metric).
         The result is the absolute maximum of these values.
 
+        Parameters
+        ----------
+        method : str
+            How to compute the aggregate. Default is :code:`between_groups`
+
         Returns
         -------
         typing.Any or pandas.Series or pandas.DataFrame
@@ -396,7 +401,7 @@ class MetricFrame:
         return (self.by_group - subtrahend).abs().max(level=self.control_levels)
 
     def ratio(self,
-              method: str) -> Union[Any, pd.Series, pd.DataFrame]:
+              method: str = 'between_groups') -> Union[Any, pd.Series, pd.DataFrame]:
         """Return the minimum ratio between groups for each metric.
 
         This method calculates a scalar value for each underlying metric by
@@ -417,6 +422,11 @@ class MetricFrame:
         features, then :attr:`.overall` is multivalued for each metric),
         expressing the ratio as a number less than 1.
         The result is the minimum of these values.
+
+        Parameters
+        ----------
+        method : str
+            How to compute the aggregate. Default is :code:`between_groups`
 
         Returns
         -------

--- a/test/unit/metrics/test_metricframe_aggregates.py
+++ b/test/unit/metrics/test_metricframe_aggregates.py
@@ -61,6 +61,14 @@ class Test1m1sf0cf:
         assert target_diff == abs(self.metric_p - self.metric_q)
 
     @pytest.mark.parametrize("metric_fn", metric)
+    def test_difference_defaults_to_between_groups(self, metric_fn):
+        self._prepare(metric_fn)
+
+        target_diff = self.target.difference()
+        assert isinstance(target_diff, float)
+        assert target_diff == abs(self.metric_p - self.metric_q)
+
+    @pytest.mark.parametrize("metric_fn", metric)
     def test_difference_to_overall(self, metric_fn):
         self._prepare(metric_fn)
 
@@ -75,6 +83,15 @@ class Test1m1sf0cf:
         self._prepare(metric_fn)
 
         target_ratio = self.target.ratio(method='between_groups')
+        assert isinstance(target_ratio, float)
+        assert target_ratio == min(self.metric_p, self.metric_q) / \
+            max(self.metric_p, self.metric_q)
+
+    @pytest.mark.parametrize("metric_fn", metric)
+    def test_ratio_defaults_to_between_groups(self, metric_fn):
+        self._prepare(metric_fn)
+
+        target_ratio = self.target.ratio()
         assert isinstance(target_ratio, float)
         assert target_ratio == min(self.metric_p, self.metric_q) / \
             max(self.metric_p, self.metric_q)
@@ -142,6 +159,14 @@ class Test1m1sf0cfFnDict:
         assert target_diff[self.mfn] == abs(self.metric_p - self.metric_q)
 
     @pytest.mark.parametrize("metric_fn", metric)
+    def test_difference_defaults_to_between_groups(self, metric_fn):
+        self._prepare(metric_fn)
+
+        target_diff = self.target.difference()
+        assert isinstance(target_diff, float)
+        assert target_diff[self.mfn] == abs(self.metric_p - self.metric_q)
+
+    @pytest.mark.parametrize("metric_fn", metric)
     def test_difference_to_overall(self, metric_fn):
         self._prepare(metric_fn)
 
@@ -159,6 +184,15 @@ class Test1m1sf0cfFnDict:
         target_ratio = self.target.ratio(method='between_groups')
         assert isinstance(target_ratio, pd.Series)
         assert len(target_ratio) == 1
+        assert target_ratio[self.mfn] == min(self.metric_p, self.metric_q) / \
+            max(self.metric_p, self.metric_q)
+
+    @pytest.mark.parametrize("metric_fn", metric)
+    def test_ratio_defaults_to_between_groups(self, metric_fn):
+        self._prepare(metric_fn)
+
+        target_ratio = self.target.ratio()
+        assert isinstance(target_ratio, float)
         assert target_ratio[self.mfn] == min(self.metric_p, self.metric_q) / \
             max(self.metric_p, self.metric_q)
 

--- a/test/unit/metrics/test_metricframe_aggregates.py
+++ b/test/unit/metrics/test_metricframe_aggregates.py
@@ -163,7 +163,8 @@ class Test1m1sf0cfFnDict:
         self._prepare(metric_fn)
 
         target_diff = self.target.difference()
-        assert isinstance(target_diff, float)
+        assert isinstance(target_diff, pd.Series)
+        assert len(target_diff) == 1
         assert target_diff[self.mfn] == abs(self.metric_p - self.metric_q)
 
     @pytest.mark.parametrize("metric_fn", metric)
@@ -192,7 +193,8 @@ class Test1m1sf0cfFnDict:
         self._prepare(metric_fn)
 
         target_ratio = self.target.ratio()
-        assert isinstance(target_ratio, float)
+        assert isinstance(target_ratio, pd.Series)
+        assert len(target_ratio) == 1
         assert target_ratio[self.mfn] == min(self.metric_p, self.metric_q) / \
             max(self.metric_p, self.metric_q)
 


### PR DESCRIPTION
Adding a default method of `between_groups` to `MetricFrame.difference()` and `MetricFrame.ratio()`. This had been previously discussed, but not implemented. Also make sure that the `method=` argument has documentation.