### PR TITLE
Preparations for v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Website: https://fairlearn.github.io/
 
 ## Current release
 
-- The current stable release is available at [Fairlearn v0.4.6](https://github.com/fairlearn/fairlearn/tree/v0.4.6).
+- The current stable release is available at [Fairlearn v0.5.0](https://github.com/fairlearn/fairlearn/tree/release/v0.5.0).
 
 - Our current version differs substantially from version 0.2 or earlier. Users of these older versions should visit our [onboarding guide](https://fairlearn.github.io/master/contributor_guide/development_process.html#onboarding-guide).
 

--- a/fairlearn/__init__.py
+++ b/fairlearn/__init__.py
@@ -9,7 +9,7 @@ import os
 from .show_versions import show_versions  # noqa: F401
 
 __name__ = "fairlearn"
-__version__ = "0.4.7.dev0"
+__version__ = "0.5.1.dev0"
 _base_version = __version__  # To enable the v0.4.6 docs
 
 # Setup logging infrastructure


### PR DESCRIPTION
Some small changes:

- Bump version in `__init__.py` to `v0.5.1.dev0` (which is what our development trunk will be once v0.5.0 is out)
- Update the 'link to current version' in the main ReadMe to v0.5.0

I have left the remainder of the documentation links point to `master` for now, since they will break until v0.5.0 ships otherwise (I'm prepared to tolerate that one 'current' version at the top of the ReadMe, but not every link on the page).