### PR TITLE
Fix metrics on single elements

### DIFF
--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -512,7 +512,7 @@ class MetricFrame:
                 result.append(GroupFeature(base_name, column, i, None))
         elif isinstance(features, list):
             if np.isscalar(features[0]):
-                f_arr = np.squeeze(np.asarray(features))
+                f_arr = np.atleast_1d(np.squeeze(np.asarray(features)))
                 assert len(f_arr.shape) == 1  # Sanity check
                 check_consistent_length(f_arr, sample_array)
                 result.append(GroupFeature(base_name, f_arr, 0, None))

--- a/test/unit/metrics/test_metricframe_smoke.py
+++ b/test/unit/metrics/test_metricframe_smoke.py
@@ -260,3 +260,9 @@ def test_duplicate_cf_sf_names():
                                 sensitive_features=sf,
                                 control_features=cf)
     assert execInfo.value.args[0] == msg
+
+
+def test_single_element_lists():
+    mf = metrics.MetricFrame(skm.balanced_accuracy_score,
+                             [1], [1], sensitive_features=[0])
+    assert mf.overall == 1


### PR DESCRIPTION
Metrics designed to slice and dice data into intersecting subgroups were somehow missing the case where only a single datum is passed in. Remedy this deployable oversight. Fixes #633 