### PR TITLE
Updates for make_derived_metric

### DIFF
--- a/examples/plot_make_derived_metric.py
+++ b/examples/plot_make_derived_metric.py
@@ -103,7 +103,14 @@ X_train_unscaled = ct.fit_transform(X_train_raw)
 X_test_unscaled = ct.transform(X_test_raw)
 
 # %%
-# Rescale the input data, following a similar pattern:
+# Rescale the input data, following a similar pattern. This is the most
+# critical step for data leakage. For the one-hot encoding, so long as each
+# class appears at least once in each dataset, the columns produced will be
+# the same. In contrast, the :class:`StandardScaler` attempts to fit the
+# data to a normal distribution. If the training and test data are from
+# different distributions, then the parameters of the fit will be different
+# dependent on whether the fit is computed for all the data, or just the
+# training set.
 
 sc = StandardScaler()
 X_train = sc.fit_transform(X_train_unscaled)

--- a/examples/plot_make_derived_metric.py
+++ b/examples/plot_make_derived_metric.py
@@ -59,7 +59,7 @@ A = X_raw[["race", "sex"]]
 # set. This ensures that data doesn't leak between the two sets (this is
 # a serious but subtle
 # `problem in machine learning <https://en.wikipedia.org/wiki/Leakage_(machine_learning)>`_).
-# So, split the data:
+# So, first we split the data:
 
 (X_train, X_test, y_train, y_test, A_train, A_test) = train_test_split(
     X_raw, y, A, test_size=0.3, random_state=12345, stratify=y
@@ -77,7 +77,15 @@ A_train = A_train.reset_index(drop=True)
 A_test = A_test.reset_index(drop=True)
 
 # %%
-# Define how we wish to encode the data:
+# Next, we build two :class:`~sklearn.pipeline.Pipeline` objects
+# to process the columns, one for numeric data, and the other
+# for categorical data. Both impute missing values; the difference
+# is whether the data are scaled (numeric columns) or
+# one-hot encoded (categorical columns). Imputation of missing
+# values should generally be done with care, since it could
+# potentially introduce biases. Of course, removing rows with
+# missing data could also cause trouble, if particular subgroups
+# have poorer data quality.
 
 numeric_transformer = Pipeline(
     steps=[
@@ -97,6 +105,11 @@ preprocessor = ColumnTransformer(
         ("cat", categorical_transformer, selector(dtype_include="category")),
     ]
 )
+
+# %%
+# With our preprocessor defined, we can now build a
+# new pipeline which includes an Estimator:
+
 unmitigated_predictor = Pipeline(
     steps=[
         ("preprocessor", preprocessor),
@@ -108,6 +121,10 @@ unmitigated_predictor = Pipeline(
 )
 
 # %%
+# With the pipeline fully defined, we can first train it
+# with the training data, and then generate predictions
+# from the test data.
+
 unmitigated_predictor.fit(X_train, y_train)
 y_pred = unmitigated_predictor.predict(X_test)
 

--- a/examples/plot_make_derived_metric.py
+++ b/examples/plot_make_derived_metric.py
@@ -14,7 +14,7 @@ Making Derived Metrics
 # While the :class:`fairlearn.metrics.MetricFrame` has the ability to produce such
 # scalars through its aggregation functions, its API does not conform to that usually
 # expected by these algorithms.
-# The :func:`fairlearn.metrics.make_derived_metric` function exists to bridge this gap.
+# The :func:`~fairlearn.metrics.make_derived_metric` function exists to bridge this gap.
 #
 # Getting the Data
 # ================
@@ -92,7 +92,7 @@ y_pred = unmitigated_predictor.predict(X_test)
 #
 # Suppose our key metric is the accuracy score, and we are most interested in
 # ensuring that it exceeds some threshold for all subgroups
-# We might use the :class:`fairlearn.metrics.MetricFrame` as
+# We might use the :class:`~fairlearn.metrics.MetricFrame` as
 # follows:
 
 acc_frame = MetricFrame(skm.accuracy_score,
@@ -102,7 +102,7 @@ print("Minimum accuracy_score: ", acc_frame.group_min())
 
 # %%
 # We can create a function to perform this in a single call
-# using :func:`fairlearn.metrics.make_derived_metric`.
+# using :func:`~fairlearn.metrics.make_derived_metric`.
 # This takes the following arguments (which must always be
 # supplied as keyword arguments):
 #

--- a/examples/plot_make_derived_metric.py
+++ b/examples/plot_make_derived_metric.py
@@ -53,7 +53,7 @@ A = X_raw[['race', 'sex']]
 # %%
 # With the data imported, we perform some standard processing, and a test/train split:
 le = LabelEncoder()
-y = le.fit_transform(Y)
+y = le.fit_transform(y)
 
 le = LabelEncoder()
 
@@ -62,10 +62,10 @@ X_dummies = pd.get_dummies(X_raw)
 X_scaled = sc.fit_transform(X_dummies)
 X_scaled = pd.DataFrame(X_scaled, columns=X_dummies.columns)
 
-X_train, X_test, y_train, y_test, A_train, A_test = train_test_split(X_scaled, Y, A,
+X_train, X_test, y_train, y_test, A_train, A_test = train_test_split(X_scaled, y, A,
                                                                      test_size=0.3,
                                                                      random_state=12345,
-                                                                     stratify=Y)
+                                                                     stratify=y)
 
 # Ensure indices are aligned between X, y and A,
 # since the test_train_split operation works slightly
@@ -114,7 +114,7 @@ print("Minimum accuracy_score: ", acc_frame.group_min())
 #   which should be treated as sample
 #   parameters. This is optional, and defaults to
 #   :code:`['sample_weight']` which is appropriate for many
-#   metrics in SciKit-Learn.
+#   metrics in `scikit-learn`.
 #
 # The result is a new function with the same signature as the
 # base metric, which accepts two extra arguments:

--- a/examples/plot_make_derived_metric.py
+++ b/examples/plot_make_derived_metric.py
@@ -67,7 +67,9 @@ X_train, X_test, y_train, y_test, A_train, A_test = train_test_split(X_scaled, Y
                                                                      random_state=12345,
                                                                      stratify=Y)
 
-# Ensure indices are aligned
+# Ensure indices are aligned between X, y and A,
+# since the test_train_split operation works slightly
+# differently between Pandas (X and A) and numpy (y) objects
 X_train = X_train.reset_index(drop=True)
 X_test = X_test.reset_index(drop=True)
 A_train = A_train.reset_index(drop=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,0 @@
-[tool.black]
-line-length = 79


### PR DESCRIPTION
I had overlooked some comments on the previous PR for `make_derived_metric()`. This is to address those points.

The largest change is to the data preprocessing, which has been adjusted to avoid the problem of Data Leakage between the training and test sets (credit to @adrinjalali  for the actual `Pipeline` code). This fix has been ported to the other metrics example.