### PR TITLE
Adjust build schedule

### DIFF
--- a/devops/code-coverage.yml
+++ b/devops/code-coverage.yml
@@ -9,7 +9,7 @@ trigger: none
 pr: none
 
 schedules:
-- cron: "30 5 * * *" # Time is UTC
+- cron: "30 7 * * *" # Time is UTC
   displayName: Nightly Code Coverage Build
   branches:
     include:

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -9,7 +9,7 @@ trigger: none # No CI build
 pr: none # Not for pull requests
 
 schedules:
-- cron: "0 6 * * *" # Time is UTC
+- cron: "0 10 * * *" # Time is UTC
   displayName: Nightly Build
   branches:
     include:


### PR DESCRIPTION
Two of the scheduled builds are consistently failing, due to issues fetching datasets from OpenML. Rerunning them manually works every time, so try changing the schedule for the affected builds.

Signed-off-by: Richard Edgar <riedgar@microsoft.com>