### PR TITLE
Change Autodoc sort order

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -153,6 +153,10 @@ html_sidebars = {
     "**": ["version-sidebar.html", "sidebar-search-bs.html", "sidebar-nav-bs.html"],
 }
 
+# Change the ordering of the member documentation
+
+autodoc_member_order = 'groupwise'
+
 # The following is used by sphinx.ext.linkcode to provide links to github
 # based on pandas doc/source/conf.py
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -153,14 +153,18 @@ html_sidebars = {
     "**": ["version-sidebar.html", "sidebar-search-bs.html", "sidebar-nav-bs.html"],
 }
 
-# Change the ordering of the member documentation
+# Auto-Doc Options
+# ----------------
 
+# Change the ordering of the member documentation
 autodoc_member_order = 'groupwise'
+
+
+# Linking Code
+# ------------
 
 # The following is used by sphinx.ext.linkcode to provide links to github
 # based on pandas doc/source/conf.py
-
-
 def linkcode_resolve(domain, info):
     """Determine the URL corresponding to Python object."""
     if domain != "py":


### PR DESCRIPTION
As noted by @hildeweerts  in #601 sorting members strictly alphabetically makes little sense. It turns out that there is an `autodoc` option to group things (e.g. properties, methods) together, so turn this on.