### PR TITLE
Restore Green Builds

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -76,7 +76,6 @@ than $50,000 a year.
 
     >>> import numpy as np 
     >>> import pandas as pd
-    >>> pd.set_option('display.precision', 4)
     >>> import matplotlib.pyplot as plt 
     >>> from sklearn.datasets import fetch_openml
     >>> data = fetch_openml(data_id=1590, as_frame=True)

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -112,11 +112,11 @@ we can evaluate metrics for subgroups within the data as below:
     >>> y_pred = classifier.predict(X)
     >>> gm = MetricFrame(accuracy_score, y_true, y_pred, sensitive_features=sex)
     >>> print(gm.overall)
-    0.8443552680070431
+    0.8443...
     >>> print(gm.by_group)
     sex
-    Female    0.9251
-    Male      0.8043
+    Female    0.9251...
+    Male      0.8042...
     Name: accuracy_score, dtype: object
 
 Additionally, Fairlearn has lots of other standard metrics built-in, such as
@@ -129,11 +129,11 @@ their label:
     >>> from fairlearn.metrics import selection_rate
     >>> sr = MetricFrame(selection_rate, y_true, y_pred, sensitive_features=sex)
     >>> sr.overall
-    0.16385487899758405
+    0.1638...
     >>> sr.by_group
     sex
-    Female    0.0635
-    Male      0.2136
+    Female    0.0635...
+    Male      0.2135...
     Name: selection_rate, dtype: object   
 
 For a visual representation of the metrics try out the Fairlearn dashboard.
@@ -192,11 +192,11 @@ a vastly reduced difference in selection rate:
     >>> 
     >>> sr_mitigated = MetricFrame(selection_rate, y_true, y_pred_mitigated, sensitive_features=sex)
     >>> print(sr_mitigated.overall)
-    0.16614798738790384
+    0.1661...
     >>> print(sr_mitigated.by_group)
     sex
-    Female    0.1553
-    Male      0.1715
+    Female    0.1552...
+    Male      0.1715...
     Name: selection_rate, dtype: object
 
 Similarly, we can explore the difference between the initial model and the

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -76,6 +76,7 @@ than $50,000 a year.
 
     >>> import numpy as np 
     >>> import pandas as pd
+    >>> pd.set_option('display.precision', 4)
     >>> import matplotlib.pyplot as plt 
     >>> from sklearn.datasets import fetch_openml
     >>> data = fetch_openml(data_id=1590, as_frame=True)
@@ -115,8 +116,8 @@ we can evaluate metrics for subgroups within the data as below:
     0.8443552680070431
     >>> print(gm.by_group)
     sex
-    Female       0.925148
-    Male         0.804288
+    Female    0.9251
+    Male      0.8043
     Name: accuracy_score, dtype: object
 
 Additionally, Fairlearn has lots of other standard metrics built-in, such as
@@ -132,8 +133,8 @@ their label:
     0.16385487899758405
     >>> sr.by_group
     sex
-    Female      0.0635499
-    Male         0.213599 
+    Female    0.0635
+    Male      0.2136
     Name: selection_rate, dtype: object   
 
 For a visual representation of the metrics try out the Fairlearn dashboard.
@@ -195,8 +196,8 @@ a vastly reduced difference in selection rate:
     0.16614798738790384
     >>> print(sr_mitigated.by_group)
     sex
-    Female       0.155262
-    Male         0.171547
+    Female    0.1553
+    Male      0.1715
     Name: selection_rate, dtype: object
 
 Similarly, we can explore the difference between the initial model and the

--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -61,7 +61,6 @@ the following set of labels:
     ...                          'b', 'd', 'c', 'a', 'b', 'd', 'c', 'c']
     >>> pd.set_option('display.max_columns', 20)
     >>> pd.set_option('display.width', 80)
-    >>> pd.set_option('display.precision', 4)
     >>> pd.DataFrame({ 'y_true': y_true,
     ...                'y_pred': y_pred,
     ...                'group_membership_data': group_membership_data})

--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -61,6 +61,7 @@ the following set of labels:
     ...                          'b', 'd', 'c', 'a', 'b', 'd', 'c', 'c']
     >>> pd.set_option('display.max_columns', 20)
     >>> pd.set_option('display.width', 80)
+    >>> pd.set_option('display.precision', 4)
     >>> pd.DataFrame({ 'y_true': y_true,
     ...                'y_pred': y_pred,
     ...                'group_membership_data': group_membership_data})
@@ -125,16 +126,16 @@ metrics simultaneously:
     ...                             y_true, y_pred,
     ...                             sensitive_features=group_membership_data)
     >>> multi_metric.overall
-    precision    0.555556
-    recall            0.5
+    precision    0.5556
+    recall       0.5000
     dtype: object
     >>> multi_metric.by_group
-         precision recall
+                        precision recall
     sensitive_feature_0
-    a            0      0
-    b            1    0.5
-    c          0.6   0.75
-    d            0      0
+    a                         0.0   0.00
+    b                         1.0   0.50
+    c                         0.6   0.75
+    d                         0.0   0.00
 
 If there are per-sample arguments (such as sample weights), these can also be provided
 in a dictionary via the ``sample_params`` argument.:
@@ -152,10 +153,10 @@ in a dictionary via the ``sample_params`` argument.:
     0.45
     >>> weighted.by_group
     SF 0
-    a               0
-    b             0.5
-    c        0.714286
-    d               0
+    a    0.0000
+    b    0.5000
+    c    0.7143
+    d    0.0000
     Name: recall_score, dtype: object
 
 If mutiple metrics are being evaluated, then ``sample_params`` becomes a dictionary of
@@ -178,10 +179,10 @@ function:
     0.5396825396825397
     >>> metric_beta.by_group
     sensitive_feature_0
-    a            0
-    b     0.790698
-    c      0.63354
-    d            0
+    a    0.0000
+    b    0.7907
+    c    0.6335
+    d    0.0000
     Name: metric, dtype: object
 
 Finally, multiple sensitive features can be specified. The ``by_groups`` property then
@@ -200,14 +201,14 @@ holds the intersections of these groups:
     0.5
     >>> metric_2sf.by_group
     SF 0  SF 1
-    a     6         0
+    a     6       0.0
           8       NaN
     b     6       0.5
           8       0.5
-    c     6         1
+    c     6       1.0
           8       0.5
-    d     6         0
-          8         0
+    d     6       0.0
+          8       0.0
     Name: recall_score, dtype: object
 
 With such a small number of samples, we are obviously running into cases where
@@ -343,18 +344,18 @@ parameter:
     >>> # The 'overall' property is now split based on the control feature
     >>> metric_c_f.overall
     CF
-    H    0.428571
-    L       0.375
+    H    0.4286
+    L    0.3750
     Name: accuracy_score, dtype: object
     >>> # The 'by_group' property looks similar to how it would if we had two sensitive features
     >>> metric_c_f.by_group
     CF  SF
-    H   A          0.2
-        B          0.4
-        C         0.75
-    L   A          0.4
-        B     0.285714
-        C          0.5
+    H   A     0.2000
+        B     0.4000
+        C     0.7500
+    L   A     0.4000
+        B     0.2857
+        C     0.5000
     Name: accuracy_score, dtype: object
 
 Note how the :attr:`MetricFrame.overall` property is stratified based on the
@@ -379,8 +380,8 @@ With the :class:`MetricFrame` computed, we can perform aggregations:
     >>> # See the maximum difference in accuracy for each value of the control feature
     >>> metric_c_f.difference(method='between_groups')
     CF
-    H    0.550000
-    L    0.214286
+    H    0.5500
+    L    0.2143
     Name: accuracy_score, dtype: float64
 
 In each case, rather than a single scalar, we receive one result for each

--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -125,8 +125,8 @@ metrics simultaneously:
     ...                             y_true, y_pred,
     ...                             sensitive_features=group_membership_data)
     >>> multi_metric.overall
-    precision    0.5556
-    recall       0.5000
+    precision    0.5555...
+    recall       0.5000...
     dtype: object
     >>> multi_metric.by_group
                         precision recall
@@ -152,10 +152,10 @@ in a dictionary via the ``sample_params`` argument.:
     0.45
     >>> weighted.by_group
     SF 0
-    a    0.0000
-    b    0.5000
-    c    0.7143
-    d    0.0000
+    a    0.0000...
+    b    0.5000...
+    c    0.7142...
+    d    0.0000...
     Name: recall_score, dtype: object
 
 If mutiple metrics are being evaluated, then ``sample_params`` becomes a dictionary of
@@ -178,10 +178,10 @@ function:
     0.5396825396825397
     >>> metric_beta.by_group
     sensitive_feature_0
-    a    0.0000
-    b    0.7907
-    c    0.6335
-    d    0.0000
+    a    0.0000...
+    b    0.7906...
+    c    0.6335...
+    d    0.0000...
     Name: metric, dtype: object
 
 Finally, multiple sensitive features can be specified. The ``by_groups`` property then
@@ -343,18 +343,18 @@ parameter:
     >>> # The 'overall' property is now split based on the control feature
     >>> metric_c_f.overall
     CF
-    H    0.4286
-    L    0.3750
+    H    0.4285...
+    L    0.3750...
     Name: accuracy_score, dtype: object
     >>> # The 'by_group' property looks similar to how it would if we had two sensitive features
     >>> metric_c_f.by_group
     CF  SF
-    H   A     0.2000
-        B     0.4000
-        C     0.7500
-    L   A     0.4000
-        B     0.2857
-        C     0.5000
+    H   A     0.2000...
+        B     0.4000...
+        C     0.7500...
+    L   A     0.4000...
+        B     0.2857...
+        C     0.5000...
     Name: accuracy_score, dtype: object
 
 Note how the :attr:`MetricFrame.overall` property is stratified based on the
@@ -379,8 +379,8 @@ With the :class:`MetricFrame` computed, we can perform aggregations:
     >>> # See the maximum difference in accuracy for each value of the control feature
     >>> metric_c_f.difference(method='between_groups')
     CF
-    H    0.5500
-    L    0.2143
+    H    0.5500...
+    L    0.2142...
     Name: accuracy_score, dtype: float64
 
 In each case, rather than a single scalar, we receive one result for each

--- a/docs/user_guide/mitigation.rst
+++ b/docs/user_guide/mitigation.rst
@@ -254,6 +254,7 @@ the predicted labels.
     >>> from fairlearn.metrics import MetricFrame, selection_rate
     >>> import numpy as np
     >>> import pandas as pd
+    >>> pd.set_option('display.precision', 4)
     >>> dp = DemographicParity(difference_bound=0.01)
     >>> X                  = np.array([[0], [1], [2], [3], [4], [5], [6], [7], [8], [9]])
     >>> y_true             = np.array([ 1 ,  1 ,  1 ,  1 ,  0,   0 ,  0 ,  0 ,  0 ,  0 ])
@@ -353,16 +354,16 @@ In practice this can be used in a difference-based relaxation as follows:
     0.5714285714285714
     >>> tpr_summary.by_group
     sensitive_feature_0
-    a        0.75
-    b    0.333333
+    a    0.7500
+    b    0.3333
     Name: true_positive_rate, dtype: object
     >>> tprp.load_data(X, y_true, sensitive_features=sensitive_features)
     >>> tprp.gamma(lambda X: y_pred)
     sign  event    group_id
-    +     label=1  a           0.178571
-                   b          -0.238095
-    -     label=1  a          -0.178571
-                   b           0.238095
+    +     label=1  a           0.1786
+                   b          -0.2381
+    -     label=1  a          -0.1786
+                   b           0.2381
     dtype: float64
 
 .. note::
@@ -381,10 +382,10 @@ Alternatively, a ratio-based relaxation is also available:
     >>> tprp.load_data(X, y_true, sensitive_features=sensitive_features)
     >>> tprp.gamma(lambda X: y_pred)
     sign  event    group_id
-    +     label=1  a           0.103571
-                   b          -0.271429
-    -     label=1  a          -0.235714
-                   b           0.180952
+    +     label=1  a           0.1036
+                   b          -0.2714
+    -     label=1  a          -0.2357
+                   b           0.1810
     dtype: float64
 
 .. _equalized_odds:
@@ -409,14 +410,14 @@ and false positive rate.
     >>> eo.load_data(X, y_true, sensitive_features=sensitive_features)
     >>> eo.gamma(lambda X: y_pred)
     sign  event    group_id
-    +     label=0  a          -0.333333
-                   b           0.166667
-          label=1  a           0.178571
-                   b          -0.238095
-    -     label=0  a           0.333333
-                   b          -0.166667
-          label=1  a          -0.178571
-                   b           0.238095
+    +     label=0  a          -0.3333
+                   b           0.1667
+          label=1  a           0.1786
+                   b          -0.2381
+    -     label=0  a           0.3333
+                   b          -0.1667
+          label=1  a          -0.1786
+                   b           0.2381
     dtype: float64
 
 .. _error_rate_parity:
@@ -606,7 +607,7 @@ Group :code:`"a"` has an average loss of :math:`0.05`, while group
     >>> mae_frame.by_group
     SF 0
     a    0.05
-    b     0.5
+    b    0.50
     Name: mean_absolute_error, dtype: object
     >>> bgl.load_data(X, y_true, sensitive_features=sensitive_features)
     >>> bgl.gamma(lambda X: y_pred)

--- a/docs/user_guide/mitigation.rst
+++ b/docs/user_guide/mitigation.rst
@@ -353,16 +353,16 @@ In practice this can be used in a difference-based relaxation as follows:
     0.5714285714285714
     >>> tpr_summary.by_group
     sensitive_feature_0
-    a    0.7500
-    b    0.3333
+    a    0.7500...
+    b    0.3333...
     Name: true_positive_rate, dtype: object
     >>> tprp.load_data(X, y_true, sensitive_features=sensitive_features)
     >>> tprp.gamma(lambda X: y_pred)
     sign  event    group_id
-    +     label=1  a           0.1786
-                   b          -0.2381
-    -     label=1  a          -0.1786
-                   b           0.2381
+    +     label=1  a           0.1785...
+                   b          -0.2380...
+    -     label=1  a          -0.1785...
+                   b           0.2380...
     dtype: float64
 
 .. note::
@@ -381,10 +381,10 @@ Alternatively, a ratio-based relaxation is also available:
     >>> tprp.load_data(X, y_true, sensitive_features=sensitive_features)
     >>> tprp.gamma(lambda X: y_pred)
     sign  event    group_id
-    +     label=1  a           0.1036
-                   b          -0.2714
-    -     label=1  a          -0.2357
-                   b           0.1810
+    +     label=1  a           0.1035...
+                   b          -0.2714...
+    -     label=1  a          -0.2357...
+                   b           0.1809...
     dtype: float64
 
 .. _equalized_odds:
@@ -409,14 +409,14 @@ and false positive rate.
     >>> eo.load_data(X, y_true, sensitive_features=sensitive_features)
     >>> eo.gamma(lambda X: y_pred)
     sign  event    group_id
-    +     label=0  a          -0.3333
-                   b           0.1667
-          label=1  a           0.1786
-                   b          -0.2381
-    -     label=0  a           0.3333
-                   b          -0.1667
-          label=1  a          -0.1786
-                   b           0.2381
+    +     label=0  a          -0.3333...
+                   b           0.1666...
+          label=1  a           0.1785...
+                   b          -0.2380...
+    -     label=0  a           0.3333...
+                   b          -0.1666...
+          label=1  a          -0.1785...
+                   b           0.2380...
     dtype: float64
 
 .. _error_rate_parity:

--- a/docs/user_guide/mitigation.rst
+++ b/docs/user_guide/mitigation.rst
@@ -254,7 +254,6 @@ the predicted labels.
     >>> from fairlearn.metrics import MetricFrame, selection_rate
     >>> import numpy as np
     >>> import pandas as pd
-    >>> pd.set_option('display.precision', 4)
     >>> dp = DemographicParity(difference_bound=0.01)
     >>> X                  = np.array([[0], [1], [2], [3], [4], [5], [6], [7], [8], [9]])
     >>> y_true             = np.array([ 1 ,  1 ,  1 ,  1 ,  0,   0 ,  0 ,  0 ,  0 ,  0 ])

--- a/test/unit/preprocessing/linear_dep_remover/test_sklearn_compat.py
+++ b/test/unit/preprocessing/linear_dep_remover/test_sklearn_compat.py
@@ -30,7 +30,6 @@ from fairlearn.preprocessing import CorrelationRemover
         estimator_checks.check_dtype_object,
         estimator_checks.check_sample_weights_pandas_series,
         estimator_checks.check_sample_weights_list,
-        estimator_checks.check_sample_weights_invariance,
         estimator_checks.check_estimators_fit_returns_self,
         estimator_checks.check_complex_data,
         estimator_checks.check_estimators_empty_data_messages,


### PR DESCRIPTION
Address build breaking issues:
- The latest version of `scikit-learn` was causing trouble with the tests for `CorrelationRemover` due to changes in the behaviour of the `check_sample_weights_invariance()` test. Since `CorrelationRemover` doesn't actually permit sample weights, remove this check from the list of checks run
- Something had changed how Pandas was printing out `DataFrame` objects, causing the expected output not to match in the docs. Force a precision to address this