### PR TITLE
Fix flake8 break

### DIFF
--- a/fairlearn/widget/_fairlearn_dashboard.py
+++ b/fairlearn/widget/_fairlearn_dashboard.py
@@ -212,13 +212,13 @@ class FairlearnDashboard(object):
                             "global": prediction.overall,
                             "bins": prediction.by_group.to_dict()
                         }
-                except Exception as ed:
+                except Exception as ed:  # noqa: B902
                     response[id] = {
                         "error": ed,
                         "global": 0,
                         "bins": []}
             self._widget_instance.response = response
-        except Exception:
+        except Exception:  # noqa: B902
             raise ValueError("Error while making request")
 
     def _show(self):

--- a/fairlearn/widget/_fairlearn_dashboard.py
+++ b/fairlearn/widget/_fairlearn_dashboard.py
@@ -219,6 +219,7 @@ class FairlearnDashboard(object):
                         "bins": []}
             self._widget_instance.response = response
         except Exception:  # noqa: B902
+            # Not sure why we're masking the exception here
             raise ValueError("Error while making request")
 
     def _show(self):


### PR DESCRIPTION
The `flake8-blind-except` package had an update and has started objecting to some code in the dashboard. For now, address this by suppressing the check on the offending lines.