### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+### v0.6.1
+
 ### v0.6.0
 
 * Add `CorrelationRemover` preprocessing technique. This removes correlations

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Website: https://fairlearn.github.io/
 
 ## Current release
 
-- The current stable release is available at [Fairlearn v0.5.0](https://github.com/fairlearn/fairlearn/tree/release/v0.5.0).
+- The current stable release is available at [Fairlearn v0.5.0](https://github.com/fairlearn/fairlearn/tree/release/v0.6.0).
 
 - Our current version differs substantially from version 0.2 or earlier. Users of these older versions should visit our [onboarding guide](https://fairlearn.github.io/master/contributor_guide/development_process.html#onboarding-guide).
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Website: https://fairlearn.github.io/
 
 ## Current release
 
-- The current stable release is available at [Fairlearn v0.5.0](https://github.com/fairlearn/fairlearn/tree/release/v0.6.0).
+- The current stable release is available at [Fairlearn v0.6.0](https://github.com/fairlearn/fairlearn/tree/release/v0.6.0).
 
 - Our current version differs substantially from version 0.2 or earlier. Users of these older versions should visit our [onboarding guide](https://fairlearn.github.io/master/contributor_guide/development_process.html#onboarding-guide).
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,7 +89,7 @@ master_doc = 'index'
 
 # Multiversion settings
 
-smv_tag_whitelist = r'^v0\.4\.6|^v0\.5\.\d+$'
+smv_tag_whitelist = r'^v0\.4\.6|^v0\.5\.\d|^v0\.6\.\d+$'
 smv_branch_whitelist = r'^master$'
 
 if check_if_v046():

--- a/docs/static_landing_page/index.html
+++ b/docs/static_landing_page/index.html
@@ -28,11 +28,11 @@
 		        <ul class="navbar-nav ml-auto text-center">
 		          <li class="nav-item pr-0 pr-lg-4">
 					  <!-- Versioned Link -->
-		            <a class="nav-link" href="./v0.5.0/user_guide/index.html">User Guide</a>
+		            <a class="nav-link" href="./v0.6.0/user_guide/index.html">User Guide</a>
 		          </li>
 		          <li class="nav-item pr-0 pr-lg-4">
 					<!-- Versioned Link -->
-		            <a class="nav-link" href="./v0.5.0/api_reference/index.html">API Docs</a>
+		            <a class="nav-link" href="./v0.6.0/api_reference/index.html">API Docs</a>
 		          </li>
 		          <li class="nav-item pr-0 pr-lg-4">
 		            <a class="nav-link" href="#contribute">Contribute</a>
@@ -94,11 +94,11 @@
 						          	<div class="row">
 						          		<div class="col-12 col-lg-4 pb-3">
 											<!-- Versioned Link -->
-						            		<a class="masthead-btn text-center mr-0" href="./v0.5.0/quickstart.html">Get Started</a>
+						            		<a class="masthead-btn text-center mr-0" href="./v0.6.0/quickstart.html">Get Started</a>
 						            	</div>
 						            	<div id="about-fairlearn"  class="pb-4 pb-lg-0 col-12 col-lg-4">
 											<!-- Versioned Link -->
-						           	 		<a class="masthead-btn-transparent text-center" href="./v0.5.0/api_reference/index.html">API Docs</a>
+						           	 		<a class="masthead-btn-transparent text-center" href="./v0.6.0/api_reference/index.html">API Docs</a>
 						           	 	</div>
 						           	</div>
 					          	</div>
@@ -180,7 +180,7 @@
 					  		<h5 class="text-center text-lg-left dark">Allocation</h5>
 					  		<p class="text-center text-lg-left pb-4">For example, a system for screening loan or job applications might be better at picking good candidates among some groups of people than among others.</p>
 								<!-- Versioned Link -->  
-							  <a href="./v0.5.0/user_guide/index.html">
+							  <a href="./v0.6.0/user_guide/index.html">
 					  			<p class="text-center pb-4 text-link">Learn More</p>
 					  		</a>
 					  	</div>
@@ -228,7 +228,7 @@
 		                   	 	<ul class="list-group media-list media-list-stream">
 									<p>Use metrics like demographic parity, parity in accuracy rate, etc.</p>
 									  <!-- Versioned Link -->
-		                        	<a href="./v0.5.0/api_reference/fairlearn.metrics.html">
+		                        	<a href="./v0.6.0/api_reference/fairlearn.metrics.html">
 		                        		<p class="tab-links">See Supported Fairness Metrics</p>
 		                        	</a>
 		                    	</ul>
@@ -237,7 +237,7 @@
 			                    <ul class="list-group media-list media-list-stream">
 			                        <p>Use metrics like parity in mean squared error, worst-case mean squared error, etc.</p>
 									<!-- Versioned Link -->
-		                        	<a href="./v0.5.0/api_reference/fairlearn.metrics.html">
+		                        	<a href="./v0.6.0/api_reference/fairlearn.metrics.html">
 		                        		<p class="tab-links">See Supported Fairness Metrics</p>
 		                        	</a>
 			                    </ul>
@@ -274,7 +274,7 @@
 		  				<div class="col-12 pt-5 pb-5">
 		  					<h3 class="dark text-center bold">1. Select the fairness metric</h3>
 							  <!-- Versioned Link -->
-		  					<a href="./v0.5.0/api_reference/fairlearn.metrics.html">
+		  					<a href="./v0.6.0/api_reference/fairlearn.metrics.html">
 		                        <p class="text-center tab-links">See Supported Fairness Metrics</p>
 		                    </a>
 		  				</div>
@@ -387,7 +387,7 @@
 		    <div class="col-sm-12 col-lg-6 text-center pb-5">
 		      <h2 class="pt-5 pb-4">Getting Started</h2>
 			  <!-- Versioned Link -->
-		      <a class="models-behavior-btn" href="./v0.5.0/quickstart.html">Install Fairlearn</a>
+		      <a class="models-behavior-btn" href="./v0.6.0/quickstart.html">Install Fairlearn</a>
 		    </div>
 		  </div>
 		</div>
@@ -402,7 +402,7 @@
 					<h2 class="dark pt-5 pb-3">Contribute to Fairlearn</h2>
 					<p>We encourage you to join the effort and contribute feedback, metrics, algorithms, visualizations, ideas and more, so we can evolve the toolkit together!</p>
 					  <!-- Versioned Link -->
-					  <a class="contribute-btn mb-5" href="./v0.5.0/contributor_guide/index.html">Contribute</a>
+					  <a class="contribute-btn mb-5" href="./v0.6.0/contributor_guide/index.html">Contribute</a>
 				</div>
 			</div>
 		</div>
@@ -418,7 +418,7 @@
 	    		</div>
 	    		<div class="col-12 col-lg-3 text-center text-lg-left pt-2">
 					<!-- Versioned Link -->
-	    			<a href="./v0.5.0/api_reference/index.html">
+	    			<a href="./v0.6.0/api_reference/index.html">
 	    				<p class="white">API Docs</p>
 	    			</a>
 	    			<a href="https://github.com/Fairlearn/Fairlearn/issues/">
@@ -433,7 +433,7 @@
 	    		</div>
 	    		<div class="col-12 col-lg-3 text-center text-lg-left pt-2">
 					<!-- Versioned Link -->
-	    			<a href="./v0.5.0/user_guide/index.html">
+	    			<a href="./v0.6.0/user_guide/index.html">
 	    				<p class="white footer-bold">User Guide</p>
 	    			</a>
 	    		</div>

--- a/fairlearn/__init__.py
+++ b/fairlearn/__init__.py
@@ -9,7 +9,7 @@ import os
 from .show_versions import show_versions  # noqa: F401
 
 __name__ = "fairlearn"
-__version__ = "0.5.1.dev0"
+__version__ = "0.6.1.dev0"
 _base_version = __version__  # To enable the v0.4.6 docs
 
 # Setup logging infrastructure


### PR DESCRIPTION
Updates to the development trunk for v0.6.0 (these occur immediately after the tag/branch for v0.6.0:

- Bumps development version to v0.6.1.dev0
- Updates ReadMe to have link to v0.6.0
- Updates landing page to point to v0.6.0 docs by default
- Ensures that v0.6.0 docs are built