### PR TITLE
More Python 3.9 builds

### DIFF
--- a/devops/nightly-requirements-fixed.yml
+++ b/devops/nightly-requirements-fixed.yml
@@ -25,7 +25,7 @@ jobs:
   parameters:
     platforms:  { Linux: ubuntu-latest, Windows: vs2017-win2016 }
     installationType: 'PipLocal'
-    pyVersions: [3.6, 3.7, 3.8]
+    pyVersions: [3.6, 3.7, 3.8, 3.9]
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFileStem: $(FreezeFileStem)
     pinRequirements: True

--- a/devops/nightly-requirements-fixed.yml
+++ b/devops/nightly-requirements-fixed.yml
@@ -25,7 +25,7 @@ jobs:
   parameters:
     platforms:  { Linux: ubuntu-latest, Windows: vs2017-win2016 }
     installationType: 'PipLocal'
-    pyVersions: [3.6, 3.7, 3.8, 3.9]
+    pyVersions: [3.6, 3.7, 3.8]
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFileStem: $(FreezeFileStem)
     pinRequirements: True

--- a/devops/nightly-requirements-fixed.yml
+++ b/devops/nightly-requirements-fixed.yml
@@ -1,5 +1,6 @@
 # Nightly build pipeline with requirements pinned to lower bounds (if any)
 # This does not run on MacOS due to issues with the pinned requirements
+# There are also issues with running on Python 3.9
 
 variables:
   FreezeArtifactStem: 'freeze'

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -24,7 +24,7 @@ jobs:
   parameters:
     platforms:  { Linux: ubuntu-latest, Windows: vs2017-win2016 }
     installationType: 'PipLocal'
-    pyVersions: [3.6, 3.7, 3.8]
+    pyVersions: [3.6, 3.7, 3.8, 3.9]
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFileStem: $(FreezeFileStem)
     
@@ -33,7 +33,7 @@ jobs:
     platforms: { MacOS: macos-latest }
     testRunTypes: ['Unit']
     installationType: 'None'
-    pyVersions: [3.6, 3.7, 3.8]
+    pyVersions: [3.6, 3.7, 3.8, 3.9]
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFileStem: $(FreezeFileStem)
 

--- a/devops/pypi-release-new.yml
+++ b/devops/pypi-release-new.yml
@@ -46,7 +46,7 @@ stages:
     parameters:
       platforms:  { Linux: ubuntu-latest, Windows: vs2017-win2016 }
       installationType: 'PipLocal'
-      pyVersions: [3.6, 3.7, 3.8]
+      pyVersions: [3.6, 3.7, 3.8, 3.9]
       freezeArtifactStem: $(freezeArtifactStem)
       freezeFileStem: $(freezeFileStem)
       
@@ -55,7 +55,7 @@ stages:
       platforms: { MacOS: macos-latest }
       testRunTypes: ['Unit']
       installationType: 'None'
-      pyVersions: [3.6, 3.7, 3.8]
+      pyVersions: [3.6, 3.7, 3.8, 3.9]
       freezeArtifactStem: $(freezeArtifactStem)
       freezeFileStem: $(freezeFileStem)
 
@@ -136,7 +136,7 @@ stages:
       parameters:
         platforms: { Linux: ubuntu-latest, Windows: vs2017-win2016 }
         installationType: 'WheelArtifact'
-        pyVersions: [3.6, 3.7, 3.8]
+        pyVersions: [3.6, 3.7, 3.8, 3.9]
         freezeArtifactStem: $(freezeArtifactStem)
         freezeFileStem: $(freezeFileStem)
         wheelArtifactName: $(packageArtifactName)
@@ -146,7 +146,7 @@ stages:
         platforms: { MacOS: macos-latest }
         testRunTypes: ['Unit']
         installationType: 'WheelArtifact'
-        pyVersions: [3.6, 3.7, 3.8]
+        pyVersions: [3.6, 3.7, 3.8, 3.9]
         freezeArtifactStem: $(freezeArtifactStem)
         freezeFileStem: $(freezeFileStem)
         wheelArtifactName: $(packageArtifactName)
@@ -226,7 +226,7 @@ stages:
   - template: templates/all-tests-job-template.yml
     parameters:
       platforms:  { Linux: ubuntu-latest, Windows: vs2017-win2016 }
-      pyVersions: [3.6, 3.7, 3.8]
+      pyVersions: [3.6, 3.7, 3.8, 3.9]
       freezeArtifactStem: $(freezeArtifactStem)
       freezeFileStem: $(freezeFileStem)
       installationType: 'PyPI'
@@ -237,6 +237,7 @@ stages:
   - template: templates/all-tests-job-template.yml
     parameters:
       platforms: { MacOS: macos-latest }
+      pyVersions: [3.6, 3.7, 3.8, 3.9]
       testRunTypes: ['Unit']
       freezeArtifactStem: $(freezeArtifactStem)
       freezeFileStem: $(freezeFileStem)

--- a/devops/templates/limited-installation-job-template.yml
+++ b/devops/templates/limited-installation-job-template.yml
@@ -5,7 +5,7 @@
 parameters:
   name: 'LimitedInstallation'
   vmImage: 'ubuntu-latest'
-  pyVersions: [3.6, 3.7, 3.8]
+  pyVersions: [3.6, 3.7, 3.8, 3.9]
   freezeArtifactStem: 
   freezeFileStem:
 


### PR DESCRIPTION
Add Python 3.9 to more of the builds we have. Unfortunately, this doesn't work with the 'Nightly Fixed' build.