### PR TITLE
Replace references to master branch with the new main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,4 +115,4 @@ workflows:
             - build-doc
           filters:
             branches:
-              only: master  # don't deploy to GitHub pages from other branches
+              only: main  # don't deploy to GitHub pages from other branches

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
       - run:
           name: "Build Documentation"
           command: python scripts/build_documentation.py --documentation-path=docs --output-path=docs/_build/html
+          no_output_timeout: 30m
 
       - persist_to_workspace:
           root: docs/_build
@@ -64,6 +65,7 @@ jobs:
       - run:
           name: 'Build doctest'
           command: python -m sphinx -v -b doctest -n -j auto docs docs/_build/html
+          no_output_timeout: 30m
       
   deploy-doc:
     docker:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -69,7 +69,7 @@ Please provide the following information:
 - OS: [e.g. Windows]
 - Browser (if you're reporting a dashboard bug in jupyter): [e.g. Edge, Firefox, Chrome, Safari]
 - Python version: [e.g. 3.7.4]
-- Fairlearn version: [e.g. 0.4.5 or installed from master branch in editable mode]
+- Fairlearn version: [e.g. 0.4.5 or installed from main branch in editable mode]
 - version of Python packages: please run the following snippet and paste the output:
   ```python
   import fairlearn

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://dev.azure.com/responsibleai/fairlearn/_apis/build/status/Nightly?branchName=master)](https://dev.azure.com/responsibleai/fairlearn/_build/latest?definitionId=23&branchName=master) ![MIT license](https://img.shields.io/badge/License-MIT-blue.svg) ![PyPI](https://img.shields.io/pypi/v/fairlearn?color=blue) [![Gitter](https://badges.gitter.im/fairlearn/community.svg)](https://gitter.im/fairlearn/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) [![StackOverflow](https://img.shields.io/badge/StackOverflow-questions-blueviolet)](https://stackoverflow.com/questions/tagged/fairlearn)
+[![Build Status](https://dev.azure.com/responsibleai/fairlearn/_apis/build/status/Nightly?branchName=main)](https://dev.azure.com/responsibleai/fairlearn/_build/latest?definitionId=23&branchName=main) ![MIT license](https://img.shields.io/badge/License-MIT-blue.svg) ![PyPI](https://img.shields.io/pypi/v/fairlearn?color=blue) [![Gitter](https://badges.gitter.im/fairlearn/community.svg)](https://gitter.im/fairlearn/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) [![StackOverflow](https://img.shields.io/badge/StackOverflow-questions-blueviolet)](https://stackoverflow.com/questions/tagged/fairlearn)
 
 # Fairlearn
 
@@ -21,7 +21,7 @@ Website: https://fairlearn.github.io/
 
 - The current stable release is available at [Fairlearn v0.6.0](https://github.com/fairlearn/fairlearn/tree/release/v0.6.0).
 
-- Our current version differs substantially from version 0.2 or earlier. Users of these older versions should visit our [onboarding guide](https://fairlearn.github.io/master/contributor_guide/development_process.html#onboarding-guide).
+- Our current version differs substantially from version 0.2 or earlier. Users of these older versions should visit our [onboarding guide](https://fairlearn.github.io/main/contributor_guide/development_process.html#onboarding-guide).
 
 ## What we mean by _fairness_
 
@@ -35,7 +35,7 @@ We follow the approach known as **group fairness**, which asks: _Which groups of
 
 Group fairness is formalized by a set of constraints, which require that some aspect (or aspects) of the AI system's behavior be comparable across the groups. The Fairlearn package enables assessment and mitigation of unfairness under several common definitions.
 To learn more about our definitions of fairness, please visit our
-[user guide on Fairness of AI Systems](https://fairlearn.github.io/master/user_guide/fairness_in_machine_learning.html#fairness-of-ai-systems).
+[user guide on Fairness of AI Systems](https://fairlearn.github.io/main/user_guide/fairness_in_machine_learning.html#fairness-of-ai-systems).
 
 >_Note_:
 > Fairness is fundamentally a sociotechnical challenge. Many aspects of fairness, such as justice and due process, are not captured by quantitative fairness metrics. Furthermore, there are many quantitative fairness metrics which cannot all be satisfied simultaneously. Our goal is to enable humans to assess different mitigation strategies and then make trade-offs appropriate to their scenario.
@@ -50,22 +50,22 @@ The Fairlearn Python package has two components:
 
 ### Fairlearn algorithms
 
-For an overview of our algorithms please refer to our [website](https://fairlearn.github.io/master/user_guide/mitigation.html).
+For an overview of our algorithms please refer to our [website](https://fairlearn.github.io/main/user_guide/mitigation.html).
 
 ### Fairlearn dashboard
 
-Check out our in-depth [guide on the Fairlearn dashboard](https://fairlearn.github.io/master/user_guide/assessment.html#fairlearn-dashboard).
+Check out our in-depth [guide on the Fairlearn dashboard](https://fairlearn.github.io/main/user_guide/assessment.html#fairlearn-dashboard).
 
 ## Install Fairlearn
 
-For instructions on how to install Fairlearn check out our [Quickstart guide](https://fairlearn.github.io/master/quickstart.html).
+For instructions on how to install Fairlearn check out our [Quickstart guide](https://fairlearn.github.io/main/quickstart.html).
 
 ## Usage
 
 For common usage refer to the [Jupyter notebooks](./notebooks) and our
-[user guide](https://fairlearn.github.io/master/user_guide/index.html).
+[user guide](https://fairlearn.github.io/main/user_guide/index.html).
 Please note that our APIs are subject to change, so notebooks downloaded
-from `master` may not be compatible with Fairlearn installed with `pip`.
+from `main` may not be compatible with Fairlearn installed with `pip`.
 In this case, please navigate the tags in the repository
 (e.g. [v0.4.5](https://github.com/fairlearn/fairlearn/tree/v0.4.5))
 to locate the appropriate version of the notebook.
@@ -73,7 +73,7 @@ to locate the appropriate version of the notebook.
 ## Contributing
 
 To contribute please check our
-[contributor guide](https://fairlearn.github.io/master/contributor_guide/index.html).
+[contributor guide](https://fairlearn.github.io/main/contributor_guide/index.html).
 
 ## Maintainers
 

--- a/devops/PR-Gate.yml
+++ b/devops/PR-Gate.yml
@@ -3,7 +3,7 @@ variables:
   FreezeFileStem: 'requirements-freeze'
 
 pr:
-- master
+- main
 - release/*
 
 trigger: none # No CI build

--- a/devops/code-coverage.yml
+++ b/devops/code-coverage.yml
@@ -13,7 +13,7 @@ schedules:
   displayName: Nightly Code Coverage Build
   branches:
     include:
-      - master
+      - main
   always: true
 
 jobs:

--- a/devops/nightly-requirements-fixed.yml
+++ b/devops/nightly-requirements-fixed.yml
@@ -15,7 +15,7 @@ schedules:
   displayName: Nightly Build
   branches:
     include:
-      - master
+      - main
   always: true
 
 pool:

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -13,7 +13,7 @@ schedules:
   displayName: Nightly Build
   branches:
     include:
-      - master
+      - main
   always: true
 
 pool:

--- a/devops/other-ml-packages.yml
+++ b/devops/other-ml-packages.yml
@@ -5,7 +5,7 @@ trigger: none # No CI build
 pr:
   branches:
     include:
-    - master
+    - main
   paths:
     include:
     - test_othermlpackages/*
@@ -15,7 +15,7 @@ schedules:
   displayName: Nightly Build
   branches:
     include:
-      - master
+      - main
   always: true
 
 pool:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,7 +90,7 @@ master_doc = 'index'
 # Multiversion settings
 
 smv_tag_whitelist = r'^v0\.4\.6|^v0\.5\.\d|^v0\.6\.\d+$'
-smv_branch_whitelist = r'^master$'
+smv_branch_whitelist = r'^main$'
 
 if check_if_v046():
     print("Current version is v0.4.6, will apply overrides")
@@ -201,7 +201,7 @@ def linkcode_resolve(domain, info):
     else:
         linespec = ""
 
-    tag_or_branch = os.getenv("SPHINX_MULTIVERSION_NAME", default="master")
+    tag_or_branch = os.getenv("SPHINX_MULTIVERSION_NAME", default="main")
     fn = os.path.relpath(fn, start=os.path.dirname(fairlearn.__file__)).replace(os.sep, '/')
     return f"http://github.com/fairlearn/fairlearn/blob/{tag_or_branch}/fairlearn/{fn}{linespec}"
 

--- a/docs/contributor_guide/contributing_example_notebooks.rst
+++ b/docs/contributor_guide/contributing_example_notebooks.rst
@@ -42,7 +42,7 @@ This allows them to be rendered properly with output from all cells.
 These notebooks are generated based on `plot_*.py` files in
 `percent format <https://jupytext.readthedocs.io/en/latest/formats.html#the-percent-format>`_
 in the
-`examples/notebooks directory <https://github.com/fairlearn/fairlearn/tree/master/examples/notebooks>`_
+`examples/notebooks directory <https://github.com/fairlearn/fairlearn/tree/main/examples/notebooks>`_
 of the repository.
 To do this yourself make sure to install sphinx and its
 add-ons by running :code:`python scripts/install_requirements.py --pinned False` in the repository

--- a/docs/contributor_guide/development_process.rst
+++ b/docs/contributor_guide/development_process.rst
@@ -1,14 +1,14 @@
 Development process
 -------------------
 
-Development happens against the :code:`master` branch following the
+Development happens against the :code:`main` branch following the
 `GitHub flow model <https://guides.github.com/introduction/flow/>`_.
 Contributors should use their own forks of the repository. In their fork, they
-create feature branches off of :code:`master`, and their pull requests should
-target the :code:`master` branch. Maintainers are responsible for prompt
+create feature branches off of :code:`main`, and their pull requests should
+target the :code:`main` branch. Maintainers are responsible for prompt
 review of pull requests.
 
-Pull requests against :code:`master` trigger automated tests that are run
+Pull requests against :code:`main` trigger automated tests that are run
 through Azure DevOps, GitHub Actions, and CircleCI. Additional test suites are
 run periodically. When adding new code paths or features, tests are a
 requirement to complete a pull request. They should be added in the
@@ -136,30 +136,30 @@ command
 Note that the Fairlearn dashboard is built using nodejs and requires
 additional steps. To build the Fairlearn dashboard after making changes to it,
 `install Yarn <https://yarnpkg.com/lang/en/docs/install>`_, and then run the
-`widget build script <https://github.com/fairlearn/fairlearn/tree/master/scripts/build_widget.py>`_.
+`widget build script <https://github.com/fairlearn/fairlearn/tree/main/scripts/build_widget.py>`_.
 
 The Requirements Files
 """"""""""""""""""""""
 
 The prerequisites for Fairlearn are split between three separate files:
 
-    -  `requirements.txt <https://github.com/fairlearn/fairlearn/blob/master/requirements.txt>`_
+    -  `requirements.txt <https://github.com/fairlearn/fairlearn/blob/main/requirements.txt>`_
        contains the prerequisites for the core Fairlearn package
 
-    -  `requirements-customplots.txt <https://github.com/fairlearn/fairlearn/blob/master/requirements-customplots.txt>`_
+    -  `requirements-customplots.txt <https://github.com/fairlearn/fairlearn/blob/main/requirements-customplots.txt>`_
        contains additional prerequisites for the :code:`[customplots]` extension for Fairlearn
 
-    -  `requirements-dev.txt <https://github.com/fairlearn/fairlearn/blob/master/requirements-dev.txt>`_ contains
+    -  `requirements-dev.txt <https://github.com/fairlearn/fairlearn/blob/main/requirements-dev.txt>`_ contains
        the prerequisites for Fairlearn development (such as flake8 and pytest)
 
-The `requirements.txt <https://github.com/fairlearn/fairlearn/blob/master/requirements.txt>`_
+The `requirements.txt <https://github.com/fairlearn/fairlearn/blob/main/requirements.txt>`_
 and
-`requirements-customplots.txt <https://github.com/fairlearn/fairlearn/blob/master/requirements-customplots.txt>`_
+`requirements-customplots.txt <https://github.com/fairlearn/fairlearn/blob/main/requirements-customplots.txt>`_
 files are consumed
-by `setup.py <https://github.com/fairlearn/fairlearn/blob/master/setup.py>`_ to specify the dependencies to be
+by `setup.py <https://github.com/fairlearn/fairlearn/blob/main/setup.py>`_ to specify the dependencies to be
 documented in the wheel files.
 To help simplify installation of the prerequisites, we have the
-`install_requirements.py <https://github.com/fairlearn/fairlearn/blob/master/scripts/install_requirements.py>`_
+`install_requirements.py <https://github.com/fairlearn/fairlearn/blob/main/scripts/install_requirements.py>`_
 script which runs :code:`pip install` on all three of the above files.
 This script will also optionally pin the requirements to any lower bound specified (by changing any
 occurrences of :code:`>=` to :code:`==` in each file).
@@ -220,7 +220,7 @@ you encounter any problems.
 Investigating automated test failures
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For every pull request to :code:`master` with automated tests, you can check
+For every pull request to :code:`main` with automated tests, you can check
 the logs of the tests to find the root cause of failures. Our tests currently
 run through Azure Pipelines with steps for setup, testing, and teardown. The
 :code:`Checks` tab of a pull request contains a link to the

--- a/docs/contributor_guide/fairlearn_repository_overview.rst
+++ b/docs/contributor_guide/fairlearn_repository_overview.rst
@@ -5,27 +5,27 @@ Everything in the Fairlearn repository falls under one of the following
 categories:
 
 * Python source code in the
-  `fairlearn <https://github.com/fairlearn/fairlearn/tree/master/fairlearn>`_
+  `fairlearn <https://github.com/fairlearn/fairlearn/tree/main/fairlearn>`_
   directory
 * Python test code in the
-  `test <https://github.com/fairlearn/fairlearn/tree/master/test>`_ directory
+  `test <https://github.com/fairlearn/fairlearn/tree/main/test>`_ directory
 * Visualization source code in the
-  `visualization <https://github.com/fairlearn/fairlearn/tree/master/visualization>`_
+  `visualization <https://github.com/fairlearn/fairlearn/tree/main/visualization>`_
   directory
 * Automation / DevOps / CI pipeline definitions for
 
   * Azure DevOps in the
-    `devops <https://github.com/fairlearn/fairlearn/tree/master/devops>`_
+    `devops <https://github.com/fairlearn/fairlearn/tree/main/devops>`_
     directory
   * GitHub Actions in the
-    `.github <https://github.com/fairlearn/fairlearn/tree/master/.github>`_
+    `.github <https://github.com/fairlearn/fairlearn/tree/main/.github>`_
     directory
   * CircleCI in the
-    `.circleci <https://github.com/fairlearn/fairlearn/tree/master/.circleci>`_
+    `.circleci <https://github.com/fairlearn/fairlearn/tree/main/.circleci>`_
     directory
 
 * Documentation definition and configuration in the
-  `docs <https://github.com/fairlearn/fairlearn/tree/master/docs>`_ directory
+  `docs <https://github.com/fairlearn/fairlearn/tree/main/docs>`_ directory
 * Example notebooks in the
-  `examples <https://github.com/fairlearn/fairlearn/tree/master/examples>`_
+  `examples <https://github.com/fairlearn/fairlearn/tree/main/examples>`_
   directory

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -30,7 +30,7 @@ see :ref:`version_migration_guide`.
     The Fairlearn API is still evolving, so example code in 
     this documentation may not work with every version of Fairlearn.
     Please use the version selector to get to the instructions for
-    the appropriate version. The instructions for the :code:`master`
+    the appropriate version. The instructions for the :code:`main`
     branch require Fairlearn to be installed from a clone of the
     repository. See :ref:`advanced_install` for the required steps.
 

--- a/notebooks/ReadMe.md
+++ b/notebooks/ReadMe.md
@@ -2,9 +2,9 @@
 
 We are still exploring possibilities for the APIs in Fairlearn,
 meaning that we sometimes have breaking changes.
-As a result, notebooks taken from the `master` branch on GitHub may
+As a result, notebooks taken from the `main` branch on GitHub may
 not always be compatible with a version of Fairlearn installed using
-`pip` (notebooks on `master` will always be compatible with `master`).
+`pip` (notebooks on `main` will always be compatible with `main`).
 
 If you encounter compatibility problems with notebooks, go to your terminal and run:
 ```
@@ -18,4 +18,4 @@ Then, on the GitHub page, navigate to that version
 and download the notebooks from there.
 
 Alternatively, [install Fairlearn from a cloned repository](https://fairlearn.github.io/contributor_guide/development_process.html#advanced-installation-instructions)
-in order to use the notebooks from `master`.
+in order to use the notebooks from `main`.


### PR DESCRIPTION
Finally getting to this!

I did the following:

![image](https://user-images.githubusercontent.com/10245648/107110615-211f8500-67fe-11eb-8b7d-d55e88446724.png)

If you want to run these commands locally, copy from here:

```bash
git branch -m master <BRANCH>
git fetch origin
git branch -u origin/<BRANCH> <BRANCH>
```

This closes #477 

Outstanding:
- [ ] ensure that website build resumes after this PR, and that `main` is shown in the version selector rather than `master`
- [ ] ensure that Azure DevOps is using main now

Signed-off-by: Roman Lutz <rolutz@microsoft.com>