### PR TITLE
Put requirements file into tarball

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,10 @@ setuptools.setup(
         ('share/jupyter/lab/extensions', [
             'fairlearn/widget/js/'
             'fairlearn_widget/labextension/fairlearn-widget-0.1.0.tgz'
+        ]),
+        ('.', [
+            'requirements.txt',
+            'requirements-customplots.txt'
         ])],
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,10 @@ setuptools.setup(
             'fairlearn/widget/js/'
             'fairlearn_widget/labextension/fairlearn-widget-0.1.0.tgz'
         ]),
-        ('.', [
-            'requirements.txt',
+        ('./requirements.txt', [
+            'requirements.txt'
+        ]),
+        ('./requirements-customplots.txt', [
             'requirements-customplots.txt'
         ])],
     zip_safe=False,


### PR DESCRIPTION
Put the two requirements files into the distribution tarball, so that things such as

```
pip download --no-binary :all: -d ./ fairlearn
```
will work. Closes #683 