### PR TITLE
Remove scheduled builds from old 'master' branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,4 +115,4 @@ workflows:
             - build-doc
           filters:
             branches:
-              only: master  # don't deploy to GitHub pages from other branches
+              only: main  # don't deploy to GitHub pages from other branches

--- a/devops/PR-Gate.yml
+++ b/devops/PR-Gate.yml
@@ -3,7 +3,7 @@ variables:
   FreezeFileStem: 'requirements-freeze'
 
 pr:
-- master
+- main
 - release/*
 
 trigger: none # No CI build

--- a/devops/code-coverage.yml
+++ b/devops/code-coverage.yml
@@ -13,7 +13,7 @@ schedules:
   displayName: Nightly Code Coverage Build
   branches:
     include:
-      - master
+      - main
   always: true
 
 jobs:

--- a/devops/nightly-requirements-fixed.yml
+++ b/devops/nightly-requirements-fixed.yml
@@ -15,7 +15,7 @@ schedules:
   displayName: Nightly Build
   branches:
     include:
-      - master
+      - main
   always: true
 
 pool:

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -13,7 +13,7 @@ schedules:
   displayName: Nightly Build
   branches:
     include:
-      - master
+      - main
   always: true
 
 pool:

--- a/devops/other-ml-packages.yml
+++ b/devops/other-ml-packages.yml
@@ -15,7 +15,7 @@ schedules:
   displayName: Nightly Build
   branches:
     include:
-      - master
+      - main
   always: true
 
 pool:


### PR DESCRIPTION
Attempting to stop a bunch of scheduled builds kicking off on the (recently retired) `master` branch. It appears that since they still have the ADO build definitions referencing `master` the pipelines are still getting triggered. CircleCI may suffer from a similar problem. Adjust the branch name triggers for all of these.

Signed-off-by: Richard Edgar <riedgar@microsoft.com>