### PR TITLE
Alphabetized packages in api docs

### DIFF
--- a/docs/api_reference/index.rst
+++ b/docs/api_reference/index.rst
@@ -6,9 +6,9 @@ API Reference
 .. toctree::
    :maxdepth: 1
 
+   fairlearn.datasets
    fairlearn.metrics
    fairlearn.postprocessing
+   fairlearn.preprocessing
    fairlearn.reductions
    fairlearn.widget
-   fairlearn.datasets
-   fairlearn.preprocessing


### PR DESCRIPTION
Alphabetized packages in api docs.
This resolves https://github.com/fairlearn/fairlearn/issues/715
This is my first time contributing, let me know if I missed anything in the development flow. 