### PR TITLE
TST Fixes warnings for numpy dtype deprecations

### DIFF
--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -530,7 +530,7 @@ class MetricFrame:
                 result.append(GroupFeature(base_name, column, i, None))
         else:
             # Need to specify dtype to avoid inadvertent type conversions
-            f_arr = np.squeeze(np.asarray(features, dtype=np.object))
+            f_arr = np.squeeze(np.asarray(features, dtype=object))
             if len(f_arr.shape) == 1:
                 check_consistent_length(f_arr, sample_array)
                 result.append(GroupFeature(base_name, f_arr, 0, None))

--- a/test/unit/metrics/test_metricframe_process_features.py
+++ b/test/unit/metrics/test_metricframe_process_features.py
@@ -122,7 +122,7 @@ class TestTwoFeatures():
     def test_2d_array(self):
         a, b, y_true = self._get_raw_data()
         # Specify dtype to avoid unwanted string conversion
-        rf = np.asarray([a, b], dtype=np.object).transpose()
+        rf = np.asarray([a, b], dtype=object).transpose()
 
         target = _get_raw_MetricFrame()
         result = target._process_features('CF', rf, y_true)

--- a/test/unit/test_random_state.py
+++ b/test/unit/test_random_state.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT License.
 
 import pandas as pd
-import numpy as np
 from sklearn.datasets import fetch_openml
 from sklearn.model_selection import train_test_split
 from sklearn.linear_model import LogisticRegression
@@ -66,7 +65,7 @@ def _get_test_data():
     data = fetch_openml(data_id=42193)
     X = pd.DataFrame(data['data'], columns=data['feature_names']) \
         .drop(columns=['race_Caucasian', 'c_charge_degree_F'])
-    y = data['target'].astype(np.int)
+    y = data['target'].astype(int)
 
     # split the data in train-validation-test sets
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.20, random_state=0)


### PR DESCRIPTION
Related to https://github.com/fairlearn/fairlearn/issues/704

This PR fixes some warnings related to numpy dtypes.

Signed-off-by: Thomas J. Fan <thomasjpfan@gmail.com>