### PR TITLE
Update main for v0.6.1 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Website: https://fairlearn.github.io/
 
 ## Current release
 
-- The current stable release is available at [Fairlearn v0.6.0](https://github.com/fairlearn/fairlearn/tree/release/v0.6.0).
+- The current stable release is available at [Fairlearn v0.6.1](https://github.com/fairlearn/fairlearn/tree/release/v0.6.1).
 
 - Our current version differs substantially from version 0.2 or earlier. Users of these older versions should visit our [onboarding guide](https://fairlearn.github.io/main/contributor_guide/development_process.html#onboarding-guide).
 

--- a/docs/static_landing_page/index.html
+++ b/docs/static_landing_page/index.html
@@ -27,30 +27,30 @@
       		<div class="collapse navbar-collapse" id="navbarResponsive">
 		        <ul class="navbar-nav pt-2 mt-1 mr-xl-auto ml-xl-2 pl-xl-1 text-center text-nowrap">
 				  <li class="nav-item px-1">
-					  <a class="nav-link" href=./v0.6.0/quickstart.html>Getting Started</a>
+					  <a class="nav-link" href=./v0.6.1/quickstart.html>Getting Started</a>
 				  </li>
 		          <li class="nav-item px-1">
 					  <!-- Versioned Link -->
-		            <a class="nav-link" href="./v0.6.0/user_guide/index.html">User Guide</a>
+		            <a class="nav-link" href="./v0.6.1/user_guide/index.html">User Guide</a>
 		          </li>
 		          <li class="nav-item px-1">
 					<!-- Versioned Link -->
-		            <a class="nav-link" href="./v0.6.0/api_reference/index.html">API Docs</a>
+		            <a class="nav-link" href="./v0.6.1/api_reference/index.html">API Docs</a>
 		          </li>
 				  <li class="nav-item px-1">
 					<!-- Versioned Link -->
-		            <a class="nav-link" href="./v0.6.0/auto_examples/index.html">Example Notebooks</a>
+		            <a class="nav-link" href="./v0.6.1/auto_examples/index.html">Example Notebooks</a>
 		          </li>
 		          <li class="nav-item px-1">
 		            <a class="nav-link" href="#contribute">Contributor Guide</a>
 		          </li>
 				  <li class="nav-item px-1">
 					<!-- Versioned Link -->
-		            <a class="nav-link" href="./v0.6.0/faq.html">FAQ</a>
+		            <a class="nav-link" href="./v0.6.1/faq.html">FAQ</a>
 		          </li>
 				  <li class="nav-item px-1">
 					<!-- Versioned Link -->
-		            <a class="nav-link" href="./v0.6.0/about/index.html">About Us</a>
+		            <a class="nav-link" href="./v0.6.1/about/index.html">About Us</a>
 		          </li>
 				</ul>
 		        <span class="nav-item card benefit-card mr-xl-3 pt-1 mt-1">
@@ -82,7 +82,7 @@
 							Assess and mitigate fairness issues using our Python toolkit.
 							Join our community and contribute metrics, algorithms, and other resources.	
 							</p>
-							<a class="quickstart-btn mt-2 mb-5 px-4 text-center width=80px" href=./v0.6.0/quickstart.html>Get Started</a>
+							<a class="quickstart-btn mt-2 mb-5 px-4 text-center width=80px" href=./v0.6.1/quickstart.html>Get Started</a>
 				</div>
 			</div>
 		</div>
@@ -154,13 +154,13 @@
 						pip install fairlearn
 				</div>
 			    <div class="pt-4">
-				    <a class="quickstart-btn mb-5 px-4 text-center" href=./v0.6.0/quickstart.html>Quickstart Guide</a>
+				    <a class="quickstart-btn mb-5 px-4 text-center" href=./v0.6.1/quickstart.html>Quickstart Guide</a>
 			    </div>
 		    </div>
 		    <div class="col-12 col-lg-6 text-left pl-lg-4">
 				<div class="line mx-0 my-5"></div>
 				<h2 class="pt-3 pb-3 text-center text-lg-left dark">Resources</h2>
-					<a href="./v0.6.0/user_guide/index.html" target="_blank">
+					<a href="./v0.6.1/user_guide/index.html" target="_blank">
 						<h3 class="text-center text-lg-left dark my-0">
 							User Guide
 						</h3>
@@ -168,7 +168,7 @@
 					<p class="text-center text-lg-left pt-2 pb-3">
 						Learn more about fairness in AI, fairness metrics, and mitigation algorithms.
 					</p>
-					<a href="./v0.6.0/api_reference/index.html" target="_blank">
+					<a href="./v0.6.1/api_reference/index.html" target="_blank">
 						<h3 class="text-center text-lg-left dark my-0">
 							API Documentation
 						</h3>
@@ -176,7 +176,7 @@
 					<p class="text-center text-lg-left pt-2 pb-3">
 						Library reference with examples.
 					</p>
-					<a href="./v0.6.0/contributor_guide/index.html" target="_blank">
+					<a href="./v0.6.1/contributor_guide/index.html" target="_blank">
 						<h3 class="text-center text-lg-left dark my-0">
 							Contributor Guide
 						</h3>
@@ -264,7 +264,7 @@
 						Join the effort and contribute feedback, metrics, algorithms, visualizations, ideas and more, so we can evolve the toolkit together!
 					</p>
 					  <!-- Versioned Link -->
-					  <a class="contribute-btn mb-0 text-center" href="./v0.6.0/contributor_guide/index.html">Contributor Guide</a>
+					  <a class="contribute-btn mb-0 text-center" href="./v0.6.1/contributor_guide/index.html">Contributor Guide</a>
 				</div>
 			</div>
 		</div>

--- a/fairlearn/__init__.py
+++ b/fairlearn/__init__.py
@@ -9,7 +9,7 @@ import os
 from .show_versions import show_versions  # noqa: F401
 
 __name__ = "fairlearn"
-__version__ = "0.6.1.dev0"
+__version__ = "0.6.2.dev0"
 _base_version = __version__  # To enable the v0.4.6 docs
 
 # Setup logging infrastructure

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -34,4 +34,4 @@ pypandoc
 sphinx
 sphinx-gallery
 git+https://github.com/Holzhaus/sphinx-multiversion.git
-pydata-sphinx-theme>=0.5.0
+pydata-sphinx-theme==0.5.2


### PR DESCRIPTION
Required updates to `main` for the `v0.6.1` release:

- Bump version in `__init__.py`
- Update links on the static landing page

Don't need to update the doc configuration this time (regex is flexible enough)