### PR TITLE
Build Pipeline fixes

### DIFF
--- a/devops/pypi-release-new.yml
+++ b/devops/pypi-release-new.yml
@@ -101,7 +101,7 @@ stages:
         freezeArtifact: $(freezeArtifactName)
         freezeFile: $(freezeFile)
 
-    - script: python ./scripts/build_widget.py --yarn-path /usr/bin/yarn
+    - script: python ./scripts/build_widget.py --yarn-path /usr/local/bin/yarn
       displayName: 'Build widget'
 
     - script: python ./scripts/build_wheels.py --version-filename $(versionFilename) 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -34,4 +34,4 @@ pypandoc
 sphinx
 sphinx-gallery
 git+https://github.com/Holzhaus/sphinx-multiversion.git
-pydata-sphinx-theme>=0.5.0
+pydata-sphinx-theme==0.5.2


### PR DESCRIPTION
Having trouble with some pipelines:

- Documentation build was failing due to `pydata-sphinx-theme` releasing v0.6. Pin at 0.5.2 for now
- Had missed the path to `yarn` in the release pipeline