### PR TITLE
Remove bokeh plot and replace with simple matplotlib plot

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,6 +60,7 @@ def check_if_v046():
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'bokeh.sphinxext.bokeh_plot',
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.extlinks',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,6 @@ def check_if_v046():
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'bokeh.sphinxext.bokeh_plot',
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.extlinks',

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -87,8 +87,9 @@ than $50,000 a year.
     Female    16192
     Name: sex, dtype: int64
 
-.. bokeh-plot:: quickstart_plot.py
-    :source-position: none
+.. figure:: ../auto_examples/images/sphx_glr_plot_quickstart_selection_rate_001.png
+    :target: auto_examples/plot_quickstart_selection_rate.html
+    :align: center
 
 Evaluating fairness-related metrics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -87,7 +87,7 @@ than $50,000 a year.
     Female    16192
     Name: sex, dtype: int64
 
-.. figure:: ../auto_examples/images/sphx_glr_plot_quickstart_selection_rate_001.png
+.. figure:: auto_examples/images/sphx_glr_plot_quickstart_selection_rate_001.png
     :target: auto_examples/plot_quickstart_selection_rate.html
     :align: center
 

--- a/examples/plot_quickstart_selection_rate.py
+++ b/examples/plot_quickstart_selection_rate.py
@@ -7,7 +7,6 @@ Selection rates in census dataset
 =================================
 """
 # %%
-from bokeh.plotting import figure, show
 from fairlearn.metrics import MetricFrame, selection_rate
 from fairlearn.datasets import fetch_adult
 
@@ -20,20 +19,4 @@ selection_rates = MetricFrame(selection_rate,
                               y_true, y_true,
                               sensitive_features=sex)
 
-xs = list(selection_rates.by_group.index)
-ys = [selection_rates.by_group[s] for s in xs]
-
-p = figure(x_range=xs,
-           plot_height=480,
-           plot_width=640,
-           title="Fraction earning over $50,0000",
-           toolbar_location=None,
-           tools="")
-
-p.vbar(x=xs, top=ys, width=0.9)
-
-p.y_range.start = 0
-p.xgrid.grid_line_color = None
-p.axis.minor_tick_line_color = None
-
-show(p)
+selection_rates.by_group.plot(legend=False, title='Fraction earning over $50,000')

--- a/examples/plot_quickstart_selection_rate.py
+++ b/examples/plot_quickstart_selection_rate.py
@@ -19,4 +19,6 @@ selection_rates = MetricFrame(selection_rate,
                               y_true, y_true,
                               sensitive_features=sex)
 
-selection_rates.by_group.plot(legend=False, title='Fraction earning over $50,000')
+fig = selection_rates.by_group.plot.bar(
+    legend=False, rot=0,
+    title='Fraction earning over $50,000')

--- a/examples/plot_quickstart_selection_rate.py
+++ b/examples/plot_quickstart_selection_rate.py
@@ -1,11 +1,15 @@
 # Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
-"""Produce plot of selection rates for the quickstart guide."""
+"""
+=================================
+Selection rates in census dataset
+=================================
+"""
+# %%
 from bokeh.plotting import figure, show
 from fairlearn.metrics import MetricFrame, selection_rate
 from fairlearn.datasets import fetch_adult
-
 
 data = fetch_adult(as_frame=True)
 X = data.data

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,6 +29,7 @@ jupyter
 nbval
 
 # Required for documentation
+bokeh
 pypandoc
 sphinx
 sphinx-gallery

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,7 +29,6 @@ jupyter
 nbval
 
 # Required for documentation
-bokeh
 pypandoc
 sphinx
 sphinx-gallery


### PR DESCRIPTION
Our doc builds are taking a while, so it seemed like a good idea to replace the custom bokeh plot with a simpler matplotlib plot just like in #766 . Sadly, we are locked into all dependencies we ever had unless we're willing to go into older versions of Fairlearn, remove them from there, and then move the tag. Still, this simpler plotting code seemed like a step in the right direction.