### PR TITLE
Post-v0.6.2 release adjustments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+### v0.7.0
+
 ### v0.6.2
 
 * Bugfix for `_merge_columns()` when using multiple sensitive features with

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Website: https://fairlearn.github.io/
 
 ## Current release
 
-- The current stable release is available at [Fairlearn v0.6.1](https://github.com/fairlearn/fairlearn/tree/release/v0.6.1).
+- The current stable release is available at [Fairlearn v0.6.2](https://github.com/fairlearn/fairlearn/tree/release/v0.6.2).
 
 - Our current version differs substantially from version 0.2 or earlier. Users of these older versions should visit our [onboarding guide](https://fairlearn.github.io/main/contributor_guide/development_process.html#onboarding-guide).
 

--- a/docs/contributor_guide/release.rst
+++ b/docs/contributor_guide/release.rst
@@ -21,6 +21,8 @@ done on a clone of `fairlearn/fairlearn` and not on a fork).
     #. Update the version in `__init__.py` to `x.y.z`
     #. Update the version in the ReadMe
 
+#. Merge that PR.
+
 #. Run the `release pipeline <https://dev.azure.com/responsibleai/fairlearn/_build?definitionId=60>`_
 
     #. Ensure that you have selected the correct release branch
@@ -35,9 +37,12 @@ done on a clone of `fairlearn/fairlearn` and not on a fork).
 
     :code:`git push origin v<x.y.z>`
 
+#. On [GitHub's release page](https://github.com/fairlearn/fairlearn/releases)
+   create a new release and post the changes from CHANGES.md into the description.
+
 #. On the `main` branch, create a PR to:
 
-    #. Update the version in `__init__.py` to `xy.z+1.dev0`
+    #. Update the version in `__init__.py` to `x.y.z+1.dev0`
     #. Update the 'current stable release' sentence in the ReadMe to link to `v<x.y.z>`
     #. Ensure that `smv_tag_whitelist` in `docs/conf.py` will pick up the
        new release

--- a/docs/contributor_guide/release.rst
+++ b/docs/contributor_guide/release.rst
@@ -47,3 +47,5 @@ done on a clone of `fairlearn/fairlearn` and not on a fork).
     #. Ensure that `smv_tag_whitelist` in `docs/conf.py` will pick up the
        new release
     #. Update `docs/static_landing_page/` so that all the links point to the new release
+
+#. Merge that PR.

--- a/docs/static_landing_page/index.html
+++ b/docs/static_landing_page/index.html
@@ -27,30 +27,30 @@
       		<div class="collapse navbar-collapse" id="navbarResponsive">
 		        <ul class="navbar-nav pt-2 mt-1 mr-xl-auto ml-xl-2 pl-xl-1 text-center text-nowrap">
 				  <li class="nav-item px-1">
-					  <a class="nav-link" href=./v0.6.1/quickstart.html>Getting Started</a>
+					  <a class="nav-link" href=./v0.6.2/quickstart.html>Getting Started</a>
 				  </li>
 		          <li class="nav-item px-1">
 					  <!-- Versioned Link -->
-		            <a class="nav-link" href="./v0.6.1/user_guide/index.html">User Guide</a>
+		            <a class="nav-link" href="./v0.6.2/user_guide/index.html">User Guide</a>
 		          </li>
 		          <li class="nav-item px-1">
 					<!-- Versioned Link -->
-		            <a class="nav-link" href="./v0.6.1/api_reference/index.html">API Docs</a>
+		            <a class="nav-link" href="./v0.6.2/api_reference/index.html">API Docs</a>
 		          </li>
 				  <li class="nav-item px-1">
 					<!-- Versioned Link -->
-		            <a class="nav-link" href="./v0.6.1/auto_examples/index.html">Example Notebooks</a>
+		            <a class="nav-link" href="./v0.6.2/auto_examples/index.html">Example Notebooks</a>
 		          </li>
 		          <li class="nav-item px-1">
 		            <a class="nav-link" href="#contribute">Contributor Guide</a>
 		          </li>
 				  <li class="nav-item px-1">
 					<!-- Versioned Link -->
-		            <a class="nav-link" href="./v0.6.1/faq.html">FAQ</a>
+		            <a class="nav-link" href="./v0.6.2/faq.html">FAQ</a>
 		          </li>
 				  <li class="nav-item px-1">
 					<!-- Versioned Link -->
-		            <a class="nav-link" href="./v0.6.1/about/index.html">About Us</a>
+		            <a class="nav-link" href="./v0.6.2/about/index.html">About Us</a>
 		          </li>
 				</ul>
 		        <span class="nav-item card benefit-card mr-xl-3 pt-1 mt-1">
@@ -82,7 +82,7 @@
 							Assess and mitigate fairness issues using our Python toolkit.
 							Join our community and contribute metrics, algorithms, and other resources.	
 							</p>
-							<a class="quickstart-btn mt-2 mb-5 px-4 text-center width=80px" href=./v0.6.1/quickstart.html>Get Started</a>
+							<a class="quickstart-btn mt-2 mb-5 px-4 text-center width=80px" href=./v0.6.2/quickstart.html>Get Started</a>
 				</div>
 			</div>
 		</div>
@@ -154,13 +154,13 @@
 						pip install fairlearn
 				</div>
 			    <div class="pt-4">
-				    <a class="quickstart-btn mb-5 px-4 text-center" href=./v0.6.1/quickstart.html>Quickstart Guide</a>
+				    <a class="quickstart-btn mb-5 px-4 text-center" href=./v0.6.2/quickstart.html>Quickstart Guide</a>
 			    </div>
 		    </div>
 		    <div class="col-12 col-lg-6 text-left pl-lg-4">
 				<div class="line mx-0 my-5"></div>
 				<h2 class="pt-3 pb-3 text-center text-lg-left dark">Resources</h2>
-					<a href="./v0.6.1/user_guide/index.html" target="_blank">
+					<a href="./v0.6.2/user_guide/index.html" target="_blank">
 						<h3 class="text-center text-lg-left dark my-0">
 							User Guide
 						</h3>
@@ -168,7 +168,7 @@
 					<p class="text-center text-lg-left pt-2 pb-3">
 						Learn more about fairness in AI, fairness metrics, and mitigation algorithms.
 					</p>
-					<a href="./v0.6.1/api_reference/index.html" target="_blank">
+					<a href="./v0.6.2/api_reference/index.html" target="_blank">
 						<h3 class="text-center text-lg-left dark my-0">
 							API Documentation
 						</h3>
@@ -176,7 +176,7 @@
 					<p class="text-center text-lg-left pt-2 pb-3">
 						Library reference with examples.
 					</p>
-					<a href="./v0.6.1/contributor_guide/index.html" target="_blank">
+					<a href="./v0.6.2/contributor_guide/index.html" target="_blank">
 						<h3 class="text-center text-lg-left dark my-0">
 							Contributor Guide
 						</h3>
@@ -264,7 +264,7 @@
 						Join the effort and contribute feedback, metrics, algorithms, visualizations, ideas and more, so we can evolve the toolkit together!
 					</p>
 					  <!-- Versioned Link -->
-					  <a class="contribute-btn mb-0 text-center" href="./v0.6.1/contributor_guide/index.html">Contributor Guide</a>
+					  <a class="contribute-btn mb-0 text-center" href="./v0.6.2/contributor_guide/index.html">Contributor Guide</a>
 				</div>
 			</div>
 		</div>

--- a/fairlearn/__init__.py
+++ b/fairlearn/__init__.py
@@ -9,7 +9,7 @@ import os
 from .show_versions import show_versions  # noqa: F401
 
 __name__ = "fairlearn"
-__version__ = "0.6.2"
+__version__ = "0.7.0.dev0"
 _base_version = __version__  # To enable the v0.4.6 docs
 
 # Setup logging infrastructure

--- a/fairlearn/__init__.py
+++ b/fairlearn/__init__.py
@@ -9,7 +9,7 @@ import os
 from .show_versions import show_versions  # noqa: F401
 
 __name__ = "fairlearn"
-__version__ = "0.6.2.dev0"
+__version__ = "0.6.2"
 _base_version = __version__  # To enable the v0.4.6 docs
 
 # Setup logging infrastructure


### PR DESCRIPTION
Other than the adjustments in #774 this puts the version to `0.7.0.dev0` and adds the missing release instructions.

I expect the next release will require a new minor version since I have #766 out which should be completed shortly. We can certainly change that if this assumption turns out to be wrong, though.