### PR TITLE
Update mathjax_config to mathjax3_config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -209,9 +209,9 @@ def linkcode_resolve(domain, info):
 
 # -- LaTeX macros ------------------------------------------------------------
 
-mathjax_config = {
-    "TeX": {
-        "Macros": {
+mathjax3_config = {
+    "tex": {
+        "macros": {
             "E": '{\\mathbb{E}}',
             "P": '{\\mathbb{P}}',
             "given": '\\mathbin{\\vert}'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -151,7 +151,7 @@ sphinx_gallery_conf = {
 }
 
 html_sidebars = {
-    "**": ["version-sidebar.html", "sidebar-search-bs.html", "sidebar-nav-bs.html"],
+    "**": ["version-sidebar.html", "search-field.html", "sidebar-nav-bs.html"],
 }
 
 # Auto-Doc Options

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -34,4 +34,4 @@ pypandoc
 sphinx
 sphinx-gallery
 git+https://github.com/Holzhaus/sphinx-multiversion.git
-pydata-sphinx-theme==0.5.2
+pydata-sphinx-theme==0.6.3


### PR DESCRIPTION
Fixes #810 

Upon investigation, there is a newer, completely rewritten version of MathJax which is being used by Sphinx MathJax as well, the MathJax version 3. Thus it gave us `src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"` the latest version of the library in our HTML.

To accommodate this:
- Sphinx requires us to use `mathjax3_config` variable instead of `matjax_config` to set the configuration.
- Also there are some small changes in the config in terms of the syntax which were made using the [MathJax Configuration Converter](https://mathjax.github.io/MathJax-demos-web/convert-configuration/convert-configuration.html) to write the config in the new format.

### Results

**Before** 

![image](https://user-images.githubusercontent.com/50991099/119029771-b10cc780-b9c6-11eb-8c88-1d0e03a39852.png)

**After**

![image](https://user-images.githubusercontent.com/50991099/119029884-d699d100-b9c6-11eb-85ba-e31dad13b248.png)
