### PR TITLE
MNT add black config to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 79


### PR DESCRIPTION
This PR adds a config to `pyproject.toml` for people who use black. It doesn't add black to the CI or anything, it's just nice to have it in the repo for the ones who use it.

cc @riedgar-ms @romanlutz 