### PR TITLE
Fix title of About Us doc section

### DIFF
--- a/docs/about/index.rst
+++ b/docs/about/index.rst
@@ -1,7 +1,7 @@
 .. _about:
 
-About Fairlearn
-===============
+About Us
+========
 
 .. _mission:
 


### PR DESCRIPTION
Fixes the section title to match the vetted webpage header.

Signed-off-by: MiroDudik <mdudik@gmail.com>