### PR TITLE
DOC Remove redundant toctree in gallery header (#872)

### DIFF
--- a/examples/README.rst
+++ b/examples/README.rst
@@ -12,12 +12,3 @@ adding new ones please consult the guide on
 
     The Fairlearn API is still evolving, so if you want to run these
     on your local Fairlearn installation, make sure to match versions.
-
-.. toctree::
-   :maxdepth: 2
-
-   plot_grid_search_census
-
-   plot_new_metrics
-
-   plot_make_derived_metric


### PR DESCRIPTION
The left example navbar is now autogenerated by sphinx-gallery so leaving this section  is causing duplicates in the navbar.