### PR TITLE
FIX adjust test precision to 1e-5

### DIFF
--- a/test/unit/reductions/exponentiated_gradient/test_exponentiatedgradient_smoke.py
+++ b/test/unit/reductions/exponentiated_gradient/test_exponentiatedgradient_smoke.py
@@ -21,7 +21,7 @@ from .simple_learners import LeastSquaresBinaryClassifierLearner, \
 from .test_utilities import _get_data
 
 
-_PRECISION = 1e-6
+_PRECISION = 1e-5
 
 
 class TestExponentiatedGradientSmoke:


### PR DESCRIPTION
This is currently failing in the `main` branch on Mac OS with Python 3.7 (https://dev.azure.com/responsibleai/fairlearn/_build/results?buildId=12387&view=logs&j=0a22f5d8-9f3e-5735-4672-5a55fb1a2abf&t=4a75d996-b002-586d-ec0d-145d497c0466)

```
>       assert disparity == pytest.approx(data["disp"], abs=_PRECISION)
E       assert 0.020000000000000018 == 0.019999 ± 1.0e-06
E        +  where 0.019999 ± 1.0e-06 = <function approx at 0x10f0f2d40>(0.019999, abs=1e-06)
E        +    where <function approx at 0x10f0f2d40> = pytest.approx
```
As @MiroDudik pointed out in #882 this should be fixed by adjusting the precision to `1e-5` instead of `1e-6`. Once this is merged we should cherry-pick it into #882 for the release v0.7.0

Signed-off-by: Roman Lutz <rolutz@microsoft.com>