### PR TITLE
DOC Typo on control features - fix

### DIFF
--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -321,7 +321,7 @@ might be correlated with various sensitive features. Because of this, control
 features should be used with particular caution.
 
 The :class:`MetricFrame` constructor allows us to specify control features in
-a manner similar to sensitive features, using a :code:`conditional_features=`
+a manner similar to sensitive features, using a :code:`control_features=`
 parameter:
 
 .. doctest:: assessment_metrics


### PR DESCRIPTION
This PR fixes #892 
Doc typo
- Replaced `conditional_features` to `control_features`.