### PR TITLE
MNT pin sphinx at 4.0.3

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -31,7 +31,7 @@ nbval
 # Required for documentation
 bokeh
 pypandoc
-sphinx
+sphinx==4.0.3  # a bug in 4.1.0 prevents the logo from being rendered
 sphinx-gallery
 git+https://github.com/Holzhaus/sphinx-multiversion.git
 pydata-sphinx-theme==0.6.3


### PR DESCRIPTION
4.1.0 causes the logo to break #899. Once sphinx releases a new version we can check if it works and remove this pin again, or leave it and update in a controlled manner at a later point.
Signed-off-by: Roman Lutz <rolutz@microsoft.com>