### PR TITLE
MNT fix multiversion sphinx build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,9 +13,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-from packaging import version as packaging_version
 import os
-import pandas as pd
 import sys
 import inspect
 from datetime import datetime

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,6 @@
 from packaging import version as packaging_version
 import os
 import pandas as pd
-import subprocess
 import sys
 import inspect
 from datetime import datetime
@@ -98,29 +97,7 @@ master_doc = 'index'
 # Multiversion settings
 # Show only the highest patch versions of each minor version.
 # Example: include 0.4.6, but not 0.4.0 to 0.4.5
-cmd = ("git", "for-each-ref", "--format", "%(refname)")
-output = subprocess.check_output(cmd).decode()
-all_tags = [
-    packaging_version.parse(line.split('/')[2])
-    for line in output.splitlines() if line[:11] == "refs/tags/v"]
-# filter out versions below 0.4
-all_tags = [version for version in all_tags
-            if version.major > 0 or version.minor >= 4]
-version_df = pd.DataFrame(
-    [(v.major, v.minor, v.micro) for v in all_tags],
-    columns=['major', 'minor', 'micro'])
-max_versions_df = version_df.groupby(['major', 'minor']).max()
-# major and minor are in the index, values contain micro
-majors = max_versions_df.index.get_level_values('major').tolist()
-minors = max_versions_df.index.get_level_values('minor').tolist()
-micros = max_versions_df.values.reshape(-1).tolist()
-
-smv_tag_whitelist = r'|'.join(
-    [fr'^v{major}\.{minor}\.{micro}'
-     for (major, minor, micro) in zip(majors, minors, micros)]) + r'+$'
-
-print(smv_tag_whitelist)
-
+smv_tag_whitelist = r'^v0\.4\.6|^v0\.5\.0|^v0\.6\.2|^v0\.7\.0+$'
 smv_branch_whitelist = r'^main$'
 
 if check_if_v046():

--- a/docs/contributor_guide/release.rst
+++ b/docs/contributor_guide/release.rst
@@ -43,6 +43,8 @@ done on a clone of `fairlearn/fairlearn` and not on a fork).
     #. Update the version in `__init__.py` to `x.y.z+1.dev0`
     #. Update the version in `docs/static_landing_page/js/landing_page.js`
        so that all the links point to the new release
+    #. Update `smv_tag_whitelist` in `docs/conf.py` to show only the latest
+       patch version of every minor release.
    
 .. note::
     Make sure to add a note to this second PR:


### PR DESCRIPTION
#879 changed the behavior of the multiversion selection quite a bit, which resulted in `main` being excluded from the website. The root cause for that was that we use `gitpython` there but it doesn't work properly in that environment and therefore isn't able to pull in `refs` for the repo. As a follow-up I wrote #903 to use `git` directly (without `gitpython`), but as it turns out that's no better for the same reason. This PR reverts us back to the manual regex update until I manage to move us to a system that doesn't use `sphinx-multiversion`. Note that the CircleCI build will still exclude `main` if you check it here since it includes the current `main` branch rather than this current branch, and `main` will only get updated once we merge this.