### PR TITLE
FIX fix xgboost test

### DIFF
--- a/fairlearn/reductions/_moments/utility_parity.py
+++ b/fairlearn/reductions/_moments/utility_parity.py
@@ -248,8 +248,8 @@ class UtilityParity(ClassificationMoment):
            16-Jul-2018. [Online]. Available: https://arxiv.org/abs/1803.02453.
 
         """
-        lambda_event = (lambda_vec["+"] - self.ratio * lambda_vec["-"]).sum(level=_EVENT) / \
-            self.prob_event
+        lambda_event = (lambda_vec["+"] - self.ratio * lambda_vec["-"]) \
+            .groupby(level=_EVENT).sum() / self.prob_event
         lambda_group_event = (self.ratio * lambda_vec["+"] - lambda_vec["-"]) / \
             self.prob_group_event
         adjust = lambda_event - lambda_group_event

--- a/test_othermlpackages/test_xgboost.py
+++ b/test_othermlpackages/test_xgboost.py
@@ -10,20 +10,20 @@ xgb = pytest.importorskip("xgboost")
 
 
 def test_expgrad_classification():
-    estimator = xgb.XGBClassifier()
+    estimator = xgb.XGBClassifier(use_label_encoder=False)
     disparity_moment = DemographicParity()
 
     ptc.run_expgrad_classification(estimator, disparity_moment)
 
 
 def test_gridsearch_classification():
-    estimator = xgb.XGBClassifier()
+    estimator = xgb.XGBClassifier(use_label_encoder=False)
     disparity_moment = DemographicParity()
 
     ptc.run_gridsearch_classification(estimator, disparity_moment)
 
 
 def test_thresholdoptimizer_classification():
-    estimator = xgb.XGBClassifier()
+    estimator = xgb.XGBClassifier(use_label_encoder=False)
 
     ptc.run_thresholdoptimizer_classification(estimator)


### PR DESCRIPTION
closes #910 
Fixing the `FutureWarning` from `pandas` by using `groupby` instead of the `level` arg in the `sum` aggregation.
Also fixing the `UserWarning` in `xgboost` by passing an additional arg as recommended by the warning.