### PR TITLE
DOC add citation cff file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,43 @@
+# This file is a citation metadata file in the Citation File Format
+# (http://citation-file-format.github.io/).
+
+cff-version: 1.0.3
+message: "If you use Fairlearn in your work, please cite it using the following metadata"
+title: Fairlearn
+references:
+  - type: article
+    authors:
+     - affiliation: "Microsoft Corporation"
+       family-names: Bird
+       given-names: Sarah
+     - affiliation: "Microsoft Research"
+       family-names: Dudik
+       given-names: Miro
+     - affiliation: "Microsoft Corporation"
+       family-names: Edgar
+       given-names: Richard
+     - affiliation: "Microsoft Corporation"
+       family-names: Horn
+       given-names: Brandon
+     - affiliation: "Microsoft Corporation"
+       family-names: Lutz
+       given-names: Roman
+     - affiliation: "Microsoft Corporation"
+       family-names: Milan
+       given-names: Vanessa
+     - affiliation: "Microsoft Corporation"
+       family-names: Sameki
+       given-names: Mehrnoosh
+     - affiliation: "Microsoft Research"
+       family-names: Wallach
+       given-names: Hanna
+     - affiliation: "Microsoft Corporation"
+       family-names: Walker
+       given-names: Kathleen
+    institution: Microsoft
+    month: 5
+    year: 2020
+    repository-code: "https://github.com/fairlearn/fairlearn"
+    title: Fairlearn: A toolkit for assessing and improving fairness in AI
+    url: https://www.microsoft.com/en-us/research/publication/fairlearn-a-toolkit-for-assessing-and-improving-fairness-in-ai/
+    number: MSR-TR-2020-32


### PR DESCRIPTION
Add CITATION.cff file since there's a new feature to show how to cite papers/articles/books related to a repo: 

- https://twitter.com/natfriedman/status/1420122675813441540?s=20
- https://github.com/citation-file-format/citation-file-format

Importantly, this can be extended whenever we write a newer version/paper/whitepaper/article/etc.

Signed-off-by: Roman Lutz <rolutz@microsoft.com>