### PR TITLE
Removed py3.9 dependency from nightly-requirements

### DIFF
--- a/devops/nightly-requirements-fixed.yml
+++ b/devops/nightly-requirements-fixed.yml
@@ -1,6 +1,6 @@
 # Nightly build pipeline with requirements pinned to lower bounds (if any)
 # This does not run on MacOS due to issues with the pinned requirements
-# There are also issues with running on Python 3.9
+# There are also issues with running on Python 3.9, hence dependency removed (for now)
 
 variables:
   FreezeArtifactStem: 'freeze'
@@ -26,7 +26,7 @@ jobs:
   parameters:
     platforms:  { Linux: ubuntu-latest, Windows: vs2017-win2016 }
     installationType: 'PipLocal'
-    pyVersions: [3.6, 3.7, 3.8, 3.9]
+    pyVersions: [3.6, 3.7, 3.8]
     freezeArtifactStem: $(FreezeArtifactStem)
     freezeFileStem: $(FreezeFileStem)
     pinRequirements: True


### PR DESCRIPTION
closes #915 

Python version 3.9 dependency is removed from [nightly-requirements-fixed.yml](https://github.com/fairlearn/fairlearn/blob/main/devops/nightly-requirements-fixed.yml)