### PR TITLE
DOC Fix normalization error and show pie chart only for count metric

### DIFF
--- a/examples/plot_quickstart.py
+++ b/examples/plot_quickstart.py
@@ -13,7 +13,7 @@ from fairlearn.metrics import (
     false_positive_rate,
     true_positive_rate,
     selection_rate,
-    count
+    count,
 )
 import pandas as pd
 from sklearn.datasets import fetch_openml
@@ -31,17 +31,17 @@ y_pred = classifier.predict(X)
 
 # Analyze metrics using MetricFrame
 metrics = {
-    'accuracy': accuracy_score,
-    'precision': precision_score,
-    'recall': recall_score,
-    'false positive rate': false_positive_rate,
-    'true positive rate': true_positive_rate,
-    'selection rate': selection_rate,
-    'count': count}
-metric_frame = MetricFrame(metrics=metrics,
-                           y_true=y_true,
-                           y_pred=y_pred,
-                           sensitive_features=sex)
+    "accuracy": accuracy_score,
+    "precision": precision_score,
+    "recall": recall_score,
+    "false positive rate": false_positive_rate,
+    "true positive rate": true_positive_rate,
+    "selection rate": selection_rate,
+    "count": count,
+}
+metric_frame = MetricFrame(
+    metrics=metrics, y_true=y_true, y_pred=y_pred, sensitive_features=sex
+)
 metric_frame.by_group.plot.bar(
     subplots=True,
     layout=[3, 3],
@@ -72,12 +72,12 @@ metric_frame.by_group.plot(
     title="Show all metrics in Accent colormap",
 )
 
-# Customize plots with kind
-metric_frame.by_group.plot(
+# Customize plots with kind (note that we are only plotting the "count" metric here because we are showing a pie chart)
+metric_frame.by_group[["count"]].plot(
     kind="pie",
     subplots=True,
-    layout=[3, 3],
+    layout=[1, 1],
     legend=False,
     figsize=[12, 8],
-    title="Show all metrics in pie",
+    title="Show count metric in pie chart",
 )


### PR DESCRIPTION
Removes the normalization error in the Assessment section of the User Guide. The `black` formatting appears to be adding an errant comma in line 16, but that doesn't appear to be causing any errors when I run the file locally. Please reject this request if that will screw things up.

related to #852 