### PR TITLE
FEAT Introduce StreamingMetricFrame to accumulate batches

### DIFF
--- a/fairlearn/metrics/__init__.py
+++ b/fairlearn/metrics/__init__.py
@@ -26,6 +26,7 @@ for each combination of subgroups.
 import sys as _sys
 
 from ._metric_frame import MetricFrame  # noqa: F401
+from ._streaming_metric_frame import StreamingMetricFrame  # noqa: F401
 from ._make_derived_metric import make_derived_metric  # noqa: F401
 
 from ._generated_metrics import _generated_metric_dict
@@ -61,6 +62,7 @@ for _name, _func in _generated_metric_dict.items():
 _core = [
     "MetricFrame",
     "make_derived_metric"
+    "StreamingMetricFrame"
 ]
 
 _disparities = [

--- a/fairlearn/metrics/_streaming_metric_frame.py
+++ b/fairlearn/metrics/_streaming_metric_frame.py
@@ -107,11 +107,13 @@ class StreamingMetricFrame:
             control features are present.
         """
         check_consistent_length(y_true, y_pred)
+        check_consistent_length(y_true, sensitive_features)
         self._y_true = self._concat_if_not_none(self._y_true, y_true)
         self._y_pred = self._concat_if_not_none(self._y_pred, y_pred)
         self._sensitive_features = self._concat_if_not_none(self._sensitive_features,
                                                             sensitive_features)
         if control_features is not None:
+            check_consistent_length(y_true, control_features)
             self._control_features = self._concat_if_not_none(self._control_features,
                                                               control_features)
         elif self._control_features is not None:
@@ -121,7 +123,7 @@ class StreamingMetricFrame:
             self._sample_params = self._concat_if_not_none(self._sample_params,
                                                            sample_params)
 
-    def get_metric(self) -> MetricFrame:
+    def get_metric_frame(self) -> MetricFrame:
         """Get the MetricFrame computed on the accumulated values."""
         if self._y_true is None:
             raise ValueError(_EMPTY_BATCHES_ERR)

--- a/fairlearn/metrics/_streaming_metric_frame.py
+++ b/fairlearn/metrics/_streaming_metric_frame.py
@@ -53,11 +53,15 @@ class StreamingMetricFrame:
         self._sample_params = None
 
     def reset(self):
-        """Reset accumulators: y_true, y_pred, sensitive_features and control_features."""
+        """Reset accumulators.
+
+        Reset y_true, y_pred, sensitive_features, control_features and sample_params.
+        """
         self._y_true = None
         self._y_pred = None
         self._sensitive_features = None
         self._control_features = None
+        self._sample_params = None
 
     def add_data(self, y_true, y_pred, sensitive_features, control_features=None,
                  sample_params: Optional[Union[Dict[str, Any], Dict[str, Dict[str, Any]]]] = None):

--- a/fairlearn/metrics/_streaming_metric_frame.py
+++ b/fairlearn/metrics/_streaming_metric_frame.py
@@ -1,0 +1,178 @@
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
+# Licensed under the MIT License.
+
+from typing import Callable, Dict, Optional, Any, Union, List, TypeVar
+
+import numpy as np
+import pandas as pd
+from sklearn.utils import check_consistent_length
+
+from fairlearn.metrics import MetricFrame
+
+_EMPTY_BATCHES_ERR = "No data to process, please add batches with `add_data`."
+_CF_BAD_STATE_ERR = ("MetricFrame expected `control_features=None`"
+                     " because it was initialized as such.")
+
+# A TypeVar to express possible batch types.
+B = TypeVar('B', Dict, np.ndarray, List, pd.Series, pd.DataFrame)
+
+
+class StreamingMetricFrame:
+    """Streaming version of MetricFrame.
+
+    Accumulate values to evaluate the metric(s) later on.
+    See MetricFrame documentation for information on metrics.
+
+    Parameters
+    ----------
+    metrics : callable or dict
+        The underlying metric functions which are to be calculated. This
+        can either be a single metric function or a dictionary of functions.
+        These functions must be callable as
+        ``fn(y_true, y_pred, **sample_params)``.
+        If there are any other arguments required (such as ``beta`` for
+        :func:`sklearn.metrics.fbeta_score`) then
+        :func:`functools.partial` must be used.
+
+        **Note** that the values returned by various members of the class change
+        based on whether this argument is a callable or a dictionary of
+        callables. This distinction remains *even if* the dictionary only
+        contains a single entry.
+    """
+
+    def __init__(self,
+                 *,
+                 metrics: Union[Callable, Dict[str, Callable]]):
+        self._metrics = metrics
+
+        # Accumulators
+        self._y_true = None
+        self._y_pred = None
+        self._sensitive_features = None
+        self._control_features = None
+        self._sample_params = None
+
+    def reset(self):
+        """Reset accumulators: y_true, y_pred, sensitive_features and control_features."""
+        self._y_true = None
+        self._y_pred = None
+        self._sensitive_features = None
+        self._control_features = None
+
+    def add_data(self, y_true, y_pred, sensitive_features, control_features=None,
+                 sample_params: Optional[Union[Dict[str, Any], Dict[str, Dict[str, Any]]]] = None):
+        """Add data to the MetricFrame.
+
+        Parameters
+        ----------
+        y_true : List, pandas.Series, numpy.ndarray, pandas.DataFrame
+        The ground-truth labels (for classification) or target values (for regression).
+
+        y_pred : List, pandas.Series, numpy.ndarray, pandas.DataFrame
+            The predictions.
+
+        sensitive_features : (List, pandas.Series, dict of 1d arrays,
+         numpy.ndarray, pandas.DataFrame)
+            The sensitive features which should be used to create the subgroups.
+            At least one sensitive feature must be provided.
+            All names (whether on pandas objects or dictionary keys) must be strings.
+            We also forbid DataFrames with column names of ``None``.
+            For cases where no names are provided we generate names ``sensitive_feature_[n]``.
+
+        control_features : (List, pandas.Series, dict of 1d arrays,
+         numpy.ndarray, pandas.DataFrame)
+            Control features are similar to sensitive features, in that they
+            divide the input data into subgroups.
+            Unlike the sensitive features, aggregations are not performed
+            across the control features - for example, the ``overall`` property
+            will have one value for each subgroup in the control feature(s),
+            rather than a single value for the entire data set.
+            Control features can be specified similarly to the sensitive features.
+            However, their default names (if none can be identified in the
+            input values) are of the format ``control_feature_[n]``.
+
+        sample_params : dict
+            Parameters for the metric function(s). If there is only one metric function,
+            then this is a dictionary of strings and array-like objects, which are split
+            alongside the ``y_true`` and ``y_pred`` arrays, and passed to the metric function.
+            If there are multiple metric functions (passed as a dictionary), then this is
+            a nested dictionary, with the first set of string keys identifying the
+            metric function name, with the values being the string-to-array-like dictionaries.
+
+            **Note** the types returned by members of the class vary based on whether
+            control features are present.
+        """
+        check_consistent_length(y_true, y_pred)
+        self._y_true = self._concat_if_not_none(self._y_true, y_true)
+        self._y_pred = self._concat_if_not_none(self._y_pred, y_pred)
+        self._sensitive_features = self._concat_if_not_none(self._sensitive_features,
+                                                            sensitive_features)
+        if control_features is not None:
+            self._control_features = self._concat_if_not_none(self._control_features,
+                                                              control_features)
+        elif self._control_features is not None:
+            raise ValueError(_CF_BAD_STATE_ERR)
+
+        if sample_params is not None:
+            self._sample_params = self._concat_if_not_none(self._sample_params,
+                                                           sample_params)
+
+    def get_metric(self) -> MetricFrame:
+        """Get the MetricFrame computed on the accumulated values."""
+        if self._y_true is None:
+            raise ValueError(_EMPTY_BATCHES_ERR)
+        return MetricFrame(metrics=self._metrics,
+                           y_true=self._y_true,
+                           y_pred=self._y_pred,
+                           sensitive_features=self._sensitive_features,
+                           control_features=self._control_features,
+                           sample_params=self._sample_params)
+
+    def _concat_batches(self, batches: List[B]) -> B:
+        """Concatenate a list of items together.
+
+        When merging Dicts, the values will be merged and a new dict will be created.
+        DataFrames' columns need to match to be concatenated.
+        Arrays, list and Series can be merged using simple functions.
+
+        Parameters
+        ----------
+        batches : List[Union[Dict, nd.array, List, Serie, DataFrame]]
+            A list of batch to concat together. The batches must be of the same type.
+
+        Returns
+        ---------
+        Batches concatenated into a single object.
+        """
+        if len(batches) == 0:
+            raise ValueError(_EMPTY_BATCHES_ERR)
+        batch_type = type(batches[0])
+        if not all([type(arr) is batch_type for arr in batches]):
+            raise ValueError("Can't concatenate arrays of different types.")
+
+        # Simple cases, array, Series and list can be concat easily.
+        if batch_type is np.ndarray:
+            result = np.concatenate(batches)
+        elif batch_type is list:
+            result = sum(batches, [])
+        elif batch_type is pd.Series:
+            result = pd.concat(batches)
+        elif batch_type is pd.DataFrame:
+            # To concat dataframe, we check if the columns match.
+            col_nums = batches[0].columns
+            if any([col_nums != df.columns for df in batches]):
+                raise ValueError(f"Column mismatch expected {col_nums},"
+                                 f" got {[df.columns for df in batches]}")
+            result = pd.concat(batches)
+        elif batch_type is dict:
+            # Create a new dict that merges values of all keys.
+            all_keys = set(sum((list(b.keys()) for b in batches), []))
+            return {k: self._concat_batches([b[k] for b in batches if k in b])
+                    for k in all_keys}
+        else:
+            raise ValueError(f"Can't concatenate {batch_type}: {batches}")
+        return result
+
+    def _concat_if_not_none(self, val1: Optional[B], val2: B) -> B:
+        # Helper function that concats batches when possible.
+        return val2 if val1 is None else self._concat_batches([val1, val2])

--- a/test/unit/metrics/test_streaming_metric_frame.py
+++ b/test/unit/metrics/test_streaming_metric_frame.py
@@ -17,7 +17,7 @@ from .utils import batchify
 
 @pytest.mark.parametrize("transform_y_p", conversions_for_1d)
 @pytest.mark.parametrize("transform_y_t", conversions_for_1d)
-@pytest.mark.parametrize("num_batches", [1, 3, 5])
+@pytest.mark.parametrize("num_batches", [1, 3, 5, len(y_t)])
 def test_alternate_compute(transform_y_t, transform_y_p, num_batches):
     target = metrics.StreamingMetricFrame(metrics=skm.recall_score)
 
@@ -45,7 +45,7 @@ def test_alternate_compute(transform_y_t, transform_y_p, num_batches):
 
 @pytest.mark.parametrize("transform_y_p", conversions_for_1d)
 @pytest.mark.parametrize("transform_y_t", conversions_for_1d)
-@pytest.mark.parametrize("num_batches", [1, 3, 5])
+@pytest.mark.parametrize("num_batches", [1, 3, 5, len(y_t)])
 def test_simple_sample_params(transform_y_t, transform_y_p, num_batches):
     sample_weights = np.random.rand(len(y_t))
     batch_generator = batchify(num_batches, y_t, y_p, g_4, sample_weights)
@@ -83,7 +83,7 @@ def test_simple_sample_params(transform_y_t, transform_y_p, num_batches):
 
 @pytest.mark.parametrize("transform_y_p", conversions_for_1d)
 @pytest.mark.parametrize("transform_y_t", conversions_for_1d)
-@pytest.mark.parametrize("num_batches", [1, 3, 5])
+@pytest.mark.parametrize("num_batches", [1, 3, 5, len(y_t)])
 def test_basic_streaming(transform_y_t, transform_y_p, num_batches):
     batch_generator = batchify(num_batches, y_t, y_p, g_4)
     target = metrics.StreamingMetricFrame(metrics=skm.recall_score)
@@ -120,6 +120,11 @@ def test_basic_streaming(transform_y_t, transform_y_p, num_batches):
 
     assert target_metric.group_min() == met_regular.group_min()
     assert target_metric.group_max() == met_regular.group_max()
+
+    # Verify that reset works.
+    target.reset()
+    assert all(v is None for v in (target._y_true, target._y_pred, target._sensitive_features,
+                                   target._control_features, target._sample_params))
 
 
 def test_exception_on_no_data():

--- a/test/unit/metrics/test_streaming_metric_frame.py
+++ b/test/unit/metrics/test_streaming_metric_frame.py
@@ -1,0 +1,226 @@
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
+# Licensed under the MIT License.
+
+import numpy as np
+import pandas as pd
+import pytest
+import sklearn.metrics as skm
+
+import fairlearn.metrics as metrics
+from test.unit.input_convertors import (conversions_for_1d,
+                                        ensure_ndarray,
+                                        ensure_list,
+                                        ensure_dataframe)
+from .data_for_test import y_t, y_p, g_4
+from .utils import batchify
+
+
+@pytest.mark.parametrize("transform_y_p", conversions_for_1d)
+@pytest.mark.parametrize("transform_y_t", conversions_for_1d)
+@pytest.mark.parametrize("num_batches", [1, 3, 5])
+def test_alternate_compute(transform_y_t, transform_y_p, num_batches):
+    target = metrics.StreamingMetricFrame(metrics=skm.recall_score)
+
+    batch_generator = batchify(num_batches, y_t, y_p, g_4)
+    for y_t_batches, y_p_batches, g_4_batches in batch_generator:
+        g_f = pd.DataFrame(data=g_4_batches, columns=['My feature'])
+        target.add_data(y_true=transform_y_t(y_t_batches),
+                        y_pred=transform_y_p(y_p_batches),
+                        sensitive_features=g_f)
+
+    assert len(target._y_true) == len(y_t)
+    assert target.get_metric().overall == skm.recall_score(y_t, y_p)
+
+    batch_generator = batchify(num_batches, y_t, y_p, g_4)
+    for y_t_batches, y_p_batches, g_4_batches in batch_generator:
+        g_f = pd.DataFrame(data=g_4_batches, columns=['My feature'])
+        target.add_data(y_true=transform_y_t(y_t_batches),
+                        y_pred=transform_y_p(y_p_batches),
+                        sensitive_features=g_f)
+    assert len(target._y_true) == 2 * len(y_t)
+
+    # We check that calling `by_group` will recompute the values.
+    assert len(target.get_metric().by_group) == 2
+
+
+@pytest.mark.parametrize("transform_y_p", conversions_for_1d)
+@pytest.mark.parametrize("transform_y_t", conversions_for_1d)
+@pytest.mark.parametrize("num_batches", [1, 3, 5])
+def test_simple_sample_params(transform_y_t, transform_y_p, num_batches):
+    sample_weights = np.random.rand(len(y_t))
+    batch_generator = batchify(num_batches, y_t, y_p, g_4, sample_weights)
+    target = metrics.StreamingMetricFrame(metrics=skm.recall_score)
+
+    for y_t_batches, y_p_batches, g_4_batches, sw_batches in batch_generator:
+        g_f = pd.DataFrame(data=g_4_batches, columns=['My feature'])
+        target.add_data(y_true=transform_y_t(y_t_batches),
+                        y_pred=transform_y_p(y_p_batches),
+                        sensitive_features=g_f,
+                        sample_params={'sample_weight': sw_batches})
+
+    target_metric = target.get_metric()
+    # Check we have correct return types
+    assert isinstance(target_metric.overall, float)
+    assert isinstance(target_metric.by_group, pd.Series)
+
+    # Check we have expected number of elements
+    assert len(target_metric.by_group) == 2
+    assert np.array_equal(target_metric.by_group.index.names, ['My feature'])
+
+    # Compare to the non-batched version.
+    g4 = pd.DataFrame(data=g_4, columns=['My feature'])
+    met_regular = metrics.MetricFrame(metrics=skm.recall_score, y_true=y_t,
+                                      y_pred=y_p, sensitive_features=g4,
+                                      sample_params={'sample_weight': sample_weights})
+    assert target_metric.overall == met_regular.overall
+
+    for k, v in met_regular.by_group.items():
+        assert v == target_metric.by_group[k]
+
+    assert target_metric.group_min() == met_regular.group_min()
+    assert target_metric.group_max() == met_regular.group_max()
+
+
+@pytest.mark.parametrize("transform_y_p", conversions_for_1d)
+@pytest.mark.parametrize("transform_y_t", conversions_for_1d)
+@pytest.mark.parametrize("num_batches", [1, 3, 5])
+def test_basic_streaming(transform_y_t, transform_y_p, num_batches):
+    batch_generator = batchify(num_batches, y_t, y_p, g_4)
+    target = metrics.StreamingMetricFrame(metrics=skm.recall_score)
+
+    for y_t_batches, y_p_batches, g_4_batches in batch_generator:
+        g_f = pd.DataFrame(data=g_4_batches, columns=['My feature'])
+        target.add_data(y_true=transform_y_t(y_t_batches),
+                        y_pred=transform_y_p(y_p_batches),
+                        sensitive_features=g_f)
+
+    target_metric = target.get_metric()
+    # Check on the indices properties
+    assert target_metric.control_levels is None
+    assert isinstance(target_metric.sensitive_levels, list)
+    assert (target_metric.sensitive_levels == ['My feature'])
+
+    # Check we have correct return types
+    assert isinstance(target_metric.overall, float)
+    assert isinstance(target_metric.by_group, pd.Series)
+
+    # Check we have expected number of elements
+    assert len(target_metric.by_group) == 2
+    assert np.array_equal(target_metric.by_group.index.names, ['My feature'])
+
+    # Compare to the non-batched version.
+    g4 = pd.DataFrame(data=g_4, columns=['My feature'])
+    met_regular = metrics.MetricFrame(metrics=skm.recall_score,
+                                      y_true=y_t, y_pred=y_p,
+                                      sensitive_features=g4)
+    assert target_metric.overall == met_regular.overall
+
+    for k, v in met_regular.by_group.items():
+        assert v == target_metric.by_group[k]
+
+    assert target_metric.group_min() == met_regular.group_min()
+    assert target_metric.group_max() == met_regular.group_max()
+
+
+def test_exception_on_no_data():
+    target = metrics.StreamingMetricFrame(metrics=skm.recall_score)
+
+    with pytest.raises(ValueError) as excinfo:
+        _ = target.get_metric()
+    assert "No data to process" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("transform_y_p", conversions_for_1d)
+def test_concat_batches(transform_y_p):
+    num_batches = 5
+    metric_frame = metrics.StreamingMetricFrame(metrics=skm.recall_score)
+    # Get y_p from the batch to make a list of batch.
+    batches = [b for [b] in batchify(num_batches, transform_y_p(y_p))]
+    concatenated = metric_frame._concat_batches(batches)
+    assert len(concatenated) == len(y_p)
+
+
+def test_concat_batches_error():
+    metric_frame = metrics.StreamingMetricFrame(metrics=skm.recall_score)
+    with pytest.raises(ValueError) as excinfo:
+        metric_frame._concat_batches([])
+    assert "No data to process" in str(excinfo.value)
+
+    lst_input, arr_input = ensure_list(y_t), ensure_ndarray(y_t)
+    with pytest.raises(ValueError) as excinfo:
+        metric_frame._concat_batches([lst_input, arr_input])
+    assert "Can't concatenate arrays of different types" in str(excinfo.value)
+
+    df1, df2 = ensure_dataframe(y_t), ensure_dataframe(y_t)
+    # Edit column name
+    df1.columns = [f"{c}_" for c in df1.columns]
+    with pytest.raises(ValueError) as excinfo:
+        metric_frame._concat_batches([df1, df2])
+    assert "Column mismatch" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("transform_y_p", conversions_for_1d)
+@pytest.mark.parametrize("transform_y_t", conversions_for_1d)
+@pytest.mark.parametrize("num_batches", [1, 3, 5])
+def test_multimetric_straming(transform_y_t, transform_y_p, num_batches):
+    batch_generator = batchify(num_batches, y_t, y_p, g_4)
+    target = metrics.StreamingMetricFrame(metrics={'recall': skm.recall_score,
+                                                   'precision': skm.precision_score})
+
+    for y_t_batches, y_p_batches, g_4_batches in batch_generator:
+        g_f = pd.DataFrame(data=g_4_batches, columns=['My feature'])
+        target.add_data(y_true=transform_y_t(y_t_batches),
+                        y_pred=transform_y_p(y_p_batches),
+                        sensitive_features=g_f)
+
+    target_metric = target.get_metric()
+
+    # Compare to the non-batched version.
+    g4 = pd.DataFrame(data=g_4, columns=['My feature'])
+    met_regular = metrics.MetricFrame(metrics={'recall': skm.recall_score,
+                                               'precision': skm.precision_score},
+                                      y_true=y_t, y_pred=y_p,
+                                      sensitive_features=g4)
+    assert (target_metric.overall == met_regular.overall).all()
+
+    for k, v in met_regular.by_group.items():
+        assert (v == target_metric.by_group[k]).all()
+
+    assert (target_metric.group_min() == met_regular.group_min()).all()
+    assert (target_metric.group_max() == met_regular.group_max()).all()
+
+
+@pytest.mark.parametrize("transform_y_p", conversions_for_1d)
+@pytest.mark.parametrize("transform_y_t", conversions_for_1d)
+@pytest.mark.parametrize("num_batches", [1, 3, 5])
+def test_nested_sample_params(transform_y_t, transform_y_p, num_batches):
+    sample_weights = np.random.rand(len(y_t))
+    batch_generator = batchify(num_batches, y_t, y_p, g_4, sample_weights)
+    target = metrics.StreamingMetricFrame(metrics={'recall': skm.recall_score,
+                                                   'precision': skm.precision_score})
+
+    for y_t_batches, y_p_batches, g_4_batches, sw_batches in batch_generator:
+        g_f = pd.DataFrame(data=g_4_batches, columns=['My feature'])
+        target.add_data(y_true=transform_y_t(y_t_batches),
+                        y_pred=transform_y_p(y_p_batches),
+                        sensitive_features=g_f,
+                        sample_params={'recall': {'sample_weight': sw_batches},
+                                       'precision': {'sample_weight': sw_batches}})
+
+    target_metric = target.get_metric()
+
+    # Compare to the non-batched version.
+    g4 = pd.DataFrame(data=g_4, columns=['My feature'])
+    weights_ = {'recall': {'sample_weight': sample_weights},
+                'precision': {'sample_weight': sample_weights}}
+    met_regular = metrics.MetricFrame(metrics={'recall': skm.recall_score,
+                                               'precision': skm.precision_score}, y_true=y_t,
+                                      y_pred=y_p, sensitive_features=g4,
+                                      sample_params=weights_)
+    assert (target_metric.overall == met_regular.overall).all()
+
+    for k, v in met_regular.by_group.items():
+        assert (v == target_metric.by_group[k]).all()
+
+    assert (target_metric.group_min() == met_regular.group_min()).all()
+    assert (target_metric.group_max() == met_regular.group_max()).all()

--- a/test/unit/metrics/utils.py
+++ b/test/unit/metrics/utils.py
@@ -14,7 +14,7 @@ def _get_raw_MetricFrame():
 def batchify(num_batches, *args: List[Iterable]) -> Generator:
     reference = args[0]
     assert [len(arr) == len(reference) for arr in args], "Can't batch arrays of unequal lengths."
-    assert num_batches < len(reference), "Can't make more batches than there is elements."
+    assert num_batches <= len(reference), "Can't make more batches than there is elements."
     batch_size = int(math.ceil(len(reference) / num_batches))
     for idx in range(0, len(reference), batch_size):
         yield [arr[idx: (idx + batch_size)] for arr in args]

--- a/test/unit/metrics/utils.py
+++ b/test/unit/metrics/utils.py
@@ -1,5 +1,7 @@
 # Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
+import math
+from typing import Generator, Iterable, List
 
 import fairlearn.metrics as metrics
 
@@ -7,3 +9,12 @@ import fairlearn.metrics as metrics
 def _get_raw_MetricFrame():
     # Gets an uninitialised MetricFrame for testing purposes
     return metrics.MetricFrame.__new__(metrics.MetricFrame)
+
+
+def batchify(num_batches, *args: List[Iterable]) -> Generator:
+    reference = args[0]
+    assert [len(arr) == len(reference) for arr in args], "Can't batch arrays of unequal lengths."
+    assert num_batches < len(reference), "Can't make more batches than there is elements."
+    batch_size = int(math.ceil(len(reference) / num_batches))
+    for idx in range(0, len(reference), batch_size):
+        yield [arr[idx: (idx + batch_size)] for arr in args]


### PR DESCRIPTION
Introduce StreamingMetricFrame to accumulate batches and enable batch evaluation.

This version focuses on maintainability and is much easier to work with than the previous one. Most checks are now done by MetricFrame.

Fixes #655 


### Notes

In the previous PR (#670), we mentioned that converting everything to pandas would be valuable.
I think this would be useful, but this approach gets complicated with nested dict found in `sample_params`. I am open to propositions on how to fix that and maybe get rid of `StreamingMetricFrame._concat_batches`.



