### PR TITLE
ENH make CorrelationRemover expose n_features_in_ and feature_names_in_

### DIFF
--- a/docs/user_guide/installation_and_version_guide/v0.7.1.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.7.1.rst
@@ -15,3 +15,5 @@ v0.7.1
 * Fixed a bug whereby passing a custom :code:`grid` object to a :code:`GridSearch`
   reduction would result in a :code:`KeyError` if the column names were not ordered
   integers.
+* :class:`~fairlearn.preprocessing.CorrelationRemover` now exposes
+  :code:`n_features_in_` and :code:`feature_names_in_`.

--- a/fairlearn/preprocessing/_correlation_remover.py
+++ b/fairlearn/preprocessing/_correlation_remover.py
@@ -71,13 +71,16 @@ class CorrelationRemover(BaseEstimator, TransformerMixin):
         if isinstance(X, pd.DataFrame):
             self.lookup_ = {c: i for i, c in enumerate(X.columns)}
             return X.values
+        # correctly handle a 1d input
+        if len(X.shape) == 1:
+            return {0: 0}
         self.lookup_ = {i: i for i in range(X.shape[1])}
         return X
 
     def fit(self, X, y=None):
         """Learn the projection required to make the dataset uncorrelated with sensitive columns."""  # noqa: E501
         self._create_lookup(X)
-        X = check_array(X, estimator=self)
+        X = self._validate_data(X)
         X_use, X_sensitive = self._split_X(X)
         self.sensitive_mean_ = X_sensitive.mean()
         X_s_center = X_sensitive - self.sensitive_mean_
@@ -88,7 +91,9 @@ class CorrelationRemover(BaseEstimator, TransformerMixin):
     def transform(self, X):
         """Transform X by applying the correlation remover."""
         X = check_array(X, estimator=self)
-        check_is_fitted(self, ["beta_", "X_shape_", "lookup_", "sensitive_mean_"])
+        check_is_fitted(
+            self, ["beta_", "X_shape_", "lookup_", "sensitive_mean_"]
+        )
         if self.X_shape_[1] != X.shape[1]:
             raise ValueError(
                 f"The trained data has {self.X_shape_[1]} features while this dataset has "
@@ -100,3 +105,17 @@ class CorrelationRemover(BaseEstimator, TransformerMixin):
         X_use = np.atleast_2d(X_use)
         X_filtered = np.atleast_2d(X_filtered)
         return self.alpha * X_filtered + (1 - self.alpha) * X_use
+
+    def _more_tags(self):
+        return {
+            "_xfail_checks": {
+                "check_parameters_default_constructible": (
+                    "sensitive_feature_ids has to be explicitly set to "
+                    "instantiate this estimator"
+                ),
+                "check_transformer_data_not_an_array": (
+                    "this estimator only accepts pandas dataframes or numpy "
+                    "ndarray as input."
+                )
+            }
+        }

--- a/test/unit/preprocessing/linear_dep_remover/test_sklearn_compat.py
+++ b/test/unit/preprocessing/linear_dep_remover/test_sklearn_compat.py
@@ -4,51 +4,44 @@
 import pytest
 import numpy as np
 import pandas as pd
-from sklearn.utils import estimator_checks
+from sklearn.utils.estimator_checks import parametrize_with_checks
 
 from fairlearn.preprocessing import CorrelationRemover
 
 
-@pytest.mark.parametrize(
-    "test_fn",
+@parametrize_with_checks(
     [
-        # transformer checks
-        estimator_checks.check_transformer_general,
-        estimator_checks.check_transformers_unfitted,
-        # general estimator checks
-        estimator_checks.check_fit2d_predict1d,
-        estimator_checks.check_methods_subset_invariance,
-        estimator_checks.check_fit2d_1sample,
-        estimator_checks.check_fit2d_1feature,
-        estimator_checks.check_get_params_invariance,
-        estimator_checks.check_set_params,
-        estimator_checks.check_dict_unchanged,
-        estimator_checks.check_dont_overwrite_parameters,
-        # nonmeta_checks
-        estimator_checks.check_estimators_dtypes,
-        estimator_checks.check_fit_score_takes_y,
-        estimator_checks.check_dtype_object,
-        estimator_checks.check_sample_weights_pandas_series,
-        estimator_checks.check_sample_weights_list,
-        estimator_checks.check_estimators_fit_returns_self,
-        estimator_checks.check_complex_data,
-        estimator_checks.check_estimators_empty_data_messages,
-        estimator_checks.check_pipeline_consistency,
-        estimator_checks.check_estimators_nan_inf,
-        estimator_checks.check_estimators_overwrite_params,
-        estimator_checks.check_estimator_sparse_data,
-        estimator_checks.check_estimators_pickle,
+        CorrelationRemover(sensitive_feature_ids=[]),
+        CorrelationRemover(sensitive_feature_ids=[0]),
     ]
 )
-def test_estimator_checks(test_fn):
-    test_fn(CorrelationRemover.__name__, CorrelationRemover(sensitive_feature_ids=[]))
-    test_fn(CorrelationRemover.__name__, CorrelationRemover(sensitive_feature_ids=[0]))
+def test_sklearn_compatible_estimator(estimator, check):
+    check(estimator)
 
 
 def test_linear_dependence():
-    X = np.array([[0, 0, 1, 1, ],
-                  [1, 1, 2, 2, ],
-                  [0.1, 0.2, 1.2, 1.1, ]]).T
+    X = np.array(
+        [
+            [
+                0,
+                0,
+                1,
+                1,
+            ],
+            [
+                1,
+                1,
+                2,
+                2,
+            ],
+            [
+                0.1,
+                0.2,
+                1.2,
+                1.1,
+            ],
+        ]
+    ).T
 
     X_tfm = CorrelationRemover(sensitive_feature_ids=[0]).fit(X).transform(X)
     assert X_tfm.shape[1] == 2
@@ -56,12 +49,33 @@ def test_linear_dependence():
 
 
 def test_linear_dependence_pd():
-    X = np.array([[0, 0, 1, 1, ],
-                  [1, 1, 2, 2, ],
-                  [0.1, 0.2, 1.2, 1.1, ]]).T
+    X = np.array(
+        [
+            [
+                0,
+                0,
+                1,
+                1,
+            ],
+            [
+                1,
+                1,
+                2,
+                2,
+            ],
+            [
+                0.1,
+                0.2,
+                1.2,
+                1.1,
+            ],
+        ]
+    ).T
 
-    df = pd.DataFrame(X, columns=['a', 'b', 'c'])
+    df = pd.DataFrame(X, columns=["a", "b", "c"])
 
-    X_tfm = CorrelationRemover(sensitive_feature_ids=['a']).fit(df).transform(df)
+    X_tfm = (
+        CorrelationRemover(sensitive_feature_ids=["a"]).fit(df).transform(df)
+    )
     assert X_tfm.shape[1] == 2
     assert np.allclose(X_tfm[:, 0], 1.5)


### PR DESCRIPTION
fixes #964

Makes `CorrelationRemover` pass sklearn common tests, and include 2 tests which are going to fail as `xfail`. In the process, the estimator now exposes `n_features_in_` and `feature_names_in_` via calling `_validate_data`.


It's also formatting the two files with `black`.