### PR TITLE
TST use int minvalue instead of None in _get_labels_for_confusion_matrix

### DIFF
--- a/fairlearn/metrics/_extra_metrics.py
+++ b/fairlearn/metrics/_extra_metrics.py
@@ -61,7 +61,7 @@ def _get_labels_for_confusion_matrix(labels, pos_label):
     # Ensure unique_labels has two elements
     if len(unique_labels) == 1:
         if unique_labels[0] == pos_label:
-            unique_labels = [None, pos_label]
+            unique_labels = [np.iinfo(np.int64).min, pos_label]
         else:
             unique_labels.append(pos_label)
     elif len(unique_labels) == 2:

--- a/test/unit/metrics/test_extra_metrics.py
+++ b/test/unit/metrics/test_extra_metrics.py
@@ -36,17 +36,17 @@ class TestGetLabelsForConfusionMatrix:
         r1 = _get_labels_for_confusion_matrix([-1], None)
         assert np.array_equal(r1, [-1, 1])
         r2 = _get_labels_for_confusion_matrix([1], None)
-        assert np.array_equal(r2, [None, 1])
+        assert np.array_equal(r2, [np.iinfo(np.int64).min, 1])
 
     def test_single_value_numeric_pos_label(self):
         r0 = _get_labels_for_confusion_matrix([0], 3)
         assert np.array_equal(r0, [0, 3])
         r1 = _get_labels_for_confusion_matrix([0], 0)
-        assert np.array_equal(r1, [None, 0])
+        assert np.array_equal(r1, [np.iinfo(np.int64).min, 0])
 
     def test_single_value_alpha_pos_label(self):
         r0 = _get_labels_for_confusion_matrix(['a'], 'a')
-        assert np.array_equal(r0, [None, 'a'])
+        assert np.array_equal(r0, [np.iinfo(np.int64).min, 'a'])
         r1 = _get_labels_for_confusion_matrix(['a'], 0)
         assert np.array_equal(r1, ['a', 0])
 


### PR DESCRIPTION
fixes #963


This PR uses an integer minvalue instead of None in _get_labels_for_confusion_matrix, to fix the `TypeError: '<' not supported between instances of 'int' and 'NoneType'` issue