### PR TITLE
ENH Add ranking metrics

### DIFF
--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -279,6 +279,7 @@ Base metric                                     :code:`group_min` :code:`group_m
 :func:`.true_positive_rate`                     .                 .                 Y                  Y
 :func:`.exposure`                               .                 .                 Y                  Y
 :func:`.utility`                                .                 .                 Y                  Y
+:func:`.exposure_utility_ratio`                 .                 .                 Y                  Y
 :func:`sklearn.metrics.accuracy_score`          Y                 .                 Y                  Y
 :func:`sklearn.metrics.balanced_accuracy_score` Y                 .                 .                  .
 :func:`sklearn.metrics.f1_score`                Y                 .                 .                  .

--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -279,7 +279,7 @@ Base metric                                     :code:`group_min` :code:`group_m
 :func:`.true_positive_rate`                     .                 .                 Y                  Y
 :func:`.exposure`                               .                 .                 Y                  Y
 :func:`.utility`                                .                 .                 Y                  Y
-:func:`.exposure_utility_ratio`                 .                 .                 Y                  Y
+:func:`.proportional_exposure`                  .                 .                 Y                  Y
 :func:`sklearn.metrics.accuracy_score`          Y                 .                 Y                  Y
 :func:`sklearn.metrics.balanced_accuracy_score` Y                 .                 .                  .
 :func:`sklearn.metrics.f1_score`                Y                 .                 .                  .

--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -277,6 +277,8 @@ Base metric                                     :code:`group_min` :code:`group_m
 :func:`.selection_rate`                         .                 .                 Y                  Y
 :func:`.true_negative_rate`                     .                 .                 Y                  Y
 :func:`.true_positive_rate`                     .                 .                 Y                  Y
+:func:`.exposure`                               .                 .                 Y                  Y
+:func:`.utility`                                .                 .                 Y                  Y
 :func:`sklearn.metrics.accuracy_score`          Y                 .                 Y                  Y
 :func:`sklearn.metrics.balanced_accuracy_score` Y                 .                 .                  .
 :func:`sklearn.metrics.f1_score`                Y                 .                 .                  .

--- a/docs/user_guide/fairness_in_machine_learning.rst
+++ b/docs/user_guide/fairness_in_machine_learning.rst
@@ -201,12 +201,12 @@ attention an instance is expected to receive, based on their position in the ran
 computed as a logarithmic discount :math:`\frac{1}{log(1+i)}` for each position :math:`i`, as used
 in discounted cumulative gain (DCG).
 
-* *Allocation harm*: We try to allocate the exposure that each item gets fairly across the groups.
+* *Exposure*: We try to allocate the exposure that each item gets fairly across the groups.
   A ranking :math:`\tau` has a fair exposure allocation under a distribution over :math:`(X,A,Y)`,
   if its ranking for :math:`\tau(X)` is statistically independent over sensitive feature:math:`A`.
   [#6]_
 
-* *Quality-of-service harm*: We try to keep the exposure that each item gets proportional to its
+* *Proportional exposure*: We try to keep the exposure that each item gets proportional to its
   "ground-truth" relevance. Otherwise small differences in relevance can lead to huge differences
   in exposure. A ranking :math:`\tau` satisfies parity in quality-of-service under
   a distribution over :math:`(X,A,Y)`, if its ranking for :math:`\tau(X)` is statistically

--- a/docs/user_guide/fairness_in_machine_learning.rst
+++ b/docs/user_guide/fairness_in_machine_learning.rst
@@ -202,12 +202,12 @@ discount :math:`\frac{1}{log(1+i)}` for each position :math:`i`, as used in disc
 cumulative gain (DCG).
 
 * *Allocation harm*:  A ranking :math:`\tau` has a fair exposure allocation under
-a distribution over :math:`(X,A,Y)`, if its ranking for :math:`\tau(X)` is statistically
-independent over sensitive feature :math:`A`. [#6]_
+  a distribution over :math:`(X,A,Y)`, if its ranking for :math:`\tau(X)` is statistically
+  independent over sensitive feature :math:`A`. [#6]_
 
 * *Quality-of-service harm*: A ranking :math:`\tau` satisfies parity in quality-of-service under
-a distribution over :math:`(X,A,Y)`, if its ranking for :math:`\tau(X)` is statistically
-proportional to :math:`Y`, independent over sensitive feature :math:`A`. [#6]_
+  a distribution over :math:`(X,A,Y)`, if its ranking for :math:`\tau(X)` is statistically
+  proportional to :math:`Y`, independent over sensitive feature :math:`A`. [#6]_
 
 Disparity metrics, group metrics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/user_guide/fairness_in_machine_learning.rst
+++ b/docs/user_guide/fairness_in_machine_learning.rst
@@ -198,15 +198,16 @@ harms as well as quality-of-service harms.
 
 Fairlearn considers two constraints for rankings, based on the exposure of X, where exposure
 is defined as how much attention each place in the ranking gets. Calculated by a logarithmic
-discount :math:`\frac{1}{log(1+i)}` for each position :math:`i`.
+discount :math:`\frac{1}{log(1+i)}` for each position :math:`i`, as used in discounted
+cumulative gain (DCG).
 
 * *Allocation harm*:  A ranking :math:`\tau` has a fair exposure allocation under
 a distribution over :math:`(X,A,Y)`, if its ranking for :math:`\tau(X)` is statistically
-independent over sensitive feature :math:`A`.
+independent over sensitive feature :math:`A`. [#6]_
 
 * *Quality-of-service harm*: A ranking :math:`\tau` satisfies parity in quality-of-service under
 a distribution over :math:`(X,A,Y)`, if its ranking for :math:`\tau(X)` is statistically
-proportional to :math:`Y`, independent over sensitive feature :math:`A`.
+proportional to :math:`Y`, independent over sensitive feature :math:`A`. [#6]_
 
 Disparity metrics, group metrics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -435,3 +436,6 @@ the algorithm may impact the intended outcomes of a given model.
 
    .. [#5] Obermeyer, Powers, Vogeli, Mullainathan `"Dissecting racial bias in an algorithm used to manage the health of populations"
       <https://science.sciencemag.org/content/366/6464/447>`_, Science, 2019.
+
+   .. [#6] Singh, Joachims `"Fairness of Exposure in Rankings"
+      <https://dl.acm.org/doi/10.1145/3219819.3220088>`_, KDD, 2018.

--- a/docs/user_guide/fairness_in_machine_learning.rst
+++ b/docs/user_guide/fairness_in_machine_learning.rst
@@ -196,16 +196,19 @@ harms as well as quality-of-service harms.
 
 *Ranking*:
 
-Fairlearn considers two constraints for rankings, based on the exposure of X, where exposure
-is defined as how much attention each place in the ranking gets. Calculated by a logarithmic
-discount :math:`\frac{1}{log(1+i)}` for each position :math:`i`, as used in discounted
-cumulative gain (DCG).
+Fairlearn includes two constraints for rankings, based on exposure: a measure for the amount of
+attention an instance is expected to receive, based on their position in the ranking. Exposure is
+computed as a logarithmic discount :math:`\frac{1}{log(1+i)}` for each position :math:`i`, as used
+in discounted cumulative gain (DCG).
 
-* *Allocation harm*:  A ranking :math:`\tau` has a fair exposure allocation under
-  a distribution over :math:`(X,A,Y)`, if its ranking for :math:`\tau(X)` is statistically
-  independent over sensitive feature :math:`A`. [#6]_
+* *Allocation harm*: We try to allocate the exposure that each item gets fairly across the groups.
+  A ranking :math:`\tau` has a fair exposure allocation under a distribution over :math:`(X,A,Y)`,
+  if its ranking for :math:`\tau(X)` is statistically independent over sensitive feature:math:`A`.
+  [#6]_
 
-* *Quality-of-service harm*: A ranking :math:`\tau` satisfies parity in quality-of-service under
+* *Quality-of-service harm*: We try to keep the exposure that each item gets proportional to its
+  "ground-truth" relevance. Otherwise small differences in relevance can lead to huge differences
+  in exposure. A ranking :math:`\tau` satisfies parity in quality-of-service under
   a distribution over :math:`(X,A,Y)`, if its ranking for :math:`\tau(X)` is statistically
   proportional to :math:`Y`, independent over sensitive feature :math:`A`. [#6]_
 

--- a/docs/user_guide/fairness_in_machine_learning.rst
+++ b/docs/user_guide/fairness_in_machine_learning.rst
@@ -194,6 +194,20 @@ group loss primarily seeks to mitigate quality-of-service harms. Equalized
 odds and equal opportunity can be used as a diagnostic for both allocation
 harms as well as quality-of-service harms.
 
+*Ranking*:
+
+Fairlearn considers two constraints for rankings, based on the exposure of X, where exposure
+is defined as how much attention each place in the ranking gets. Calculated by a logarithmic
+discount :math:`\frac{1}{log(1+i)}` for each position :math:`i`.
+
+* *Allocation harm*:  A ranking :math:`\tau` has a fair exposure allocation under
+a distribution over :math:`(X,A,Y)`, if its ranking for :math:`\tau(X)` is statistically
+independent over sensitive feature :math:`A`.
+
+* *Quality-of-service harm*: A ranking :math:`\tau` satisfies parity in quality-of-service under
+a distribution over :math:`(X,A,Y)`, if its ranking for :math:`\tau(X)` is statistically
+proportional to :math:`Y`, independent over sensitive feature :math:`A`.
+
 Disparity metrics, group metrics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/examples/plot_ranking.py
+++ b/examples/plot_ranking.py
@@ -16,17 +16,19 @@ from fairlearn.metrics import MetricFrame
 # `"Fairness of Exposure in Ranking" <https://dl.acm.org/doi/10.1145/3219819.3220088>`_
 # by Singh and Joachims (2018).
 # The example demonstrates how small differences in item relevance can lead to large differences
-# in exposure. Differences in exposure can be harmful not only because you are ranking individuals
-# directly but individuals can also be indirect affected by a ranking, think about books, music or
-# products in online retail.
+# in exposure. Differences in exposure can be harmful when we rank individuals, such as in hiring.
+# Groups of people can also be indirectly affected by rankings of items such as books, music, or
+# products in online retail. For example, it could be that authors of color's products are
+# consistently lower ranked in search results.
 #
 # We reproduce the example of the paper, which for simplicity reasons uses a binary gender category
-# as sensitive attribute. The metric however also works for multi-class sensitive attributes.
+# as sensitive attribute. However, the metric can also be applied to multi-categorical sensitive
+# attributes.
 #
 # Consider a web-service that connects employers ("users") to potential employees ("items").
-# The web-service uses a ranking-based system to present a set of 6 applicants of which 3 are male
-# and 3 are female. Male applicants have relevance of 0.80, 0.79, 0.78 respectively for the
-# employer, while female applicants have relevance of 0.77, 0.76, 0.75.
+# The web-service uses a ranking-based system to present a set of 6 applicants of which 3 are
+# labelled man and 3 are labelled woman. Men have relevance of 0.80, 0.79, 0.78 respectively for
+# the employer, while women have relevance of 0.77, 0.76, 0.75.
 # In this setting a relevance of 0.75 is defined as, 75% of all employers issuing the query
 # considered the applicant relevant.
 #
@@ -42,7 +44,7 @@ from fairlearn.metrics import MetricFrame
 
 
 ranking_pred = [1, 2, 3, 4, 5, 6]  # ranking
-gender = ['Male', 'Male', 'Male', 'Female', 'Female', 'Female']
+gender = ['Man', 'Man', 'Man', 'Woman', 'Woman', 'Woman']
 y_true = [0.82, 0.81, 0.80, 0.79, 0.78, 0.77]
 
 # %%
@@ -54,7 +56,7 @@ y_true = [0.82, 0.81, 0.80, 0.79, 0.78, 0.77]
 #   standard exposure drop-off of :math:`1/log_2(1+j)` as used in Discounted Cumulative Gain
 #   (`DCG <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.dcg_score.html>`_)
 #   , to account for position bias. If there are big differences in exposure this could be an
-#   indication of allocation harm, i.e. males are on average ranked way higher than females by the
+#   indication of allocation harm, i.e. men are on average ranked way higher than women by the
 #   web-service.
 #
 # - The :func:`fairlearn.metrics.utility` metric indicates the average "ground-truth" relevance of
@@ -100,12 +102,12 @@ mf.ratio()
 # proportional exposure is not equal (plot 3)
 
 # %%
-# How can we fix this? A simple solution is to rerank the items, in such a way that females get
-# more exposure and males get less exposure. For example we can swap the top male with the top
-# female applicant and remeasure the quality-of-service harm.
+# How can we fix this? A simple solution is to rerank the items, in such a way that women get
+# more exposure and men get less exposure. For example we can swap the top man with the top
+# woman and remeasure the quality-of-service harm.
 
 ranking_pred = [1, 2, 3, 4, 5, 6]  # ranking
-gender = ['Female', 'Male', 'Male', 'Male', 'Female', 'Female']
+gender = ['Woman', 'Man', 'Man', 'Man', 'Woman', 'Woman']
 y_true = [0.79, 0.81, 0.80, 0.82, 0.78, 0.77]  # Continuous relevance score
 
 # Analyze metrics using MetricFrame

--- a/examples/plot_ranking.py
+++ b/examples/plot_ranking.py
@@ -1,0 +1,43 @@
+# Copyright (c) Fairlearn contributors.
+# Licensed under the MIT License.
+
+"""
+=========================================
+Ranking
+=========================================
+"""
+
+from fairlearn.metrics import exposure, utility, exposure_utility_ratio
+from fairlearn.metrics import MetricFrame
+
+ranking_pred = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]  # ranking
+sex = ['Male', 'Male', 'Male', 'Female', 'Male', 'Female', 'Female', 'Female', 'Male', 'Female']
+y_true = [1, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1]  # Continuous relevance score
+
+# Also works with binary relevance scores:
+# y_true = [1,1,1,0,1,1,1,0,0,1]  # Binary: Was the recommendation relevant?
+
+# Analyze metrics using MetricFrame
+# Careful that in contrast to the classification problem, y_pred now requires a ranking
+metrics = {
+    'exposure (allocation harm)': exposure,
+    'average utility': utility,
+    'exposure/utility (quality_of_service)': exposure_utility_ratio
+}
+
+mf = MetricFrame(metrics=metrics,
+                 y_true=y_true,
+                 y_pred=ranking_pred,
+                 sensitive_features={'sex': sex})
+
+# Customize the plot
+mf.by_group.plot(
+    kind="bar",
+    subplots=True,
+    layout=[1, 3],
+    legend=False,
+    figsize=(12, 4)
+)
+
+# Show the ratio of the metrics, 0 equals unfair and 1 equals fair.
+mf.ratio()

--- a/examples/plot_ranking.py
+++ b/examples/plot_ranking.py
@@ -13,7 +13,8 @@ from fairlearn.metrics import MetricFrame
 # %%
 # This notebook shows how to apply functionalities of :mod:`fairlearn.metrics` to ranking problems.
 # We showcase the example "Fairly Allocating Economic Opportunity" from the paper
-# "Fairness of Exposure in Ranking" by Singh and Joachims (2018).
+# `"Fairness of Exposure in Ranking" <https://dl.acm.org/doi/10.1145/3219819.3220088>`_
+# by Singh and Joachims (2018).
 # The example demonstrates how small differences in item relevance can lead to large differences
 # in exposure. Differences in exposure can be harmful not only because you are ranking individuals
 # directly but individuals can also be indirect affected by a ranking, think about books, music or
@@ -51,7 +52,7 @@ y_true = [0.82, 0.81, 0.80, 0.79, 0.78, 0.77]
 #   items, based on their position in the ranking. Exposure is the value that we assign to every
 #   place in the ranking, calculated by a
 #   standard exposure drop-off of :math:`1/log_2(1+j)` as used in Discounted Cumulative Gain
-#   :ref:`(DCG) <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.dcg_score.html>`
+#   (`DCG <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.dcg_score.html>`_)
 #   , to account for position bias. If there are big differences in exposure this could be an
 #   indication of allocation harm, i.e. males are on average ranked way higher than females by the
 #   web-service.
@@ -59,10 +60,10 @@ y_true = [0.82, 0.81, 0.80, 0.79, 0.78, 0.77]
 # - The :func:`fairlearn.metrics.utility` metric indicates the average "ground-truth" relevance of
 #   a group.
 #
-# - The :func:`exposure_utility_ratio` metric computes the average exposure of a group, divided by
-#   its utility (i.e., average relevance). Differences between groups indicate that the exposure of
-#   some groups is not proportional to their ground-truth utility, which can be seen as a measure
-#   of quality-of-service harm.
+# - The :func:`fairlearn.metrics.exposure_utility_ratio` metric computes the average exposure of a
+#   group, divided by its utility (i.e., average relevance). Differences between groups indicate
+#   that the exposure of some groups is not proportional to their ground-truth utility, which can
+#   be seen as a measure of quality-of-service harm.
 #
 # We can compare ranking metrics across groups using :class:`fairlearn.metrics.MetricFrame`.
 
@@ -88,7 +89,7 @@ mf.by_group.plot(
 
 # %%
 # We can compute the minimum ratio between groups using
-# :meth:`MetricFrame.ratio(method='between_groups')`. The closer the ratio is to 1 the more fair
+# :func:`fairlearn.metrics.MetricFrame.ratio`. The closer the ratio is to 1 the more fair
 # the ranking is.
 mf.ratio()
 

--- a/examples/plot_ranking.py
+++ b/examples/plot_ranking.py
@@ -11,42 +11,60 @@ from fairlearn.metrics import exposure, utility, exposure_utility_ratio
 from fairlearn.metrics import MetricFrame
 
 # %%
-# This notebook shows how to use Fairlearn with rankings. We showcase the example "Fairly
-# Allocating Economic Opportunity" from the paper "Fairness of Exposure in Ranking" by Singh and
-# Joachims (2018).
+# This notebook shows how to apply functionalities of :mod:`fairlearn.metrics` to ranking problems.
+# We showcase the example "Fairly Allocating Economic Opportunity" from the paper
+# "Fairness of Exposure in Ranking" by Singh and Joachims (2018).
 # The example demonstrates how small differences in item relevance can lead to large differences
-# in exposure.
+# in exposure. Differences in exposure can be harmful not only because you are ranking individuals
+# directly but individuals can also be indirect affected by a ranking, think about books, music or
+# products in online retail.
 #
-# Consider a web-service that connects employers (users) to potential employees (items).
-# The web-service uses a ranking-kased system to present a set of 6 applicants of which 3 are male
+# We reproduce the example of the paper, which for simplicity reasons uses a binary gender category
+# as sensitive attribute. The metric however also works for multi-class sensitive attributes.
+#
+# Consider a web-service that connects employers ("users") to potential employees ("items").
+# The web-service uses a ranking-based system to present a set of 6 applicants of which 3 are male
 # and 3 are female. Male applicants have relevance of 0.80, 0.79, 0.78 respectively for the
 # employer, while female applicants have relevance of 0.77, 0.76, 0.75.
-# In this setting a relevance of 0.75 is defined as, 75% of all employers issuing the query found
-# the applicant relevant.
+# In this setting a relevance of 0.75 is defined as, 75% of all employers issuing the query
+# considered the applicant relevant.
 #
 # The Probability Ranking Principle suggests to rank the applicants in decreasing order of
 # relevance. What does this mean for the exposure between the two groups?
+#
+# NOTE: The used data should raise questions about
+# :ref:`construct validity <fairness_in_machine_learning.construct-validity>` , since we
+# should consider whether the "relevance" that is in the data is a good measurement of the actual
+# relevance. Hindsight bias is also a concern, since how can you know upfront if an applicant
+# will be a successful employee in the future? These concerns are important, but out of scope for
+# this use case example.
+
 
 ranking_pred = [1, 2, 3, 4, 5, 6]  # ranking
-sex = ['Male', 'Male', 'Male', 'Female', 'Female', 'Female']
+gender = ['Male', 'Male', 'Male', 'Female', 'Female', 'Female']
 y_true = [0.82, 0.81, 0.80, 0.79, 0.78, 0.77]
 
 # %%
 # Here we define what metrics we want to analyze.
 #
-# - The `exposure` metric shows the average exposure that each group gets, based on their position
-#   biases. Exposure is the value that we assign to every place in the ranking, calculated by a
-#   standard exposure drop-off of :math:`1/log_2(1+j)` as used in Discounted Cumulative Gain (DCG),
-#   to account for position bias. If there are big differences in exposure
-#   we could say that there is allocation harm in the data, i.e. males are on average ranked way
-#   higher than females by the web-service.
+# - The :func:`fairlearn.metrics.exposure` metric measures the average exposure of a group of
+#   items, based on their position in the ranking. Exposure is the value that we assign to every
+#   place in the ranking, calculated by a
+#   standard exposure drop-off of :math:`1/log_2(1+j)` as used in Discounted Cumulative Gain
+#   :ref:`(DCG) <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.dcg_score.html>`
+#   , to account for position bias. If there are big differences in exposure this could be an
+#   indication of allocation harm, i.e. males are on average ranked way higher than females by the
+#   web-service.
 #
-# - The `utility` metric shows the average relevance that each group has.
+# - The :func:`fairlearn.metrics.utility` metric indicates the average "ground-truth" relevance of
+#   a group.
 #
-# - The `exposure_utility_ratio` metric shows quality-of-service harms in the data. Since it shows
-#   what the average exposure of each group is compared to its relevance. If there a big
-#   differences in this metric we could say that the exposure of some sensitive groups is not
-#   proportional to its utility.
+# - The :func:`exposure_utility_ratio` metric computes the average exposure of a group, divided by
+#   its utility (i.e., average relevance). Differences between groups indicate that the exposure of
+#   some groups is not proportional to their ground-truth utility, which can be seen as a measure
+#   of quality-of-service harm.
+#
+# We can compare ranking metrics across groups using :class:`fairlearn.metrics.MetricFrame`.
 
 metrics = {
     'exposure (allocation harm)': exposure,
@@ -57,7 +75,7 @@ metrics = {
 mf = MetricFrame(metrics=metrics,
                  y_true=y_true,
                  y_pred=ranking_pred,
-                 sensitive_features={'sex': sex})
+                 sensitive_features={'gender': gender})
 
 # Customize the plot
 mf.by_group.plot(
@@ -68,25 +86,26 @@ mf.by_group.plot(
     figsize=(12, 4)
 )
 
-# Show the ratio of the metrics, 0 equals unfair and 1 equals fair.
+# %%
+# We can compute the minimum ratio between groups using
+# :meth:`MetricFrame.ratio(method='between_groups')`. The closer the ratio is to 1 the more fair
+# the ranking is.
 mf.ratio()
 
 # %%
 # The first plot shows that the web-service that men get significantly more exposure than women.
-# Although the second plot shows that the utility of females is comparable to the males group.
+# Although the second plot shows that the average utility of women is comparable to men.
 # Therefor we can say that the ranking contains quality-of-service harm against women, since the
 # exposure/utility ratio is not equal (plot 3)
 
 # %%
 # How can we fix this? A simple solution is to rerank the items, in such a way that females get
-# more exposure and males get less exposure. For example we can switch the top male with the top
+# more exposure and males get less exposure. For example we can swap the top male with the top
 # female applicant and remeasure the quality-of-service harm.
 
 ranking_pred = [1, 2, 3, 4, 5, 6]  # ranking
-sex = ['Female', 'Male', 'Male', 'Male', 'Female', 'Female']
+gender = ['Female', 'Male', 'Male', 'Male', 'Female', 'Female']
 y_true = [0.79, 0.81, 0.80, 0.82, 0.78, 0.77]  # Continuous relevance score
-
-print(len(ranking_pred), len(sex), len(y_true))
 
 # Analyze metrics using MetricFrame
 # Careful that in contrast to the classification problem, y_pred now requires a ranking
@@ -99,7 +118,7 @@ metrics = {
 mf = MetricFrame(metrics=metrics,
                  y_true=y_true,
                  y_pred=ranking_pred,
-                 sensitive_features={'sex': sex})
+                 sensitive_features={'gender': gender})
 
 # Customize the plot
 mf.by_group.plot(
@@ -110,8 +129,9 @@ mf.by_group.plot(
     figsize=(12, 4)
 )
 
-# Show the ratio of the metrics, 0 equals unfair and 1 equals fair.
 mf.ratio()
 
 # %%
-# The new plots show that the exposure and exposure/utility ratio are now much more equal.
+# The new plots show that the exposure and exposure/utility ratio are now much more equal. The
+# difference in exposure allocation is much smaller and the quality-of-service is better
+# in proportion to the group's average utility.

--- a/examples/plot_ranking.py
+++ b/examples/plot_ranking.py
@@ -7,7 +7,7 @@ Ranking
 =========================================
 """
 
-from fairlearn.metrics import exposure, utility, exposure_utility_ratio
+from fairlearn.metrics import exposure, utility, proportional_exposure
 from fairlearn.metrics import MetricFrame
 
 # %%
@@ -30,8 +30,8 @@ from fairlearn.metrics import MetricFrame
 # In this setting a relevance of 0.75 is defined as, 75% of all employers issuing the query
 # considered the applicant relevant.
 #
-# The Probability Ranking Principle suggests to rank the applicants in decreasing order of
-# relevance. What does this mean for the exposure between the two groups?
+# A simple way to rank the participants is in decreasing order of relevance. What does this mean
+# for the exposure between the two groups?
 #
 # NOTE: The used data should raise questions about
 # :ref:`construct validity <fairness_in_machine_learning.construct-validity>` , since we
@@ -60,7 +60,7 @@ y_true = [0.82, 0.81, 0.80, 0.79, 0.78, 0.77]
 # - The :func:`fairlearn.metrics.utility` metric indicates the average "ground-truth" relevance of
 #   a group.
 #
-# - The :func:`fairlearn.metrics.exposure_utility_ratio` metric computes the average exposure of a
+# - The :func:`fairlearn.metrics.proportional_exposure` metric computes the average exposure of a
 #   group, divided by its utility (i.e., average relevance). Differences between groups indicate
 #   that the exposure of some groups is not proportional to their ground-truth utility, which can
 #   be seen as a measure of quality-of-service harm.
@@ -70,7 +70,7 @@ y_true = [0.82, 0.81, 0.80, 0.79, 0.78, 0.77]
 metrics = {
     'exposure (allocation harm)': exposure,
     'average utility': utility,
-    'exposure/utility (quality-of-service)': exposure_utility_ratio
+    'proportional exposure (quality-of-service)': proportional_exposure
 }
 
 mf = MetricFrame(metrics=metrics,
@@ -97,7 +97,7 @@ mf.ratio()
 # The first plot shows that the web-service that men get significantly more exposure than women.
 # Although the second plot shows that the average utility of women is comparable to men.
 # Therefor we can say that the ranking contains quality-of-service harm against women, since the
-# exposure/utility ratio is not equal (plot 3)
+# proportional exposure is not equal (plot 3)
 
 # %%
 # How can we fix this? A simple solution is to rerank the items, in such a way that females get
@@ -113,7 +113,7 @@ y_true = [0.79, 0.81, 0.80, 0.82, 0.78, 0.77]  # Continuous relevance score
 metrics = {
     'exposure (allocation harm)': exposure,
     'average utility': utility,
-    'exposure/utility (quality_of_service)': exposure_utility_ratio
+    'proportional exposure (quality-of-service)': proportional_exposure
 }
 
 mf = MetricFrame(metrics=metrics,
@@ -133,6 +133,11 @@ mf.by_group.plot(
 mf.ratio()
 
 # %%
-# The new plots show that the exposure and exposure/utility ratio are now much more equal. The
+# The new plots show that the exposure and proportional exposure are now much more equal. The
 # difference in exposure allocation is much smaller and the quality-of-service is better
 # in proportion to the group's average utility.
+#
+# This was a simple example using fabricated data, just to show what the exposure metrics are
+# capable of measuring. Manually switching of people in a ranking is however not recommendable with
+# real world larger data sets. There we would recommend mitigation techniques, that are
+# unfortunately not yet implemented in Fairlearn.

--- a/examples/plot_ranking.py
+++ b/examples/plot_ranking.py
@@ -10,12 +10,83 @@ Ranking
 from fairlearn.metrics import exposure, utility, exposure_utility_ratio
 from fairlearn.metrics import MetricFrame
 
-ranking_pred = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]  # ranking
-sex = ['Male', 'Male', 'Male', 'Female', 'Male', 'Female', 'Female', 'Female', 'Male', 'Female']
-y_true = [1, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1]  # Continuous relevance score
+# %%
+# This notebook shows how to use Fairlearn with rankings. We showcase the example "Fairly
+# Allocating Economic Opportunity" from the paper "Fairness of Exposure in Ranking" by Singh and
+# Joachims (2018).
+# The example demonstrates how small differences in item relevance can lead to large differences
+# in exposure.
+#
+# Consider a web-service that connects employers (users) to potential employees (items).
+# The web-service uses a ranking-kased system to present a set of 6 applicants of which 3 are male
+# and 3 are female. Male applicants have relevance of 0.80, 0.79, 0.78 respectively for the
+# employer, while female applicants have relevance of 0.77, 0.76, 0.75.
+# In this setting a relevance of 0.75 is defined as, 75% of all employers issuing the query found
+# the applicant relevant.
+#
+# The Probability Ranking Principle suggests to rank the applicants in decreasing order of
+# relevance. What does this mean for the exposure between the two groups?
 
-# Also works with binary relevance scores:
-# y_true = [1,1,1,0,1,1,1,0,0,1]  # Binary: Was the recommendation relevant?
+ranking_pred = [1, 2, 3, 4, 5, 6]  # ranking
+sex = ['Male', 'Male', 'Male', 'Female', 'Female', 'Female']
+y_true = [0.82, 0.81, 0.80, 0.79, 0.78, 0.77]
+
+# %%
+# Here we define what metrics we want to analyze.
+#
+# - The `exposure` metric shows the average exposure that each group gets, based on their position
+#   biases. Exposure is the value that we assign to every place in the ranking, calculated by a
+#   standard exposure drop-off of :math:`1/log_2(1+j)` as used in Discounted Cumulative Gain (DCG),
+#   to account for position bias. If there are big differences in exposure
+#   we could say that there is allocation harm in the data, i.e. males are on average ranked way
+#   higher than females by the web-service.
+#
+# - The `utility` metric shows the average relevance that each group has.
+#
+# - The `exposure_utility_ratio` metric shows quality-of-service harms in the data. Since it shows
+#   what the average exposure of each group is compared to its relevance. If there a big
+#   differences in this metric we could say that the exposure of some sensitive groups is not
+#   proportional to its utility.
+
+metrics = {
+    'exposure (allocation harm)': exposure,
+    'average utility': utility,
+    'exposure/utility (quality-of-service)': exposure_utility_ratio
+}
+
+mf = MetricFrame(metrics=metrics,
+                 y_true=y_true,
+                 y_pred=ranking_pred,
+                 sensitive_features={'sex': sex})
+
+# Customize the plot
+mf.by_group.plot(
+    kind="bar",
+    subplots=True,
+    layout=[1, 3],
+    legend=False,
+    figsize=(12, 4)
+)
+
+# Show the ratio of the metrics, 0 equals unfair and 1 equals fair.
+mf.ratio()
+
+# %%
+# The first plot shows that the web-service that men get significantly more exposure than women.
+# Although the second plot shows that the utility of females is comparable to the males group.
+# Therefor we can say that the ranking contains quality-of-service harm against women, since the
+# exposure/utility ratio is not equal (plot 3)
+
+# %%
+# How can we fix this? A simple solution is to rerank the items, in such a way that females get
+# more exposure and males get less exposure. For example we can switch the top male with the top
+# female applicant and remeasure the quality-of-service harm.
+
+ranking_pred = [1, 2, 3, 4, 5, 6]  # ranking
+sex = ['Female', 'Male', 'Male', 'Male', 'Female', 'Female']
+y_true = [0.79, 0.81, 0.80, 0.82, 0.78, 0.77]  # Continuous relevance score
+
+print(len(ranking_pred), len(sex), len(y_true))
 
 # Analyze metrics using MetricFrame
 # Careful that in contrast to the classification problem, y_pred now requires a ranking
@@ -41,3 +112,6 @@ mf.by_group.plot(
 
 # Show the ratio of the metrics, 0 equals unfair and 1 equals fair.
 mf.ratio()
+
+# %%
+# The new plots show that the exposure and exposure/utility ratio are now much more equal.

--- a/fairlearn/metrics/__init__.py
+++ b/fairlearn/metrics/__init__.py
@@ -48,6 +48,14 @@ from ._extra_metrics import (  # noqa: F401
     _mean_underprediction,
     count)
 
+from ._exposure import (  # noqa: F401
+    exposure,
+    allocation_harm_in_ranking_difference,
+    allocation_harm_in_ranking_ratio,
+    quality_of_service_harm_in_ranking_difference,
+    quality_of_service_harm_in_ranking_ratio
+)
+
 
 # Add the generated metrics of the form and
 # `<metric>_{difference,ratio,group_min,group_max`
@@ -67,7 +75,7 @@ _disparities = [
     "demographic_parity_difference",
     "demographic_parity_ratio",
     "equalized_odds_difference",
-    "equalized_odds_ratio"
+    "equalized_odds_ratio",
 ]
 
 _extra_metrics = [
@@ -80,4 +88,13 @@ _extra_metrics = [
     "count"
 ]
 
-__all__ = _core + _disparities + _extra_metrics + list(sorted(_generated_metric_dict.keys()))
+_ranking_metrics = {
+    "exposure"
+    "allocation_harm_in_ranking_difference",
+    "allocation_harm_in_ranking_ratio",
+    "quality_of_service_harm_in_ranking_difference",
+    "quality_of_service_harm_in_ranking_ratio"
+}
+
+__all__ = _core + _disparities + _extra_metrics + _ranking_metrics \
+          + list(sorted(_generated_metric_dict.keys()))

--- a/fairlearn/metrics/__init__.py
+++ b/fairlearn/metrics/__init__.py
@@ -77,7 +77,11 @@ _disparities = [
     "demographic_parity_difference",
     "demographic_parity_ratio",
     "equalized_odds_difference",
-    "equalized_odds_ratio"
+    "equalized_odds_ratio",
+    "allocation_harm_in_ranking_difference",
+    "allocation_harm_in_ranking_ratio",
+    "quality_of_service_harm_in_ranking_difference",
+    "quality_of_service_harm_in_ranking_ratio"
 ]
 
 _extra_metrics = [
@@ -91,13 +95,9 @@ _extra_metrics = [
 ]
 
 _ranking_metrics = [
-    "exposure"
-    "utility"
+    "exposure",
+    "utility",
     "exposure_utility_ratio"
-    "allocation_harm_in_ranking_difference",
-    "allocation_harm_in_ranking_ratio",
-    "quality_of_service_harm_in_ranking_difference",
-    "quality_of_service_harm_in_ranking_ratio"
 ]
 
 __all__ = _core + _disparities + _extra_metrics + _ranking_metrics \

--- a/fairlearn/metrics/__init__.py
+++ b/fairlearn/metrics/__init__.py
@@ -51,11 +51,11 @@ from ._extra_metrics import (  # noqa: F401
 from ._exposure import (  # noqa: F401
     exposure,
     utility,
-    exposure_utility_ratio,
-    allocation_harm_in_ranking_difference,
-    allocation_harm_in_ranking_ratio,
-    quality_of_service_harm_in_ranking_difference,
-    quality_of_service_harm_in_ranking_ratio
+    proportional_exposure,
+    exposure_difference,
+    exposure_ratio,
+    proportional_exposure_difference,
+    proportional_exposure_ratio
 )
 
 
@@ -81,7 +81,11 @@ _disparities = [
     "allocation_harm_in_ranking_difference",
     "allocation_harm_in_ranking_ratio",
     "quality_of_service_harm_in_ranking_difference",
-    "quality_of_service_harm_in_ranking_ratio"
+    "quality_of_service_harm_in_ranking_ratio",
+    "exposure_difference",
+    "exposure_ratio",
+    "proportional_exposure_difference",
+    "proportional_exposure_ratio"
 ]
 
 _extra_metrics = [
@@ -97,7 +101,7 @@ _extra_metrics = [
 _ranking_metrics = [
     "exposure",
     "utility",
-    "exposure_utility_ratio"
+    "proportional_exposure"
 ]
 
 __all__ = _core + _disparities + _extra_metrics + _ranking_metrics \

--- a/fairlearn/metrics/__init__.py
+++ b/fairlearn/metrics/__init__.py
@@ -50,6 +50,8 @@ from ._extra_metrics import (  # noqa: F401
 
 from ._exposure import (  # noqa: F401
     exposure,
+    utility,
+    exposure_utility_ratio,
     allocation_harm_in_ranking_difference,
     allocation_harm_in_ranking_ratio,
     quality_of_service_harm_in_ranking_difference,
@@ -75,7 +77,7 @@ _disparities = [
     "demographic_parity_difference",
     "demographic_parity_ratio",
     "equalized_odds_difference",
-    "equalized_odds_ratio",
+    "equalized_odds_ratio"
 ]
 
 _extra_metrics = [
@@ -88,13 +90,15 @@ _extra_metrics = [
     "count"
 ]
 
-_ranking_metrics = {
+_ranking_metrics = [
     "exposure"
+    "utility"
+    "exposure_utility_ratio"
     "allocation_harm_in_ranking_difference",
     "allocation_harm_in_ranking_ratio",
     "quality_of_service_harm_in_ranking_difference",
     "quality_of_service_harm_in_ranking_ratio"
-}
+]
 
 __all__ = _core + _disparities + _extra_metrics + _ranking_metrics \
           + list(sorted(_generated_metric_dict.keys()))

--- a/fairlearn/metrics/_exposure.py
+++ b/fairlearn/metrics/_exposure.py
@@ -39,6 +39,10 @@ def exposure(y_true,
     if len(set(y_pred)) != len(y_pred):  # check for repetition in input ranking
         raise ValueError(_INVALID_RANKING_ERROR_MESSAGE)
 
+    # ranking should start by 1, to prevent zero division.
+    if 0 in y_pred:
+        y_pred = [x+1 for x in y_pred]
+
     y_pred = _convert_to_ndarray_and_squeeze(y_pred)
     v = [1 / np.log2(1 + j) for j in y_pred]  # logarithmic discount
 

--- a/fairlearn/metrics/_exposure.py
+++ b/fairlearn/metrics/_exposure.py
@@ -1,0 +1,279 @@
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
+# Licensed under the MIT License.
+
+import numpy as np
+from typing import Any
+
+from fairlearn.metrics._input_manipulations import _convert_to_ndarray_and_squeeze
+from ._metric_frame import MetricFrame
+
+_EMPTY_INPUT_PREDICTIONS_ERROR_MESSAGE = "Empty {0} passed to exposure function."
+_INVALID_RANKING_ERROR_MESSAGE = "Please input a valid complete ranking."
+
+
+def exposure(y_true,
+             y_pred,
+             *,
+             pos_label: Any = 1,
+             sample_weight=None) -> float:
+    """Calculate the exposure allocated to the ranking in y_pred.
+
+    For consistency with other metric functions, the ``y_true`` and ``pos_label`` arguments
+    are required, but ignored.
+
+
+    Parameters
+    ----------
+    y_true : array_like
+        The true ranking (ignored)
+    y_pred : array_like
+        The predicted ranking
+    pos_label : Scalar
+        The label to treat as the 'good' outcome (ignored)
+    sample_weight : array_like
+        Optional array of sample weights
+    """
+    if len(y_pred) == 0:
+        raise ValueError(_EMPTY_INPUT_PREDICTIONS_ERROR_MESSAGE.format('y_pred'))
+
+    if len(set(y_pred)) != len(y_pred):  # check for repetition in input ranking
+        raise ValueError(_INVALID_RANKING_ERROR_MESSAGE)
+
+    y_pred = _convert_to_ndarray_and_squeeze(y_pred)
+    v = [1 / np.log2(1 + j) for j in y_pred]  # logarithmic discount
+
+    s_w = np.ones(len(y_pred))
+    if sample_weight is not None:
+        s_w = np.squeeze(np.asarray(sample_weight))
+
+    return np.dot(v, s_w).sum()
+
+
+def utility(y_true,
+            y_pred,
+            *,
+            pos_label: Any = 1,
+            sample_weight=None) -> float:
+    """Calculate the exposure allocated to the ranking in y_pred.
+
+    For consistency with other metric functions, the ``y_true`` and ``pos_label`` arguments
+    are required, but ignored.
+
+
+    Parameters
+    ----------
+    y_true : array_like
+        The utility
+    y_pred : array_like
+        The predicted ranking
+    pos_label : Scalar
+        The label to treat as the 'good' outcome (ignored)
+    sample_weight : array_like
+        Optional array of sample weights
+    """
+    if len(y_true) == 0:
+        raise ValueError(_EMPTY_INPUT_PREDICTIONS_ERROR_MESSAGE.format('y_true'))
+
+    u = _convert_to_ndarray_and_squeeze(y_true)
+
+    s_w = np.ones(len(u))
+    if sample_weight is not None:
+        s_w = np.squeeze(np.asarray(sample_weight))
+
+    return np.dot(u, s_w).sum() / len(u)
+
+
+def exposure_utility_ratio(
+        y_true,
+        y_pred,
+        *,
+        pos_label: Any = 1,
+        sample_weight=None) -> float:
+    """Calculate the exposure allocated to the ranking in y_pred.
+
+    For consistency with other metric functions, the ``y_true`` and ``pos_label`` arguments
+    are required, but ignored.
+
+
+    Parameters
+    ----------
+    y_true : array_like
+        The utility
+    y_pred : array_like
+        The predicted ranking
+    pos_label : Scalar
+        The label to treat as the 'good' outcome (ignored)
+    sample_weight : array_like
+        Optional array of sample weights
+    """
+    e = exposure(y_true, y_pred, sample_weight=sample_weight)
+    u = utility(y_true, y_pred, sample_weight=sample_weight)
+    return e / u
+
+
+def allocation_harm_in_ranking_difference(
+        y_true,
+        y_pred,
+        *,
+        sensitive_features,
+        method='between_groups',
+        sample_weight=None) -> float:
+    """Calculate the difference in exposure allocation.
+
+    The exposure allocation difference is defined as the difference
+    between the largest and the smallest group-level exposure,
+    The exposure allocation difference of 0 means that all groups have the same exposure.
+
+
+    Parameters
+    ----------
+    y_true : array-like
+        Ground truth (correct) labels.
+    y_pred : array-like
+        Predicted ranking
+    sensitive_features :
+        The sensitive features over which demographic parity should be assessed
+    method : str
+        How to compute the differences. See :func:`fairlearn.metrics.MetricFrame.difference`
+        for details.
+    sample_weight : array-like
+        The sample weights
+
+    Returns
+    -------
+    float
+        The exposure difference
+    """
+    exposure_mf = MetricFrame(metrics=exposure,
+                              y_true=y_true,
+                              y_pred=y_pred,
+                              sensitive_features=sensitive_features,
+                              sample_params={'sample_weight': sample_weight})
+    result = exposure_mf.difference(method=method)
+    return result
+
+
+def allocation_harm_in_ranking_ratio(
+        y_true,
+        y_pred,
+        *,
+        sensitive_features,
+        method='between_groups',
+        sample_weight=None) -> float:
+    """Calculate the exposure allocation ratio.
+
+    The exposure allocation ratio is defined as the ratio
+    between the largest and the smallest group-level exposure,
+    The exposure allocation ratio of 1 means that all groups have the same exposure.
+
+
+    Parameters
+    ----------
+    y_true : array-like
+        Ground truth (correct) labels.
+    y_pred : array-like
+        Predicted ranking
+    sensitive_features :
+        The sensitive features over which demographic parity should be assessed
+    method : str
+        How to compute the differences. See :func:`fairlearn.metrics.MetricFrame.ratio`
+        for details.
+    sample_weight : array-like
+        The sample weights
+
+    Returns
+    -------
+    float
+        The exposure ratio
+    """
+    exposure_mf = MetricFrame(metrics=exposure,
+                              y_true=y_true,
+                              y_pred=y_pred,
+                              sensitive_features=sensitive_features,
+                              sample_params={'sample_weight': sample_weight})
+    result = exposure_mf.ratio(method=method)
+    return result
+
+
+def quality_of_service_harm_in_ranking_difference(
+        y_true,
+        y_pred,
+        *,
+        sensitive_features,
+        method='between_groups',
+        sample_weight=None) -> float:
+    """Calculate the quality of service harm ratio between the best and worst serviced groups.
+
+    Quality-of-service is defined as the exposure that a group gets divided by their average
+    relevance.
+    The quality-of-service ratio of 1 means that all groups have the same exposure.
+
+
+    Parameters
+    ----------
+    y_true : array-like
+        Ground truth (correct) labels.
+    y_pred : array-like
+        Predicted labels :math:`h(X)` returned by the classifier.
+    sensitive_features :
+        The sensitive features over which demographic parity should be assessed
+    method : str
+        How to compute the differences. See :func:`fairlearn.metrics.MetricFrame.difference`
+        for details.
+    sample_weight : array-like
+        The sample weights
+
+    Returns
+    -------
+    float
+        The exposure/utility difference
+    """
+    mf = MetricFrame(metrics=exposure_utility_ratio,
+                     y_true=y_true,
+                     y_pred=y_pred,
+                     sensitive_features=sensitive_features,
+                     sample_params={'sample_weight': sample_weight})
+    result = mf.difference(method=method)
+    return result
+
+
+def quality_of_service_harm_in_ranking_ratio(
+        y_true,
+        y_pred,
+        *,
+        sensitive_features,
+        method='between_groups',
+        sample_weight=None) -> float:
+    """Calculate the quality of service harm ratio between the best and worst serviced groups.
+
+    Quality-of-service is defined as the exposure that a group gets divided by their average
+    relevance.
+    The quality-of-service ratio of 1 means that all groups have the same exposure.
+
+
+    Parameters
+    ----------
+    y_true : array-like
+        Ground truth (correct) labels.
+    y_pred : array-like
+        Predicted ranking
+    sensitive_features :
+        The sensitive features over which demographic parity should be assessed
+    method : str
+        How to compute the differences. See :func:`fairlearn.metrics.MetricFrame.ratio`
+        for details.
+    sample_weight : array-like
+        The sample weights
+
+    Returns
+    -------
+    float
+        The exposure/utility ratio
+    """
+    mf = MetricFrame(metrics=exposure_utility_ratio,
+                     y_true=y_true,
+                     y_pred=y_pred,
+                     sensitive_features=sensitive_features,
+                     sample_params={'sample_weight': sample_weight})
+    result = mf.ratio(method=method)
+    return result

--- a/fairlearn/metrics/_exposure.py
+++ b/fairlearn/metrics/_exposure.py
@@ -17,7 +17,8 @@ def exposure(y_true,
     """Calculate the exposure allocated to the ranking in y_pred.
 
     Exposure is defined as the average logarithmic discount, where
-    logarithmic discount = 1 / log2 (1 + i) for i in y_pred.
+    logarithmic discount equals :math:`1 / log_2 (1 + i)` for i in y_pred, as used
+    in discounted cumulative gain (DCG).
 
     For consistency with other metric functions, the ``y_true`` argument
     is required, but ignored.
@@ -26,7 +27,7 @@ def exposure(y_true,
     Parameters
     ----------
     y_true : array_like
-        The true ranking (ignored)
+        Ground truth relevance scores. (ignored)
     y_pred : array_like
         The predicted ranking
     sample_weight : array_like
@@ -52,18 +53,21 @@ def utility(y_true,
             y_pred,
             *,
             sample_weight=None) -> float:
-    """Calculate the average utility of the ranking in y_pred.
+    """Calculate the utility of the ranking.
 
     Utility is defined as the average of y_true.
 
-    For consistency with other metric functions, the ``y_pred`` arguments
+    The goal of this metric is to be used in the `exposure_utility_ratio` metric. Where we try
+    to keep the `exposure` proportional to the `utility`.
+
+    For consistency with other metric functions, the ``y_pred`` argument
     is required, but ignored.
 
 
     Parameters
     ----------
     y_true : array_like
-        The utility
+        Ground truth relevance scores.
     y_pred : array_like
         The predicted ranking (ignored)
     sample_weight : array_like
@@ -88,6 +92,19 @@ def exposure_utility_ratio(
         sample_weight=None) -> float:
     """Calculate the exposure utility ratio of the ranking in y_pred.
 
+    Where we use the two metrics:: func:`fairlearn.metrics.exposure` and
+    func:`fairlearn.metrics.utility`.
+
+    Exposure is defined as the average logarithmic discount, where
+    logarithmic discount equals :math:`1 / log_2 (1 + i)` for i in y_pred, as used
+    in discounted cumulative gain (DCG).
+
+    Utility is defined as the average of y_true.
+
+    The goal of this metric is to measure the ratio between `utility` and `exposure`. Since in
+    ranking problems, an often occurring problem is that small differences in utility lead to
+    huge differences in exposure. See `user guide`.
+
     The exposure utility ratio is defined as the exposure of ``y_pred`` divided by the utility of
     ``y_true``.
 
@@ -95,7 +112,7 @@ def exposure_utility_ratio(
     Parameters
     ----------
     y_true : array_like
-        The utility
+        Ground truth relevance scores.
     y_pred : array_like
         The predicted ranking
     sample_weight : array_like
@@ -123,7 +140,7 @@ def allocation_harm_in_ranking_difference(
     Parameters
     ----------
     y_true : array-like
-        Ground truth (correct) labels.
+        Ground truth relevance scores.
     y_pred : array-like
         Predicted ranking
     sensitive_features :
@@ -165,7 +182,7 @@ def allocation_harm_in_ranking_ratio(
     Parameters
     ----------
     y_true : array-like
-        Ground truth (correct) labels.
+        Ground truth relevance scores.
     y_pred : array-like
         Predicted ranking
     sensitive_features :
@@ -207,7 +224,7 @@ def quality_of_service_harm_in_ranking_difference(
     Parameters
     ----------
     y_true : array-like
-        Ground truth (correct) labels.
+        Ground truth relevance scores.
     y_pred : array-like
         Predicted ranking
     sensitive_features :
@@ -249,7 +266,7 @@ def quality_of_service_harm_in_ranking_ratio(
     Parameters
     ----------
     y_true : array-like
-        Ground truth (correct) labels.
+        Ground truth relevance scores.
     y_pred : array-like
         Predicted ranking
     sensitive_features :

--- a/fairlearn/metrics/_exposure.py
+++ b/fairlearn/metrics/_exposure.py
@@ -8,6 +8,7 @@ from ._metric_frame import MetricFrame
 
 _EMPTY_INPUT_PREDICTIONS_ERROR_MESSAGE = "Empty {0} passed to exposure function."
 _INVALID_RANKING_ERROR_MESSAGE = "Please input a valid complete ranking."
+_ZERO_DIVISION_ERROR = "Average utility is 0, which causes a zero division error."
 
 
 def exposure(y_true,
@@ -124,6 +125,10 @@ def proportional_exposure(
     """
     e = exposure(y_true, y_pred, sample_weight=sample_weight)
     u = utility(y_true, y_pred, sample_weight=sample_weight)
+
+    if u == 0:
+        raise ZeroDivisionError(_ZERO_DIVISION_ERROR)
+
     return e / u
 
 

--- a/fairlearn/metrics/_exposure.py
+++ b/fairlearn/metrics/_exposure.py
@@ -85,12 +85,12 @@ def utility(y_true,
     return np.dot(u, s_w).sum() / len(u)
 
 
-def exposure_utility_ratio(
+def proportional_exposure(
         y_true,
         y_pred,
         *,
         sample_weight=None) -> float:
-    """Calculate the exposure utility ratio of the ranking in y_pred.
+    """Calculate the proportional exposure of the ranking in y_pred.
 
     Where we use the two metrics:: func:`fairlearn.metrics.exposure` and
     func:`fairlearn.metrics.utility`.
@@ -101,11 +101,11 @@ def exposure_utility_ratio(
 
     Utility is defined as the average of y_true.
 
-    The goal of this metric is to measure the ratio between `utility` and `exposure`. Since in
-    ranking problems, an often occurring problem is that small differences in utility lead to
+    The goal of this metric is to keep `utility` and `exposure` proportional to each other. Since
+    in ranking problems, an often occurring problem is that small differences in utility lead to
     huge differences in exposure. See `user guide`.
 
-    The exposure utility ratio is defined as the exposure of ``y_pred`` divided by the utility of
+    The proportional exposure is defined as the exposure of ``y_pred`` divided by the utility of
     ``y_true``.
 
 
@@ -123,18 +123,19 @@ def exposure_utility_ratio(
     return e / u
 
 
-def allocation_harm_in_ranking_difference(
+def exposure_difference(
         y_true,
         y_pred,
         *,
         sensitive_features,
         method='between_groups',
         sample_weight=None) -> float:
-    """Calculate the difference in exposure allocation.
+    """Calculate the difference in exposure allocation between groups.
 
     The exposure allocation difference is defined as the difference
-    between the largest and the smallest group-level exposure,
-    The exposure allocation difference of 0 means that all groups have the same exposure.
+    between the largest and the smallest group-level exposure.
+    The exposure allocation difference of 0 means that all groups have the same exposure. A high
+    exposure difference can be seen as an indication of allocation harm.
 
 
     Parameters
@@ -165,18 +166,19 @@ def allocation_harm_in_ranking_difference(
     return result
 
 
-def allocation_harm_in_ranking_ratio(
+def exposure_ratio(
         y_true,
         y_pred,
         *,
         sensitive_features,
         method='between_groups',
         sample_weight=None) -> float:
-    """Calculate the exposure allocation ratio.
+    """Calculate the ratio of exposure allocation between groups.
 
-    The exposure allocation ratio is defined as the ratio
-    between the largest and the smallest group-level exposure,
-    The exposure allocation ratio of 1 means that all groups have the same exposure.
+    The exposure ratio is defined as the ratio
+    between the largest and the smallest group-level exposure.
+    The exposure allocation ratio of 1 means that all groups have the same exposure. A low exposure
+    ratio can be seen as an indication of allocation harm.
 
 
     Parameters
@@ -207,18 +209,19 @@ def allocation_harm_in_ranking_ratio(
     return result
 
 
-def quality_of_service_harm_in_ranking_difference(
+def proportional_exposure_difference(
         y_true,
         y_pred,
         *,
         sensitive_features,
         method='between_groups',
         sample_weight=None) -> float:
-    """Calculate the quality of service harm ratio between the best and worst serviced groups.
+    """Calculate the proportional exposure difference between the best and worst serviced groups.
 
-    Quality-of-service is defined as the exposure that a group gets divided by their average
+    Proportional exposure is defined as the exposure that a group gets divided by their average
     relevance.
-    The quality-of-service ratio of 1 means that all groups have the same exposure.
+    The proportional exposure difference of 0 means that all groups have the same exposure. A large
+    difference can be seen as an indication of quality-of-service harm.
 
 
     Parameters
@@ -240,7 +243,7 @@ def quality_of_service_harm_in_ranking_difference(
     float
         The exposure/utility difference
     """
-    mf = MetricFrame(metrics=exposure_utility_ratio,
+    mf = MetricFrame(metrics=proportional_exposure,
                      y_true=y_true,
                      y_pred=y_pred,
                      sensitive_features=sensitive_features,
@@ -249,18 +252,19 @@ def quality_of_service_harm_in_ranking_difference(
     return result
 
 
-def quality_of_service_harm_in_ranking_ratio(
+def proportional_exposure_ratio(
         y_true,
         y_pred,
         *,
         sensitive_features,
         method='between_groups',
         sample_weight=None) -> float:
-    """Calculate the quality of service harm ratio between the best and worst serviced groups.
+    """Calculate the proportional exposure ratio between the best and worst serviced groups.
 
-    Quality-of-service is defined as the exposure that a group gets divided by their average
+    Proportional exposure is defined as the exposure that a group gets divided by their average
     relevance.
-    The quality-of-service ratio of 1 means that all groups have the same exposure.
+    The proportional exposure ratio of 1 means that all groups have the same exposure. A ratio
+    close to 0, can be seen as an indication of quality-of-service harm.
 
 
     Parameters
@@ -282,7 +286,7 @@ def quality_of_service_harm_in_ranking_ratio(
     float
         The exposure/utility ratio
     """
-    mf = MetricFrame(metrics=exposure_utility_ratio,
+    mf = MetricFrame(metrics=proportional_exposure,
                      y_true=y_true,
                      y_pred=y_pred,
                      sensitive_features=sensitive_features,

--- a/fairlearn/metrics/_exposure.py
+++ b/fairlearn/metrics/_exposure.py
@@ -127,7 +127,7 @@ def allocation_harm_in_ranking_difference(
     y_pred : array-like
         Predicted ranking
     sensitive_features :
-        The sensitive features over which demographic parity should be assessed
+        The sensitive features over which the allocation harm should be assessed
     method : str
         How to compute the differences. See :func:`fairlearn.metrics.MetricFrame.difference`
         for details.
@@ -169,7 +169,7 @@ def allocation_harm_in_ranking_ratio(
     y_pred : array-like
         Predicted ranking
     sensitive_features :
-        The sensitive features over which demographic parity should be assessed
+        The sensitive features over which the allocation harm should be assessed
     method : str
         How to compute the differences. See :func:`fairlearn.metrics.MetricFrame.ratio`
         for details.
@@ -209,9 +209,9 @@ def quality_of_service_harm_in_ranking_difference(
     y_true : array-like
         Ground truth (correct) labels.
     y_pred : array-like
-        Predicted labels :math:`h(X)` returned by the classifier.
+        Predicted ranking
     sensitive_features :
-        The sensitive features over which demographic parity should be assessed
+        The sensitive features over which the quality-of-service should be assessed
     method : str
         How to compute the differences. See :func:`fairlearn.metrics.MetricFrame.difference`
         for details.
@@ -253,7 +253,7 @@ def quality_of_service_harm_in_ranking_ratio(
     y_pred : array-like
         Predicted ranking
     sensitive_features :
-        The sensitive features over which demographic parity should be assessed
+        The sensitive features over which the quality-of-service should be assessed
     method : str
         How to compute the differences. See :func:`fairlearn.metrics.MetricFrame.ratio`
         for details.

--- a/fairlearn/metrics/_exposure.py
+++ b/fairlearn/metrics/_exposure.py
@@ -29,8 +29,8 @@ def exposure(y_true,
     ----------
     y_true : array_like
         Ground truth relevance scores. (ignored)
-    y_pred : array_like
-        The predicted ranking
+    y_pred : array_like of unique integers
+        The predicted ranking. The lower the integer the higher on the ranking.
     sample_weight : array_like
         Optional array of sample weights
     """
@@ -62,7 +62,7 @@ def utility(y_true,
 
     Utility is defined as the average of y_true.
 
-    The goal of this metric is to be used in the `exposure_utility_ratio` metric. Where we try
+    The goal of this metric is to be used in the `proportional_exposure` metric. Where we try
     to keep the `exposure` proportional to the `utility`.
 
     For consistency with other metric functions, the ``y_pred`` argument
@@ -73,8 +73,8 @@ def utility(y_true,
     ----------
     y_true : array_like
         Ground truth relevance scores.
-    y_pred : array_like
-        The predicted ranking (ignored)
+    y_pred : array_like of unique integers
+        The predicted ranking. The lower the integer the higher on the ranking. (ignored)
     sample_weight : array_like
         Optional array of sample weights
     """
@@ -106,9 +106,9 @@ def proportional_exposure(
 
     Utility is defined as the average of y_true.
 
-    The goal of this metric is to keep `utility` and `exposure` proportional to each other. Since
-    in ranking problems, an often occurring problem is that small differences in utility lead to
-    huge differences in exposure. See `user guide`.
+    In ranking problems, a frequent problem is that small differences in utility can lead to large
+    differences in exposure. See `user guide`. The goal of this metric is to keep `utility` and
+    `exposure` proportional to each other.
 
     The proportional exposure is defined as the exposure of ``y_pred`` divided by the utility of
     ``y_true``.
@@ -118,8 +118,8 @@ def proportional_exposure(
     ----------
     y_true : array_like
         Ground truth relevance scores.
-    y_pred : array_like
-        The predicted ranking
+    y_pred : array_like of unique integers
+        The predicted ranking. The lower the integer the higher on the ranking.
     sample_weight : array_like
         Optional array of sample weights
     """
@@ -141,7 +141,7 @@ def exposure_difference(
         sample_weight=None) -> float:
     """Calculate the difference in exposure allocation between groups.
 
-    The exposure allocation difference is defined as the difference
+    An exposure allocation difference is defined as the difference
     between the largest and the smallest group-level exposure.
     The exposure allocation difference of 0 means that all groups have the same exposure. A high
     exposure difference can be seen as an indication of allocation harm.
@@ -151,8 +151,8 @@ def exposure_difference(
     ----------
     y_true : array-like
         Ground truth relevance scores.
-    y_pred : array-like
-        Predicted ranking
+    y_pred : array_like of unique integers
+        The predicted ranking. The lower the integer the higher on the ranking.
     sensitive_features :
         The sensitive features over which the allocation harm should be assessed
     method : str
@@ -194,8 +194,8 @@ def exposure_ratio(
     ----------
     y_true : array-like
         Ground truth relevance scores.
-    y_pred : array-like
-        Predicted ranking
+    y_pred : array_like of unique integers
+        The predicted ranking. The lower the integer the higher on the ranking.
     sensitive_features :
         The sensitive features over which the allocation harm should be assessed
     method : str
@@ -237,8 +237,8 @@ def proportional_exposure_difference(
     ----------
     y_true : array-like
         Ground truth relevance scores.
-    y_pred : array-like
-        Predicted ranking
+    y_pred : array_like of unique integers
+        The predicted ranking. The lower the integer the higher on the ranking.
     sensitive_features :
         The sensitive features over which the quality-of-service should be assessed
     method : str
@@ -280,8 +280,8 @@ def proportional_exposure_ratio(
     ----------
     y_true : array-like
         Ground truth relevance scores.
-    y_pred : array-like
-        Predicted ranking
+    y_pred : array_like of unique integers
+        The predicted ranking. The lower the integer the higher on the ranking.
     sensitive_features :
         The sensitive features over which the quality-of-service should be assessed
     method : str

--- a/fairlearn/metrics/_exposure.py
+++ b/fairlearn/metrics/_exposure.py
@@ -1,8 +1,7 @@
-# Copyright (c) Microsoft Corporation and Fairlearn contributors.
+# Copyright (c) Fairlearn contributors.
 # Licensed under the MIT License.
 
 import numpy as np
-from typing import Any
 
 from fairlearn.metrics._input_manipulations import _convert_to_ndarray_and_squeeze
 from ._metric_frame import MetricFrame
@@ -14,12 +13,14 @@ _INVALID_RANKING_ERROR_MESSAGE = "Please input a valid complete ranking."
 def exposure(y_true,
              y_pred,
              *,
-             pos_label: Any = 1,
              sample_weight=None) -> float:
     """Calculate the exposure allocated to the ranking in y_pred.
 
-    For consistency with other metric functions, the ``y_true`` and ``pos_label`` arguments
-    are required, but ignored.
+    Exposure is defined as the average logarithmic discount, where
+    logarithmic discount = 1 / log2 (1 + i) for i in y_pred.
+
+    For consistency with other metric functions, the ``y_true`` argument
+    is required, but ignored.
 
 
     Parameters
@@ -28,8 +29,6 @@ def exposure(y_true,
         The true ranking (ignored)
     y_pred : array_like
         The predicted ranking
-    pos_label : Scalar
-        The label to treat as the 'good' outcome (ignored)
     sample_weight : array_like
         Optional array of sample weights
     """
@@ -46,18 +45,19 @@ def exposure(y_true,
     if sample_weight is not None:
         s_w = np.squeeze(np.asarray(sample_weight))
 
-    return np.dot(v, s_w).sum()
+    return np.dot(v, s_w).sum() / len(y_pred)
 
 
 def utility(y_true,
             y_pred,
             *,
-            pos_label: Any = 1,
             sample_weight=None) -> float:
-    """Calculate the exposure allocated to the ranking in y_pred.
+    """Calculate the average utility of the ranking in y_pred.
 
-    For consistency with other metric functions, the ``y_true`` and ``pos_label`` arguments
-    are required, but ignored.
+    Utility is defined as the average of y_true.
+
+    For consistency with other metric functions, the ``y_pred`` arguments
+    is required, but ignored.
 
 
     Parameters
@@ -65,9 +65,7 @@ def utility(y_true,
     y_true : array_like
         The utility
     y_pred : array_like
-        The predicted ranking
-    pos_label : Scalar
-        The label to treat as the 'good' outcome (ignored)
+        The predicted ranking (ignored)
     sample_weight : array_like
         Optional array of sample weights
     """
@@ -87,12 +85,11 @@ def exposure_utility_ratio(
         y_true,
         y_pred,
         *,
-        pos_label: Any = 1,
         sample_weight=None) -> float:
-    """Calculate the exposure allocated to the ranking in y_pred.
+    """Calculate the exposure utility ratio of the ranking in y_pred.
 
-    For consistency with other metric functions, the ``y_true`` and ``pos_label`` arguments
-    are required, but ignored.
+    The exposure utility ratio is defined as the exposure of ``y_pred`` divided by the utility of
+    ``y_true``.
 
 
     Parameters
@@ -101,8 +98,6 @@ def exposure_utility_ratio(
         The utility
     y_pred : array_like
         The predicted ranking
-    pos_label : Scalar
-        The label to treat as the 'good' outcome (ignored)
     sample_weight : array_like
         Optional array of sample weights
     """

--- a/test/unit/metrics/test_exposure.py
+++ b/test/unit/metrics/test_exposure.py
@@ -118,9 +118,7 @@ def test_proportional_exposure_weighted():
     assert round(result, 3) == 0.331
 
 
-'''
-    Test disparities
-'''
+# Test disparities
 
 
 @pytest.mark.parametrize("agg_method", _aggregate_methods)

--- a/test/unit/metrics/test_exposure.py
+++ b/test/unit/metrics/test_exposure.py
@@ -14,7 +14,8 @@ from fairlearn.metrics import (
 )
 from fairlearn.metrics._exposure import (
     _EMPTY_INPUT_PREDICTIONS_ERROR_MESSAGE,
-    _INVALID_RANKING_ERROR_MESSAGE
+    _INVALID_RANKING_ERROR_MESSAGE,
+    _ZERO_DIVISION_ERROR
 )
 
 from .data_for_test import y_t, s_w, g_1
@@ -62,12 +63,23 @@ def test_proportional_exposure_invalid_ranking():
     assert _INVALID_RANKING_ERROR_MESSAGE == exc.value.args[0]
 
 
+def test_exposure_zero_division():
+    assert exposure([], [0]) == 1
+
+
+def test_proportional_exposure_zero_division():
+    with pytest.raises(ZeroDivisionError) as exc:
+        _ = proportional_exposure([0, 0, 0], [1, 2, 3])
+    assert _ZERO_DIVISION_ERROR == exc.value.args[0]
+
+
 def test_exposure_single_element():
     assert exposure([], [1]) == 1
     assert exposure([], [10]) == 1/np.log2(1 + 10)
 
 
 def test_utility_single_element():
+    assert utility([0], []) == 0
     assert utility([1], []) == 1
     assert utility([1, 2], []) == 1.5
     assert utility([1, 2, 3], []) == 2

--- a/test/unit/metrics/test_exposure.py
+++ b/test/unit/metrics/test_exposure.py
@@ -24,9 +24,7 @@ y_p = list(range(len(y_t)))
 
 _aggregate_methods = ['between_groups', 'to_overall']
 
-'''
-    Test metrics
-'''
+# Test metrics
 
 
 def test_exposure_empty():

--- a/test/unit/metrics/test_exposure.py
+++ b/test/unit/metrics/test_exposure.py
@@ -1,0 +1,205 @@
+# Copyright (c) Fairlearn contributors.
+# Licensed under the MIT License.
+
+import pytest
+import numpy as np
+
+from fairlearn.metrics import MetricFrame
+from fairlearn.metrics import exposure, utility, proportional_exposure
+from fairlearn.metrics import (
+    exposure_difference,
+    exposure_ratio,
+    proportional_exposure_difference,
+    proportional_exposure_ratio
+)
+from fairlearn.metrics._exposure import (
+    _EMPTY_INPUT_PREDICTIONS_ERROR_MESSAGE,
+    _INVALID_RANKING_ERROR_MESSAGE
+)
+
+from .data_for_test import y_t, s_w, g_1
+
+y_p = list(range(len(y_t)))
+
+_aggregate_methods = ['between_groups', 'to_overall']
+
+'''
+    Test metrics
+'''
+
+
+def test_exposure_empty():
+    with pytest.raises(ValueError) as exc:
+        _ = exposure([], [])
+    assert _EMPTY_INPUT_PREDICTIONS_ERROR_MESSAGE.format('y_pred') == exc.value.args[0]
+
+
+def test_utility_empty():
+    with pytest.raises(ValueError) as exc:
+        _ = utility([], [])
+    assert _EMPTY_INPUT_PREDICTIONS_ERROR_MESSAGE.format('y_true') == exc.value.args[0]
+
+
+def test_proportional_exposure_empty():
+    with pytest.raises(ValueError) as exc:
+        _ = proportional_exposure([], [])
+    assert _EMPTY_INPUT_PREDICTIONS_ERROR_MESSAGE.format('y_pred') == exc.value.args[0]
+
+    with pytest.raises(ValueError) as exc:
+        _ = proportional_exposure([], [1, 2, 3])
+    assert _EMPTY_INPUT_PREDICTIONS_ERROR_MESSAGE.format('y_true') == exc.value.args[0]
+
+
+def test_exposure_invalid_ranking():
+    with pytest.raises(ValueError) as exc:
+        _ = exposure([1, 1, 1], [1, 1, 1])
+    assert _INVALID_RANKING_ERROR_MESSAGE == exc.value.args[0]
+
+
+def test_proportional_exposure_invalid_ranking():
+    with pytest.raises(ValueError) as exc:
+        _ = proportional_exposure([1, 1, 1], [1, 1, 1])
+    assert _INVALID_RANKING_ERROR_MESSAGE == exc.value.args[0]
+
+
+def test_exposure_single_element():
+    assert exposure([], [1]) == 1
+    assert exposure([], [10]) == 1/np.log2(1 + 10)
+
+
+def test_utility_single_element():
+    assert utility([1], []) == 1
+    assert utility([1, 2], []) == 1.5
+    assert utility([1, 2, 3], []) == 2
+
+
+def test_proportional_exposure_single_element():
+    assert proportional_exposure([1], [1]) == 1
+    assert proportional_exposure([10], [1]) == 0.1
+
+
+def test_exposure_unweighted():
+    result = exposure(y_t, y_p)
+    assert result == 0.23141957054179535
+
+
+def test_exposure_weighted():
+    result = exposure(y_t, y_p, sample_weight=s_w)
+    assert result == 0.4384130413271165
+
+
+def test_utility_unweighted():
+    result = utility(y_t, y_p)
+    assert result == 0.6338028169014085
+
+
+def test_utility_weighted():
+    result = utility(y_t, y_p, sample_weight=s_w)
+    assert result == 1.323943661971831
+
+
+def test_proportional_exposure_unweighted():
+    result = proportional_exposure(y_t, y_p)
+    assert result == 0.36512865574372155
+
+
+def test_proportional_exposure_weighted():
+    result = proportional_exposure(y_t, y_p, sample_weight=s_w)
+    assert result == 0.33114176525771566
+
+
+'''
+    Test disparities
+'''
+
+
+@pytest.mark.parametrize("agg_method", _aggregate_methods)
+def test_exposure_difference(agg_method):
+    actual = exposure_difference(y_t, y_p, sensitive_features=g_1, method=agg_method)
+
+    gm = MetricFrame(metrics=exposure, y_true=y_t, y_pred=y_p, sensitive_features=g_1)
+
+    assert actual == gm.difference(method=agg_method)
+
+
+@pytest.mark.parametrize("agg_method", _aggregate_methods)
+def test_exposure_difference_weighted(agg_method):
+    actual = exposure_difference(y_t, y_p,
+                                 sensitive_features=g_1,
+                                 sample_weight=s_w,
+                                 method=agg_method)
+
+    gm = MetricFrame(metrics=exposure, y_true=y_t, y_pred=y_p,
+                     sensitive_features=g_1,
+                     sample_params={'sample_weight': s_w})
+
+    assert actual == gm.difference(method=agg_method)
+
+
+@pytest.mark.parametrize("agg_method", _aggregate_methods)
+def test_exposure_ratio(agg_method):
+    actual = exposure_ratio(y_t, y_p, sensitive_features=g_1, method=agg_method)
+
+    gm = MetricFrame(metrics=exposure, y_true=y_t, y_pred=y_p, sensitive_features=g_1)
+
+    assert actual == gm.ratio(method=agg_method)
+
+
+@pytest.mark.parametrize("agg_method", _aggregate_methods)
+def test_exposure_ratio_weighted(agg_method):
+    actual = exposure_ratio(y_t, y_p,
+                            sensitive_features=g_1,
+                            sample_weight=s_w,
+                            method=agg_method)
+
+    gm = MetricFrame(metrics=exposure, y_true=y_t, y_pred=y_p,
+                     sensitive_features=g_1,
+                     sample_params={'sample_weight': s_w})
+
+    assert actual == gm.ratio(method=agg_method)
+
+
+@pytest.mark.parametrize("agg_method", _aggregate_methods)
+def test_proportional_exposure_difference(agg_method):
+    actual = proportional_exposure_difference(y_t, y_p, sensitive_features=g_1, method=agg_method)
+
+    gm = MetricFrame(metrics=proportional_exposure, y_true=y_t, y_pred=y_p, sensitive_features=g_1)
+
+    assert actual == gm.difference(method=agg_method)
+
+
+@pytest.mark.parametrize("agg_method", _aggregate_methods)
+def test_proportional_exposure_difference_weighted(agg_method):
+    actual = proportional_exposure_difference(y_t, y_p,
+                                              sensitive_features=g_1,
+                                              sample_weight=s_w,
+                                              method=agg_method)
+
+    gm = MetricFrame(metrics=proportional_exposure, y_true=y_t, y_pred=y_p,
+                     sensitive_features=g_1,
+                     sample_params={'sample_weight': s_w})
+
+    assert actual == gm.difference(method=agg_method)
+
+
+@pytest.mark.parametrize("agg_method", _aggregate_methods)
+def test_proportional_exposure_ratio(agg_method):
+    actual = proportional_exposure_ratio(y_t, y_p, sensitive_features=g_1, method=agg_method)
+
+    gm = MetricFrame(metrics=proportional_exposure, y_true=y_t, y_pred=y_p, sensitive_features=g_1)
+
+    assert actual == gm.ratio(method=agg_method)
+
+
+@pytest.mark.parametrize("agg_method", _aggregate_methods)
+def test_proportional_exposure_ratio_weighted(agg_method):
+    actual = proportional_exposure_ratio(y_t, y_p,
+                                         sensitive_features=g_1,
+                                         sample_weight=s_w,
+                                         method=agg_method)
+
+    gm = MetricFrame(metrics=proportional_exposure, y_true=y_t, y_pred=y_p,
+                     sensitive_features=g_1,
+                     sample_params={'sample_weight': s_w})
+
+    assert actual == gm.ratio(method=agg_method)

--- a/test/unit/metrics/test_exposure.py
+++ b/test/unit/metrics/test_exposure.py
@@ -92,32 +92,32 @@ def test_proportional_exposure_single_element():
 
 def test_exposure_unweighted():
     result = exposure(y_t, y_p)
-    assert result == 0.23141957054179535
+    assert round(result, 3) == 0.231
 
 
 def test_exposure_weighted():
     result = exposure(y_t, y_p, sample_weight=s_w)
-    assert result == 0.4384130413271165
+    assert round(result, 3) == 0.438
 
 
 def test_utility_unweighted():
     result = utility(y_t, y_p)
-    assert result == 0.6338028169014085
+    assert round(result, 3) == 0.634
 
 
 def test_utility_weighted():
     result = utility(y_t, y_p, sample_weight=s_w)
-    assert result == 1.323943661971831
+    assert round(result, 3) == 1.324
 
 
 def test_proportional_exposure_unweighted():
     result = proportional_exposure(y_t, y_p)
-    assert result == 0.36512865574372155
+    assert round(result, 3) == 0.365
 
 
 def test_proportional_exposure_weighted():
     result = proportional_exposure(y_t, y_p, sample_weight=s_w)
-    assert result == 0.33114176525771566
+    assert round(result, 3) == 0.331
 
 
 '''


### PR DESCRIPTION
Closes #959

#### Design choices:

- New metric `exposure`, which can be used to show allocation harms
- New metric `utility`, which is the average y_true of a subgroup
- New metric `proportional exposure`, which is used to show quality-of-service harms, since you want the exposure of a group to be comparable to its relevance. 
- y_pred is used for giving the input ranking, so list with integers from 1 to n. 

#### Problem
This PR has the same problems as discussed in #756, since the exposure metric does not use y_true. And y_pred is used to input a ranking, which might be confusing.

#### Example
<img src="https://user-images.githubusercontent.com/1357585/136267741-1efd35cf-c88c-4d44-bd8d-b49eeefe14fc.JPG" width=700>

#### TODO
- [x] Test cases
- [x] User guide