### PR TITLE
Adding Thresholder and RejectOptionClassifier 

### DIFF
--- a/fairlearn/postprocessing/__init__.py
+++ b/fairlearn/postprocessing/__init__.py
@@ -7,10 +7,12 @@ The predictor's output is adjusted to fulfill specified parity constraints. The 
 learn how to adjust the predictor's output from the training data.
 """
 
+from ._thresholder import Thresholder
 from ._threshold_optimizer import ThresholdOptimizer  # noqa: F401
 from ._plotting import plot_threshold_optimizer  # noqa: F401
 
 __all__ = [
+    "Thresholder"
     "ThresholdOptimizer",
-    "plot_threshold_optimizer"
+    "plot_threshold_optimizer",
 ]

--- a/fairlearn/postprocessing/_thresholder.py
+++ b/fairlearn/postprocessing/_thresholder.py
@@ -1,0 +1,105 @@
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
+# Licensed under the MIT License.
+
+import numpy as np
+from sklearn import clone
+from sklearn.base import BaseEstimator, MetaEstimatorMixin
+from sklearn.exceptions import NotFittedError
+from sklearn.utils.validation import check_is_fitted
+from warnings import warn
+
+
+from postprocessing._threshold_operation import ThresholdOperation
+
+# try to get it to work now
+from utils._common import _get_soft_predictions
+from utils._input_validation import _validate_and_reformat_input
+from postprocessing._constants import (
+    BASE_ESTIMATOR_NONE_ERROR_MESSAGE,
+    BASE_ESTIMATOR_NOT_FITTED_WARNING)
+
+
+# how it should be
+# from ..utils._common import _get_soft_predictions
+# from ..utils._input_validation import _validate_and_reformat_input
+# from ._constants import (
+#     BASE_ESTIMATOR_NONE_ERROR_MESSAGE,
+#     BASE_ESTIMATOR_NOT_FITTED_WARNING)
+
+
+class Thresholder(BaseEstimator, MetaEstimatorMixin):
+    r"""Create my own description here
+
+    Parameters
+
+    References
+    ----------
+
+    """
+
+    def __init__(self, estimator, threshold_dict, prefit=False,
+                 predict_method='deprecated'):
+        self.estimator = estimator
+        self.threshold_dict = threshold_dict
+        self.prefit = prefit
+        self.predict_method = predict_method
+
+    def fit(self, X, y, **kwargs):
+        """Fit the estimator.
+
+        If `prefit` is set to `True` then the base estimator is kept as is.
+        Otherwise it is fitted from the provided arguments.
+        """
+        if self.estimator is None:
+            raise ValueError(BASE_ESTIMATOR_NONE_ERROR_MESSAGE)
+
+        if self.predict_method == "deprecated":
+            warn(
+                "'predict_method' default value is changed from 'predict' to "
+                "'auto'. Explicitly pass `predict_method='predict' to "
+                "replicate the old behavior, or pass `predict_method='auto' "
+                "or other valid values to silence this warning.",
+                FutureWarning,
+            )
+            self._predict_method = "predict"
+        else:
+            self._predict_method = self.predict_method
+
+        if not self.prefit:
+            self.estimator_ = clone(self.estimator).fit(X, y, **kwargs)
+        else:
+            try:
+                check_is_fitted(self.estimator)
+            except NotFittedError:
+                warn(BASE_ESTIMATOR_NOT_FITTED_WARNING.format(type(self).__name__))
+            self.estimator_ = self.estimator
+        return self
+
+    def predict(self, X, *, sensitive_features):
+        """
+        Predict stuff, write better explanation later"""
+
+        check_is_fitted(self)
+
+        # get soft predictions
+        base_predictions = np.array(
+            _get_soft_predictions(self.estimator_, X, self._predict_method)
+        )
+
+        # validate and reformat input
+        _, base_predictions_vector, sensitive_feature_vector, _ = _validate_and_reformat_input(
+            X, y=base_predictions, sensitive_features=sensitive_features, expect_y=True,
+            enforce_binary_labels=False)
+
+        final_predictions = 0.0*base_predictions_vector
+
+        for a, threshold in self.threshold_dict.items():
+
+            operation = ThresholdOperation('>', threshold)
+
+            thresholded_predictions = 1.0 * operation(base_predictions_vector)
+
+            final_predictions[sensitive_feature_vector == a] = \
+                thresholded_predictions[sensitive_feature_vector == a]
+
+        return final_predictions

--- a/test/unit/postprocessing/test_thresholder.py
+++ b/test/unit/postprocessing/test_thresholder.py
@@ -1,0 +1,58 @@
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
+# Licensed under the MIT License.
+
+import numpy as np
+import pandas as pd
+
+from sklearn.linear_model import LogisticRegression
+from fairlearn.postprocessing import Thresholder
+
+
+def test_thresholder():
+    X = pd.DataFrame([
+        [0, 4], [6, 2], [1, 3], [10, 5], [1, 7], [-2, 1], [3, 10], [14, 5],
+        [1, 3], [1, 5], [1, 7], [-5, 9], [3, 13], [7, 1], [-8, 4], [9, 1]])
+    y = pd.Series([0, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1, 1, 0])
+    a1 = "A"
+    a2 = "B"
+    a3 = "C"
+    a4 = "D"
+    A = pd.DataFrame([[a1, a3, a1 + a3], [a1, a3, a1 + a3],
+                      [a2, a3, a2 + a3], [a2, a3, a2 + a3], [a2, a3, a2 + a3], [a2, a3, a2 + a3],
+                      [a2, a4, a2 + a4], [a2, a4, a2 + a4], [a2, a4, a2 + a4], [a2, a4, a2 + a4],
+                      [a2, a4, a2 + a4], [a2, a4, a2 + a4], [a2, a4, a2 + a4], [a2, a4, a2 + a4],
+                      [a1, a4, a1 + a4], [a1, a4, a1 + a4]],
+                     columns=['SF1', 'SF2', 'SF1+2'])
+
+    estimator = LogisticRegression()
+    estimator.fit(X, y)
+
+    # finish when there are answers about how to deal with multiple sensitive features
+    # thresholder_multi = Thresholder(estimator=estimator, threshold_dict=//todo,
+    #                                 prefit=True,
+    #                                 predict_method='predict_proba')
+
+    threshold_dict_combined = {'AC': .36, 'BC': .43, 'BD': .4, 'AD': .465}
+    thresholder_combined = Thresholder(estimator=estimator,
+                                       threshold_dict=threshold_dict_combined,
+                                       prefit=True,
+                                       predict_method='predict_proba')
+
+    X_test = pd.concat([
+        pd.DataFrame([[5, 4], [7, 2], [0, 3], [1, 2], [-2, 9], [1, 1], [0, 5], [-3, 3]]),
+        X])
+    A_test = pd.concat([
+        pd.DataFrame([[a1, a3, a1 + a3], [a1, a3, a1 + a3],
+                      [a2, a3, a2 + a3], [a2, a3, a2 + a3],
+                      [a2, a4, a2 + a4], [a2, a4, a2 + a4],
+                      [a1, a4, a1 + a4], [a1, a4, a1 + a4]],
+                     columns=['SF1', 'SF2', 'SF1+2']),
+        A])
+
+    expected_y = pd.Series([1, 0, 1, 0, 1, 0, 0, 1, 1, 1, 0, 0,
+                           1, 0, 1, 0, 1, 1, 1, 1, 1, 0, 1, 0])
+
+    thresholder_combined.fit(X, y)
+    outputted_y = thresholder_combined.predict(X_test, sensitive_features=A_test.loc[:, 'SF1+2'])
+
+    assert (np.array_equal(outputted_y, expected_y))


### PR DESCRIPTION
For issue #958 

So far I have the first version for `Thresholder`, and the first version of a unit test for `Thresholder`. 

To those files, I for sure want to add: 
- A test for prefit = True, and some more options for `predict_method`
- A way to deal with multiple sensitive features, when we have decided on how to do so (see discussion in issue)

Furthermore, I will start working on RejectOptionClassifier when everything for `Thresholder` is done.