### PR TITLE
MNT fix doc build warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,8 +83,8 @@ intersphinx_mapping = {'python3': ('https://docs.python.org/3', None),
                        'matplotlib': ('https://matplotlib.org/', None,),
                        'tensorflow': (
                             'https://www.tensorflow.org/api_docs/python',
-                            'https://github.com/GPflow/tensorflow-intersphinx/'
-                            'raw/master/tf2_py_objects.inv'
+                            'https://raw.githubusercontent.com/GPflow/'
+                            'tensorflow-intersphinx/master/tf2_py_objects.inv'
                         )}
 
 # Add any paths that contain templates here, relative to this directory.

--- a/fairlearn/reductions/_moments/utility_parity.py
+++ b/fairlearn/reductions/_moments/utility_parity.py
@@ -122,7 +122,7 @@ class UtilityParity(ClassificationMoment):
 
         The `utilities` is a 2-d array which corresponds to g(X,A,Y,h(X)) as
         mentioned in the paper
-        `Agarwal et al. (2018) <https://arxiv.org/abs/1803.02453>` [2]_.
+        `Agarwal et al. (2018) <https://arxiv.org/abs/1803.02453>`_ [2]_.
         The `utilities` defaults to h(X), i.e. [0, 1] for each X_i.
         The first column is G^0 and the second is G^1.
         Assumes binary classification with labels 0/1.
@@ -279,10 +279,11 @@ class DemographicParity(UtilityParity):
     :class:`pandas:pandas.Series`
     will only have a single entry, which will be equal to 1.
     Similarly, the `index` property will have twice as many entries
-    (corresponding to the Lagrange multipliers for positive and negative constraints)
-    as there are unique values for the sensitive feature.
-    The :meth:`signed_weights` method will compute the costs according
-    to Example 3 of `Agarwal et al. (2018) <https://arxiv.org/abs/1803.02453>`_ [4]_.
+    (corresponding to the Lagrange multipliers for positive and negative
+    constraints) as there are unique values for the sensitive feature.
+    The :meth:`UtilityParity.signed_weights` method will compute the costs
+    according to Example 3 of
+    `Agarwal et al. (2018) <https://arxiv.org/abs/1803.02453>`_ [4]_.
 
     This :class:`~Moment` also supports control features, which can be used to
     stratify the data, with the Demographic Parity constraint applied within
@@ -341,9 +342,9 @@ class TruePositiveRateParity(UtilityParity):
     by two (for the Lagrange multipliers for positive and negative
     constraints).
 
-    With these definitions, the :meth:`signed_weights` method will calculate
-    the costs for `Y=1` as they are calculated in Example 4 of
-    `Agarwal et al. (2018) <https://arxiv.org/abs/1803.02453>`, but will use
+    With these definitions, the :meth:`UtilityParity.signed_weights` method
+    will calculate the costs for `Y=1` as they are calculated in Example 4 of
+    `Agarwal et al. (2018) <https://arxiv.org/abs/1803.02453>`_, but will use
     the weights equal to zero for `Y=0` [5]_.
 
     This :class:`~Moment` also supports control features, which can be used to


### PR DESCRIPTION
Fixing a few doc build warnings including

```
loading intersphinx inventory from https://github.com/GPflow/tensorflow-intersphinx/raw/master/tf2_py_objects.inv...
intersphinx inventory has moved: https://github.com/GPflow/tensorflow-intersphinx/raw/master/tf2_py_objects.inv -> https://raw.githubusercontent.com/GPflow/tensorflow-intersphinx/master/tf2_py_objects.inv
```
and
```
/fairlearn/reductions/_moments/utility_parity.py:docstring of fairlearn.reductions._moments.utility_parity.TruePositiveRateParity:26: WARNING: py:meth reference target not found: signed_weights
```
as well as a few links that didn't render due to missing trailing underscores and inconsistent line-wrap.