### PR TITLE
DOC: ACSIncome Documentation

### DIFF
--- a/docs/user_guide/datasets/acs_income.rst
+++ b/docs/user_guide/datasets/acs_income.rst
@@ -1,16 +1,23 @@
 .. _acsincome-data:
-Retiring Adult: ACSIncome
+ACSIncome
 -------------------------
 
 Introduction
 ^^^^^^^^^^^^^^^^^
 
 The ACSIncome dataset is one of five datasets created by Ding et al. [1]_ 
-as an improved alternative to the popular UCI Adult dataset.
-The authors compiled data from the American Community Survey (ACS) Public Use Microdata Sample (PUMS). 
+as an improved alternative to the popular UCI Adult dataset [2]_.
+Briefly, the UCI Adult dataset is commonly used as a benchmark dataset when comparing
+different algorithmic fairness interventions. ACSIncome offers a few improvements,
+such as providing more datapoints (1,664,500 vs. 48,842) and more recent data (2018 vs. 1994).
+Further, the binary labels in the UCI Adult dataset indicate whether an indivdual earned 
+more than $50k US dollars in that year. Ding et al. show that the choice of threshold impacts
+the amount of fairness violation, so they allow users to define any threshold.
+
+Ding et al. compiled data from the American Community Survey (ACS) Public Use Microdata Sample (PUMS). 
 Note that this is a different source than the Annual Social and Economic Supplement (ASEC) 
 of the Current Population Survey (CPS) used to construct the original UCI Adult dataset.
-Ding et al. [1]_ filtered the data such that ACSIncome only includes individuals above 16 years old 
+Ding et al. filtered the data such that ACSIncome only includes individuals above 16 years old 
 who worked at least 1 hour per week in the past year and had an income of at least $100.
 
 
@@ -18,7 +25,7 @@ who worked at least 1 hour per week in the past year and had an income of at lea
 
 Dataset Description
 ^^^^^^^^^^^^^^^^^^^
-The authors provide data from 2014-2018 for all 50 states and Puerto Rico.
+Ding et al. provide data from 2014-2018 for all 50 states and Puerto Rico.
 We uploaded the 2018 data to OpenML, which fairlearn can access.
 The dataset contains 1,664,500 rows. Each row describes a person and contains 10 features, which we describe below:
 
@@ -104,8 +111,8 @@ The dataset contains 1,664,500 rows. Each row describes a person and contains 10
          13. Unmarried partner
          14. Foster child
          15. Other nonrelative
-         16. Institutionalized group quarters population. Includes correctional facilities, nursing homes, and mental hopsitals. [2]_
-         17. Noninstitutionalized group quarters population. Includes college dormitories, military barracks, group homes, missions, and shelters. [2]_
+         16. Institutionalized group quarters population. Includes correctional facilities, nursing homes, and mental hopsitals. [3]_
+         17. Noninstitutionalized group quarters population. Includes college dormitories, military barracks, group homes, missions, and shelters. [3]_
 
    *  - WKHP
       - Usual hours worked per week in the past 12 months. Values are an integer from 1 to 99. Any hours above 99 are rounded down to 99
@@ -148,6 +155,8 @@ A threshold can be applied to PINCP to frame this as a binary classification tas
   .. [1] Frances Ding, Moritz Hardt, John Miller, Ludwig Schmidt `"Retiring Adult: New Datasets for Fair Machine Learning" <https://arxiv.org/pdf/2108.04884.pdf>`_,
       Advances in Neural Information Processing Systems 34, 2021.
 
-  .. [2] `"Group Quarters and Residence Rules for Poverty", <https://www.census.gov/topics/income-poverty/poverty/guidance/group-quarters.html>`_,
+  .. [2] R. Kohavi and B. Becker. "UCI Adult Data Set." UCI Meachine Learning Repository, 5, 1996.
+
+  .. [3] `"Group Quarters and Residence Rules for Poverty", <https://www.census.gov/topics/income-poverty/poverty/guidance/group-quarters.html>`_,
       United States Census Bureau.
 

--- a/docs/user_guide/datasets/acs_income.rst
+++ b/docs/user_guide/datasets/acs_income.rst
@@ -14,8 +14,8 @@ a few improvements, such as providing more datapoints (1,664,500 vs. 48,842)
 and more recent data (2018 vs. 1994). Further, the binary labels in the UCI 
 Adult dataset indicate whether an individual earned more than $50k US dollars 
 in that year. Ding et al. show that the choice of threshold impacts the 
-amount of disparity, so they allow users to define any threshold 
-rather than fixing it at $50k.
+amount of disparity in proportion of positives, so they allow users to 
+define any threshold rather than fixing it at $50k.
 
 Ding et al. compiled data from the American Community Survey (ACS) Public 
 Use Microdata Sample (PUMS). Note that this is a different source than the 
@@ -32,7 +32,7 @@ Dataset Description
 ^^^^^^^^^^^^^^^^^^^
 Ding et al. provide data from 2014-2018 for all 50 states and Puerto Rico.
 Note that Puerto Rico is the only US territory included in this dataset.
-We uploaded the 2018 data to OpenML, which anyone can access.
+We uploaded the 2018 data to `OpenML <https://www.openml.org/d/43141>`_.
 The dataset contains 1,664,500 rows. Each row describes a person and contains 
 10 features, which we describe below:
 
@@ -101,7 +101,7 @@ The dataset contains 1,664,500 rows. Each row describes a person and contains
       - Place of birth. There are over 200 categories, including the 50 US states and several countries. Please see the data dictionary at `ACS PUMS documentation <https://www.census.gov/programs-surveys/acs/microdata/documentation.2018.html>`_ for the full list.
 
    *  - RELP
-      - Relationship:
+      - Relationship to householder:
          0. Reference person
          1. Husband or wife
          2. Biological son or daughter

--- a/docs/user_guide/datasets/acs_income.rst
+++ b/docs/user_guide/datasets/acs_income.rst
@@ -5,23 +5,22 @@ Retiring Adult: ACSIncome
 Introduction
 ^^^^^^^^^^^^^^^^^
 
-The ACSIncome dataset is one of five datasets created by Ding et al. [#0]_ 
+The ACSIncome dataset is one of five datasets created by Ding et al. [1]_ 
 as an improved alternative to the popular UCI Adult dataset.
 The authors compiled data from the American Community Survey (ACS) Public Use Microdata Sample (PUMS). 
 Note that this is a different source than the Annual Social and Economic Supplement (ASEC) 
 of the Current Population Survey (CPS) used to construct the original UCI Adult dataset.
-Ding et al. [#0]_ filtered the data such that ACSIncome only includes individuals above 16 years old 
+Ding et al. [1]_ filtered the data such that ACSIncome only includes individuals above 16 years old 
 who worked at least 1 hour per week in the past year and had an income of at least $100.
-
-
 
 
 .. _acsincome_dataset_description:
 
 Dataset Description
 ^^^^^^^^^^^^^^^^^^^
-Data is provided from 2018 for all 50 states and Puerto Rico.
-There are 1,664,500 rows and 10 features, which are described below:
+The authors provide data from 2014-2018 for all 50 states and Puerto Rico.
+We uploaded the 2018 data to OpenML, which fairlearn can access.
+The dataset contains 1,664,500 rows. Each row describes a person and contains 10 features, which we describe below:
 
 .. list-table::
    :header-rows: 1
@@ -105,8 +104,8 @@ There are 1,664,500 rows and 10 features, which are described below:
          13. Unmarried partner
          14. Foster child
          15. Other nonrelative
-         16. Institutionalized group quarters population
-         17. Noninstitutionalized group quarters population
+         16. Institutionalized group quarters population. Includes correctional facilities, nursing homes, and mental hopsitals. [2]_
+         17. Noninstitutionalized group quarters population. Includes college dormitories, military barracks, group homes, missions, and shelters. [2]_
 
    *  - WKHP
       - Usual hours worked per week in the past 12 months. Values are an integer from 1 to 99. Any hours above 99 are rounded down to 99
@@ -141,25 +140,14 @@ A threshold can be applied to PINCP to frame this as a binary classification tas
       - Description
 
    *  - PINCP
-      - Total income, denoted as an integer ranging from 104 to 1,423,000.
-
-
-An additonal column for the state code is also provided so users to easily filter the data to focus on subsets by state.
-
-.. list-table::
-   :header-rows: 1
-   :widths: 7 30
-   :stub-columns: 1
-
-   *  - Column name
-      - Description
-
-   *  - ST
-      - State Code based on 2010 Census definitions. Please see the data dictionary at `ACS PUMS documentation <https://www.census.gov/programs-surveys/acs/microdata/documentation.2018.html>`_ for the full list.
+      - Total income per person, denoted as an integer ranging from 104 to 1,423,000.
 
 
 .. topic:: References:
 
-  .. [#0] Frances Ding, Moritz Hardt, John Miller, Ludwig Schmidt `"Retiring Adult: New Datasets for Fair Machine Learning" <https://arxiv.org/pdf/2108.04884.pdf>`_,
+  .. [1] Frances Ding, Moritz Hardt, John Miller, Ludwig Schmidt `"Retiring Adult: New Datasets for Fair Machine Learning" <https://arxiv.org/pdf/2108.04884.pdf>`_,
       Advances in Neural Information Processing Systems 34, 2021.
+
+  .. [2] `"Group Quarters and Residence Rules for Poverty", <https://www.census.gov/topics/income-poverty/poverty/guidance/group-quarters.html>`_,
+      United States Census Bureau.
 

--- a/docs/user_guide/datasets/acs_income.rst
+++ b/docs/user_guide/datasets/acs_income.rst
@@ -1,4 +1,4 @@
-.. _acsincome-data:
+.. _acsincome_data:
 ACSIncome
 ---------
 
@@ -26,11 +26,12 @@ years old who worked at least 1 hour per week in the past year and had an
 income of at least $100.
 
 
-.. _acsincome-dataset-description:
+.. _acsincome_dataset_description:
 
 Dataset Description
 ^^^^^^^^^^^^^^^^^^^
 Ding et al. provide data from 2014-2018 for all 50 states and Puerto Rico.
+Note that Puerto Rico is the only US territory included in this dataset.
 We uploaded the 2018 data to OpenML, which anyone can access.
 The dataset contains 1,664,500 rows. Each row describes a person and contains 
 10 features, which we describe below:

--- a/docs/user_guide/datasets/acs_income.rst
+++ b/docs/user_guide/datasets/acs_income.rst
@@ -140,7 +140,7 @@ A threshold can be applied to PINCP to frame this as a binary classification tas
       - Description
 
    *  - PINCP
-      - Total income per person, denoted as an integer ranging from 104 to 1,423,000.
+      - Total annual income per person, denoted as an integer ranging from 104 to 1,423,000.
 
 
 .. topic:: References:

--- a/docs/user_guide/datasets/acs_income.rst
+++ b/docs/user_guide/datasets/acs_income.rst
@@ -1,0 +1,165 @@
+.. _acsincome-data:
+Retiring Adult: ACSIncome
+-------------------------
+
+Introduction
+^^^^^^^^^^^^^^^^^
+
+The ACSIncome dataset is one of five datasets created by Ding et al. [#1]_ 
+as an improved alternative to the popular UCI Adult dataset.
+The authors compiled data from the American Community Survey (ACS) Public Use Microdata Sample (PUMS). 
+Note that this is a different source than the Annual Social and Economic Supplement (ASEC) 
+of the Current Population Survey (CPS) used to construct the original UCI Adult dataset.
+Ding et al. [#1]_ filtered the data such that ACSIncome only includes individuals above 16 years old 
+who worked at least 1 hour per week in the past year and had an income of at least $100.
+
+
+
+
+.. _acsincome_dataset_description:
+
+Dataset Description
+^^^^^^^^^^^^^^^^^^^
+Data is provided from 2018 for all 50 states and Puerto Rico.
+There are 1,664,500 rows and 10 features, which are described below:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 7 30
+   :stub-columns: 1
+
+   *  - Column name
+      - Description
+
+   *  - AGEP
+      - Age as an integer from 0 to 99
+
+   *  - COW
+      - Class of worker:
+         1. Employee of a private for-profit company or business, or of an individual, for wages, salary, or commissions 
+         2. Employee of a private not-for-profit, tax-exempt, or charitable organization 
+         3. Local government employee (city, county, etc.) 
+         4. State government employee 
+         5. Federal government employee 
+         6. Self-employed in own not incorporated business, professional practice, or farm 
+         7. Self-employed in own incorporated business, professional practice or farm 
+         8. Working without pay in family business or farm 
+         9. Unemployed and last worked 5 years ago or earlier or never worked
+
+   *  - SCHL
+      - Educational attainment:
+         1. No schooling completed
+         2. Nursery school or preschool
+         3. Kindergarten
+         4. Grade 1
+         5. Grade 2
+         6. Grade 3
+         7. Grade 4
+         8. Grade 5
+         9. Grade 6
+         10. Grade 7
+         11. Grade 8
+         12. Grade 9
+         13. Grade 10
+         14. Grade 11
+         15. Grade 12 (no diploma)
+         16. Regular high school diploma
+         17. GED or alternative credential
+         18. Some college but less than 1 year
+         19. 1 or more years of college credit but no degree
+         20. Associate's degree
+         21. Bachelor's degree
+         22. Master's degree
+         23. Professional degree beyond a bachelor's degree
+         24. Doctorate degree
+
+   *  - MAR
+      - Marital status:
+         1. Married
+         2. Widowed
+         3. Divorced
+         4. Separated
+         5. Never married or under 15 years old
+
+   *  - OCCP
+      - Occupation. There are over 500 categories. Please see data dictionary at `ACS PUMS documentation <https://www.census.gov/programs-surveys/acs/microdata/documentation.2018.html>`_ for the full list of occupation codes.
+
+   *  - POBP
+      - Place of birth. There are over 200 categories, including the 50 US states and several countries. Please see the data dictionary at `ACS PUMS documentation <https://www.census.gov/programs-surveys/acs/microdata/documentation.2018.html>`_ for the full list.
+
+   *  - RELP
+      - Relationship:
+         0. Reference person
+         1. Husband or wife
+         2. Biological son or daughter
+         3. Adopted son or daughter
+         4. Stepson or stepdaughter
+         5. Brother or sister
+         6. Father or mother
+         7. Grandchild
+         8. Parent-in-law
+         9. Son-in-law or daughter-in-law
+         10. Other relative
+         11. Roomer or boarder
+         12. Housemate or roommate
+         13. Unmarried partner
+         14. Foster child
+         15. Other nonrelative
+         16. Institutionalized group quarters population
+         17. Noninstitutionalized group quarters population
+
+   *  - WKHP
+      - Usual hours worked per week in the past 12 months. Values are an integer from 1 to 99. Any hours above 99 are rounded down to 99
+
+   *  - SEX
+      - Sex code:
+         1. Male
+         2. Female
+
+   *  - RAC1P
+      - Race code
+         1. White alone
+         2. Black or African American alone
+         3. American Indian alone
+         4. Alaska Native alone
+         5. American Indian and Alaska native tribes specified; or American Indian or Alaska Native, not specified and no other races
+         6. Asian alone
+         7. Native Hawaiian and Other Pacific Islander alone
+         8. Some Other Race alone
+         9. Two or More races
+
+
+The target label is given by PINCP. For generalizability, the integer value is provided.
+A threshold can be applied to PINCP to frame this as a binary classification task.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 7 30
+   :stub-columns: 1
+
+   *  - Column name
+      - Description
+
+   *  - PINCP
+      - Total income, denoted as an integer ranging from 104 to 1,423,000.
+
+
+An additonal column for the state code is also provided so users to easily filter the data to focus on subsets by state.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 7 30
+   :stub-columns: 1
+
+   *  - Column name
+      - Description
+
+   *  - ST
+      - State Code based on 2010 Census definitions. Please see the data dictionary at `ACS PUMS documentation <https://www.census.gov/programs-surveys/acs/microdata/documentation.2018.html>`_ for the full list.
+
+
+.. topic:: References:
+
+  .. [#1] Frances Ding, Moritz Hardt, John Miller, Ludwig Schmidt `"Retiring Adult: New Datasets for Fair Machine Learning" <https://arxiv.org/pdf/2108.04884.pdf>`_,
+      Advances in Neural Information Processing Systems 34, 2021.
+

--- a/docs/user_guide/datasets/acs_income.rst
+++ b/docs/user_guide/datasets/acs_income.rst
@@ -14,7 +14,7 @@ a few improvements, such as providing more datapoints (1,664,500 vs. 48,842)
 and more recent data (2018 vs. 1994). Further, the binary labels in the UCI 
 Adult dataset indicate whether an individual earned more than $50k US dollars 
 in that year. Ding et al. show that the choice of threshold impacts the 
-amount of fairness violation, so they allow users to define any threshold 
+amount of disparity, so they allow users to define any threshold 
 rather than fixing it at $50k.
 
 Ding et al. compiled data from the American Community Survey (ACS) Public 

--- a/docs/user_guide/datasets/acs_income.rst
+++ b/docs/user_guide/datasets/acs_income.rst
@@ -1,33 +1,39 @@
 .. _acsincome-data:
 ACSIncome
--------------------------
+---------
+
 
 Introduction
-^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^
 
 The ACSIncome dataset is one of five datasets created by Ding et al. [1]_ 
 as an improved alternative to the popular UCI Adult dataset [2]_.
-Briefly, the UCI Adult dataset is commonly used as a benchmark dataset when comparing
-different algorithmic fairness interventions. ACSIncome offers a few improvements,
-such as providing more datapoints (1,664,500 vs. 48,842) and more recent data (2018 vs. 1994).
-Further, the binary labels in the UCI Adult dataset indicate whether an indivdual earned 
-more than $50k US dollars in that year. Ding et al. show that the choice of threshold impacts
-the amount of fairness violation, so they allow users to define any threshold.
+Briefly, the UCI Adult dataset is commonly used as a benchmark dataset 
+when comparing different algorithmic fairness interventions. ACSIncome offers 
+a few improvements, such as providing more datapoints (1,664,500 vs. 48,842) 
+and more recent data (2018 vs. 1994). Further, the binary labels in the UCI 
+Adult dataset indicate whether an individual earned more than $50k US dollars 
+in that year. Ding et al. show that the choice of threshold impacts the 
+amount of fairness violation, so they allow users to define any threshold 
+rather than fixing it at $50k.
 
-Ding et al. compiled data from the American Community Survey (ACS) Public Use Microdata Sample (PUMS). 
-Note that this is a different source than the Annual Social and Economic Supplement (ASEC) 
-of the Current Population Survey (CPS) used to construct the original UCI Adult dataset.
-Ding et al. filtered the data such that ACSIncome only includes individuals above 16 years old 
-who worked at least 1 hour per week in the past year and had an income of at least $100.
+Ding et al. compiled data from the American Community Survey (ACS) Public 
+Use Microdata Sample (PUMS). Note that this is a different source than the 
+Annual Social and Economic Supplement (ASEC) of the Current Population 
+Survey (CPS) used to construct the original UCI Adult dataset. Ding et al. 
+filtered the data such that ACSIncome only includes individuals above 16 
+years old who worked at least 1 hour per week in the past year and had an 
+income of at least $100.
 
 
-.. _acsincome_dataset_description:
+.. _acsincome-dataset-description:
 
 Dataset Description
 ^^^^^^^^^^^^^^^^^^^
 Ding et al. provide data from 2014-2018 for all 50 states and Puerto Rico.
-We uploaded the 2018 data to OpenML, which fairlearn can access.
-The dataset contains 1,664,500 rows. Each row describes a person and contains 10 features, which we describe below:
+We uploaded the 2018 data to OpenML, which anyone can access.
+The dataset contains 1,664,500 rows. Each row describes a person and contains 
+10 features, which we describe below:
 
 .. list-table::
    :header-rows: 1
@@ -111,7 +117,7 @@ The dataset contains 1,664,500 rows. Each row describes a person and contains 10
          13. Unmarried partner
          14. Foster child
          15. Other nonrelative
-         16. Institutionalized group quarters population. Includes correctional facilities, nursing homes, and mental hopsitals. [3]_
+         16. Institutionalized group quarters population. Includes correctional facilities, nursing homes, and mental hospitals. [3]_
          17. Noninstitutionalized group quarters population. Includes college dormitories, military barracks, group homes, missions, and shelters. [3]_
 
    *  - WKHP
@@ -135,8 +141,9 @@ The dataset contains 1,664,500 rows. Each row describes a person and contains 10
          9. Two or More races
 
 
-The target label is given by PINCP. For generalizability, the integer value is provided.
-A threshold can be applied to PINCP to frame this as a binary classification task.
+The target label is given by PINCP. For generalizability, the integer value 
+is provided. A threshold can be applied to PINCP to frame this as a binary 
+classification task.
 
 .. list-table::
    :header-rows: 1
@@ -155,8 +162,9 @@ A threshold can be applied to PINCP to frame this as a binary classification tas
   .. [1] Frances Ding, Moritz Hardt, John Miller, Ludwig Schmidt `"Retiring Adult: New Datasets for Fair Machine Learning" <https://arxiv.org/pdf/2108.04884.pdf>`_,
       Advances in Neural Information Processing Systems 34, 2021.
 
-  .. [2] R. Kohavi and B. Becker. "UCI Adult Data Set." UCI Meachine Learning Repository, 5, 1996.
+  .. [2] R. Kohavi and B. Becker, UCI Machine Learning Repository: Adult Data Set, 01-May-1996. 
+      Available Online `[link] <https://archive.ics.uci.edu/ml/datasets/adult>`_.
 
-  .. [3] `"Group Quarters and Residence Rules for Poverty", <https://www.census.gov/topics/income-poverty/poverty/guidance/group-quarters.html>`_,
+  .. [3] `"Group Quarters and Residence Rules for Poverty" <https://www.census.gov/topics/income-poverty/poverty/guidance/group-quarters.html>`_,
       United States Census Bureau.
 

--- a/docs/user_guide/datasets/acs_income.rst
+++ b/docs/user_guide/datasets/acs_income.rst
@@ -5,12 +5,12 @@ Retiring Adult: ACSIncome
 Introduction
 ^^^^^^^^^^^^^^^^^
 
-The ACSIncome dataset is one of five datasets created by Ding et al. [#1]_ 
+The ACSIncome dataset is one of five datasets created by Ding et al. [#0]_ 
 as an improved alternative to the popular UCI Adult dataset.
 The authors compiled data from the American Community Survey (ACS) Public Use Microdata Sample (PUMS). 
 Note that this is a different source than the Annual Social and Economic Supplement (ASEC) 
 of the Current Population Survey (CPS) used to construct the original UCI Adult dataset.
-Ding et al. [#1]_ filtered the data such that ACSIncome only includes individuals above 16 years old 
+Ding et al. [#0]_ filtered the data such that ACSIncome only includes individuals above 16 years old 
 who worked at least 1 hour per week in the past year and had an income of at least $100.
 
 
@@ -160,6 +160,6 @@ An additonal column for the state code is also provided so users to easily filte
 
 .. topic:: References:
 
-  .. [#1] Frances Ding, Moritz Hardt, John Miller, Ludwig Schmidt `"Retiring Adult: New Datasets for Fair Machine Learning" <https://arxiv.org/pdf/2108.04884.pdf>`_,
+  .. [#0] Frances Ding, Moritz Hardt, John Miller, Ludwig Schmidt `"Retiring Adult: New Datasets for Fair Machine Learning" <https://arxiv.org/pdf/2108.04884.pdf>`_,
       Advances in Neural Information Processing Systems 34, 2021.
 

--- a/docs/user_guide/datasets/adult_data.rst
+++ b/docs/user_guide/datasets/adult_data.rst
@@ -2,7 +2,7 @@
 Retiring Adult
 -------------------------
 
-This section contains datasets created by Ding et al. [#1]_, which are described
+This section contains datasets created by Ding et al. [#0]_, which are described
 in their published paper "Retiring Adult: New Datasets for Fair Machine Learning" (2021).
 
 .. toctree::
@@ -13,6 +13,6 @@ in their published paper "Retiring Adult: New Datasets for Fair Machine Learning
 
 .. topic:: References:
 
-  .. [#1] Frances Ding, Moritz Hardt, John Miller, Ludwig Schmidt `"Retiring Adult: New Datasets for Fair Machine Learning" <https://arxiv.org/pdf/2108.04884.pdf>`_,
+  .. [#0] Frances Ding, Moritz Hardt, John Miller, Ludwig Schmidt `"Retiring Adult: New Datasets for Fair Machine Learning" <https://arxiv.org/pdf/2108.04884.pdf>`_,
       Advances in Neural Information Processing Systems 34, 2021.
 

--- a/docs/user_guide/datasets/adult_data.rst
+++ b/docs/user_guide/datasets/adult_data.rst
@@ -1,4 +1,4 @@
-.. _adult-data:
+.. _adult_data:
 Adult Census Dataset
 --------------------
 

--- a/docs/user_guide/datasets/adult_data.rst
+++ b/docs/user_guide/datasets/adult_data.rst
@@ -1,9 +1,11 @@
-.. _retiring-adult-data:
-Retiring Adult
--------------------------
+.. _adult-data:
+Adult Census Dataset
+--------------------
 
-This section contains datasets created by Ding et al. [1]_, which are described
-in their published paper "Retiring Adult: New Datasets for Fair Machine Learning" (2021).
+This section contains datasets created by Ding et al. [1]_. The 
+authors indend for their dataset to replace the UCI Adult dataset [2]_, 
+which is a popular benchmark dataset for comparing algorithmic interventions 
+with respect to fairness metrics.
 
 .. toctree::
    :maxdepth: 2
@@ -16,3 +18,5 @@ in their published paper "Retiring Adult: New Datasets for Fair Machine Learning
   .. [1] Frances Ding, Moritz Hardt, John Miller, Ludwig Schmidt `"Retiring Adult: New Datasets for Fair Machine Learning" <https://arxiv.org/pdf/2108.04884.pdf>`_,
       Advances in Neural Information Processing Systems 34, 2021.
 
+  .. [2] R. Kohavi and B. Becker, UCI Machine Learning Repository: Adult Data Set, 01-May-1996. 
+      Available Online `[link] <https://archive.ics.uci.edu/ml/datasets/adult>`_.

--- a/docs/user_guide/datasets/adult_data.rst
+++ b/docs/user_guide/datasets/adult_data.rst
@@ -1,0 +1,18 @@
+.. _retiring-adult-data:
+Retiring Adult
+-------------------------
+
+This section contains datasets created by Ding et al. [#1]_, which are described
+in their published paper "Retiring Adult: New Datasets for Fair Machine Learning" (2021).
+
+.. toctree::
+   :maxdepth: 2
+   :glob:
+
+   acs*
+
+.. topic:: References:
+
+  .. [#1] Frances Ding, Moritz Hardt, John Miller, Ludwig Schmidt `"Retiring Adult: New Datasets for Fair Machine Learning" <https://arxiv.org/pdf/2108.04884.pdf>`_,
+      Advances in Neural Information Processing Systems 34, 2021.
+

--- a/docs/user_guide/datasets/adult_data.rst
+++ b/docs/user_guide/datasets/adult_data.rst
@@ -2,7 +2,7 @@
 Retiring Adult
 -------------------------
 
-This section contains datasets created by Ding et al. [#0]_, which are described
+This section contains datasets created by Ding et al. [1]_, which are described
 in their published paper "Retiring Adult: New Datasets for Fair Machine Learning" (2021).
 
 .. toctree::
@@ -13,6 +13,6 @@ in their published paper "Retiring Adult: New Datasets for Fair Machine Learning
 
 .. topic:: References:
 
-  .. [#0] Frances Ding, Moritz Hardt, John Miller, Ludwig Schmidt `"Retiring Adult: New Datasets for Fair Machine Learning" <https://arxiv.org/pdf/2108.04884.pdf>`_,
+  .. [1] Frances Ding, Moritz Hardt, John Miller, Ludwig Schmidt `"Retiring Adult: New Datasets for Fair Machine Learning" <https://arxiv.org/pdf/2108.04884.pdf>`_,
       Advances in Neural Information Processing Systems 34, 2021.
 

--- a/docs/user_guide/datasets/adult_data.rst
+++ b/docs/user_guide/datasets/adult_data.rst
@@ -3,7 +3,7 @@ Adult Census Dataset
 --------------------
 
 This section contains datasets created by Ding et al. [1]_. The 
-authors indend for their dataset to replace the UCI Adult dataset [2]_, 
+authors intend for their dataset to replace the UCI Adult dataset [2]_, 
 which is a popular benchmark dataset for comparing algorithmic interventions 
 with respect to fairness metrics.
 

--- a/docs/user_guide/datasets/boston_housing_data.rst
+++ b/docs/user_guide/datasets/boston_housing_data.rst
@@ -1,6 +1,4 @@
-Datasets
-==========
-
+.. _boston-housing-data:
 Revisiting the Boston Housing Dataset
 -------------------------------------
 

--- a/docs/user_guide/datasets/boston_housing_data.rst
+++ b/docs/user_guide/datasets/boston_housing_data.rst
@@ -1,4 +1,4 @@
-.. _boston-housing-data:
+.. _boston_housing_data:
 Revisiting the Boston Housing Dataset
 -------------------------------------
 

--- a/docs/user_guide/datasets/index.rst
+++ b/docs/user_guide/datasets/index.rst
@@ -3,7 +3,7 @@
 Datasets
 ==========
 
-In this section we dive deeper into various datasets that have fairness-related concerns.
+In this section, we dive deeper into various datasets that have fairness-related concerns.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/user_guide/datasets/index.rst
+++ b/docs/user_guide/datasets/index.rst
@@ -1,0 +1,13 @@
+.. _datasets:
+
+Datasets
+==========
+
+This section contains pages describing datasets that have been
+incorporated into the Fairlearn package.
+
+.. toctree::
+   :maxdepth: 2
+
+   adult_data
+   boston_housing_data

--- a/docs/user_guide/datasets/index.rst
+++ b/docs/user_guide/datasets/index.rst
@@ -3,8 +3,7 @@
 Datasets
 ==========
 
-This section contains pages describing datasets that have been
-incorporated into the Fairlearn package.
+In this section we dive deeper into various datasets that have fairness-related concerns.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -9,6 +9,6 @@ User Guide
    fairness_in_machine_learning
    assessment
    mitigation
-   datasets
+   datasets/index
    installation_and_version_guide/index
    further_resources

--- a/docs/user_guide/installation_and_version_guide/v0.7.1.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.7.1.rst
@@ -17,3 +17,4 @@ v0.7.1
   integers.
 * :class:`~fairlearn.preprocessing.CorrelationRemover` now exposes
   :code:`n_features_in_` and :code:`feature_names_in_`.
+* Added the ACSIncome dataset and corresponding documentation.

--- a/fairlearn/datasets/__init__.py
+++ b/fairlearn/datasets/__init__.py
@@ -5,13 +5,13 @@
 """This module contains datasets that can be used for benchmarking and education."""
 
 
-from ._fetch_acsincome import fetch_acsincome
+from ._fetch_acs_income import fetch_acs_income
 from ._fetch_adult import fetch_adult
 from ._fetch_boston import fetch_boston
 from ._fetch_bank_marketing import fetch_bank_marketing
 
 __all__ = [
-    "fetch_acsincome",
+    "fetch_acs_income",
     "fetch_adult",
     "fetch_boston",
     "fetch_bank_marketing",

--- a/fairlearn/datasets/__init__.py
+++ b/fairlearn/datasets/__init__.py
@@ -5,11 +5,13 @@
 """This module contains datasets that can be used for benchmarking and education."""
 
 
+from ._fetch_acsincome import fetch_acsincome
 from ._fetch_adult import fetch_adult
 from ._fetch_boston import fetch_boston
 from ._fetch_bank_marketing import fetch_bank_marketing
 
 __all__ = [
+    "fetch_acsincome",
     "fetch_adult",
     "fetch_boston",
     "fetch_bank_marketing",

--- a/fairlearn/datasets/_fetch_acs_income.py
+++ b/fairlearn/datasets/_fetch_acs_income.py
@@ -13,16 +13,17 @@ def fetch_acs_income(*, cache=True, data_home=None,
                      as_frame=False, return_X_y=False,
                      states=None,
                      ):
-    """Load the ACS Income dataset.
+    """Load the ACS Income dataset (regression).
+    Read more in the :ref:`User Guide <acsincome_data>`.
 
     Download it if necessary.
 
-    ==============   ==============
-    Samples total           1664500
-    Dimensionality               10
-    Features                   real
-    Target                     real
-    ==============   ==============
+    ==============   ====================
+    Samples total                 1664500
+    Dimensionality                     10
+    Features         numeric, categorical
+    Target                        numeric
+    ==============   ====================
 
     Source: Paper: Ding et al. (2021) [1]_
             and corresponding repository https://github.com/zykls/folktables/
@@ -56,8 +57,7 @@ def fetch_acs_income(*, cache=True, data_home=None,
         If None, data from all 50 US states and Puerto Rico will be returned.
         Note that Puerto Rico is the only US territory included in this dataset.
         The state abbreviations and codes can be found on page 1 of the data
-        dictionary at ACS PUMS:
-        https://www2.census.gov/programs-surveys/acs/tech_docs/pums/data_dict/PUMS_Data_Dictionary_2018.pdf
+        dictionary at ACS PUMS [2]_.
 
     Returns
     -------
@@ -88,6 +88,9 @@ def fetch_acs_income(*, cache=True, data_home=None,
     .. [1] Ding, F., Hardt, M., Miller, J., & Schmidt, L. (2021).
        "Retiring Adult: New Datasets for Fair Machine Learning."
        Advances in Neural Information Processing Systems, 34.
+
+    .. [2] `"2018 ACS PUMS Data Dictionary" <https://www2.census.gov/programs-surveys/acs/tech_docs/pums/data_dict/PUMS_Data_Dictionary_2018.pdf>`_,
+       United States Census Bureau.
 
     """
     # State Code based on 2010 Census definitions

--- a/fairlearn/datasets/_fetch_acs_income.py
+++ b/fairlearn/datasets/_fetch_acs_income.py
@@ -9,10 +9,10 @@ from sklearn.datasets import fetch_openml
 from ._constants import _DOWNLOAD_DIRECTORY_NAME
 
 
-def fetch_acsincome(*, cache=True, data_home=None,
-                    as_frame=False, return_X_y=False,
-                    states=None,
-                    ):
+def fetch_acs_income(*, cache=True, data_home=None,
+                     as_frame=False, return_X_y=False,
+                     states=None,
+                     ):
     """Load the ACS Income dataset.
 
     Download it if necessary.

--- a/fairlearn/datasets/_fetch_acs_income.py
+++ b/fairlearn/datasets/_fetch_acs_income.py
@@ -54,6 +54,7 @@ def fetch_acs_income(*, cache=True, data_home=None,
     states: list, default=None
         List containing two letter (capitalized) state abbreviations.
         If None, data from all 50 US states and Puerto Rico will be returned.
+        Note that Puerto Rico is the only US territory included in this dataset.
         The state abbreviations and codes can be found on page 1 of the data
         dictionary at ACS PUMS:
         https://www2.census.gov/programs-surveys/acs/tech_docs/pums/data_dict/PUMS_Data_Dictionary_2018.pdf

--- a/fairlearn/datasets/_fetch_acs_income.py
+++ b/fairlearn/datasets/_fetch_acs_income.py
@@ -14,6 +14,7 @@ def fetch_acs_income(*, cache=True, data_home=None,
                      states=None,
                      ):
     """Load the ACS Income dataset (regression).
+
     Read more in the :ref:`User Guide <acsincome_data>`.
 
     Download it if necessary.
@@ -89,8 +90,7 @@ def fetch_acs_income(*, cache=True, data_home=None,
        "Retiring Adult: New Datasets for Fair Machine Learning."
        Advances in Neural Information Processing Systems, 34.
 
-    .. [2] `"2018 ACS PUMS Data Dictionary" <https://www2.census.gov/programs-surveys/acs/tech_docs/pums/data_dict/PUMS_Data_Dictionary_2018.pdf>`_,
-       United States Census Bureau.
+    .. [2] "2018 ACS PUMS Data Dictionary". United States Census Bureau.
 
     """
     # State Code based on 2010 Census definitions

--- a/fairlearn/datasets/_fetch_acsincome.py
+++ b/fairlearn/datasets/_fetch_acsincome.py
@@ -53,8 +53,9 @@ def fetch_acsincome(*, cache=True, data_home=None,
 
     states: list, default=None
         List containing two letter (capitalized) state abbreviations.
-        If None, data from all 50 US states, including Puerto Rico, will be returned.
-        The state abbreviations and codes can be found on page 1 of the data dictionary at ACS PUMS
+        If None, data from all 50 US states and Puerto Rico will be returned.
+        The state abbreviations and codes can be found on page 1 of the data
+        dictionary at ACS PUMS:
         https://www2.census.gov/programs-surveys/acs/tech_docs/pums/data_dict/PUMS_Data_Dictionary_2018.pdf
 
     Returns

--- a/fairlearn/datasets/_fetch_acsincome.py
+++ b/fairlearn/datasets/_fetch_acsincome.py
@@ -3,19 +3,23 @@
 
 import pathlib
 
+import numpy as np
+import pandas as pd
 from sklearn.datasets import fetch_openml
 from ._constants import _DOWNLOAD_DIRECTORY_NAME
 
 
 def fetch_acsincome(*, cache=True, data_home=None,
-                    as_frame=False, return_X_y=False):
+                    as_frame=False, return_X_y=False,
+                    states=None,
+                    ):
     """Load the ACS Income dataset.
 
     Download it if necessary.
 
     ==============   ==============
     Samples total           1664500
-    Dimensionality               12
+    Dimensionality               10
     Features                   real
     Target                     real
     ==============   ==============
@@ -47,21 +51,24 @@ def fetch_acsincome(*, cache=True, data_home=None,
         If True, returns ``(data.data, data.target)`` instead of a Bunch
         object.
 
+    states: list, default=None
+        List containing state abbreviations. If None, data from all 50 US
+        states, including Puerto Rico, will be returned.
+
     Returns
     -------
     dataset : :obj:`~sklearn.utils.Bunch`
         Dictionary-like object, with the following attributes.
 
-        data : ndarray, shape (1664500, 12)
-            Each row corresponding to the 10 feature values in order as well as
-            the state code (ST) and the target variable (PINCP).
+        data : ndarray, shape (1664500, 10)
+            Each row corresponding to the 10 feature values in order.
             If ``as_frame`` is True, ``data`` is a pandas object.
         target : numpy array of shape (1664500,)
             Integer denoting each person's income.
             A threshold can be applied as a postprocessing step to frame this
             as a binary classification problem.
             If ``as_frame`` is True, ``target`` is a pandas object.
-        feature_names : list of length 12
+        feature_names : list of length 10
             Array of ordered feature names used in the dataset.
         DESCR : string
             Description of the ACSIncome dataset.
@@ -79,13 +86,55 @@ def fetch_acsincome(*, cache=True, data_home=None,
        Advances in Neural Information Processing Systems, 34.
 
     """
+    # State Code based on 2010 Census definitions
+    _STATE_CODES = {'AL': '01', 'AK': '02', 'AZ': '04', 'AR': '05', 'CA': '06',
+                    'CO': '08', 'CT': '09', 'DE': '10', 'FL': '12', 'GA': '13',
+                    'HI': '15', 'ID': '16', 'IL': '17', 'IN': '18', 'IA': '19',
+                    'KS': '20', 'KY': '21', 'LA': '22', 'ME': '23', 'MD': '24',
+                    'MA': '25', 'MI': '26', 'MN': '27', 'MS': '28', 'MO': '29',
+                    'MT': '30', 'NE': '31', 'NV': '32', 'NH': '33', 'NJ': '34',
+                    'NM': '35', 'NY': '36', 'NC': '37', 'ND': '38', 'OH': '39',
+                    'OK': '40', 'OR': '41', 'PA': '42', 'RI': '44', 'SC': '45',
+                    'SD': '46', 'TN': '47', 'TX': '48', 'UT': '49', 'VT': '50',
+                    'VA': '51', 'WA': '53', 'WV': '54', 'WI': '55', 'WY': '56',
+                    'PR': '72'}
+    if states is None:
+        states = _STATE_CODES.keys()
     if not data_home:
         data_home = pathlib.Path().home() / _DOWNLOAD_DIRECTORY_NAME
 
-    return fetch_openml(
-        data_id=43137,
+    # fetch data for all 50 US states and Puerto Rico
+    data_dict = fetch_openml(
+        data_id=43141,
         data_home=data_home,
         cache=cache,
-        as_frame=as_frame,
-        return_X_y=return_X_y,
+        as_frame=True,
+        return_X_y=False,
     )
+
+    # filter by state
+    df_all = data_dict['data'].copy(deep=True)
+    df_all['PINCP'] = data_dict['target']
+    cols = df_all.columns
+    df = pd.DataFrame(np.zeros((0, len(cols))), columns=cols)
+    for state in states:
+        dfs = [df, df_all.query(f"ST == {int(_STATE_CODES[state])}")]
+        df = pd.concat(dfs)
+    # drop the state column since it is not a feature in the published ACSIncome dataset
+    df.drop('ST', axis=1, inplace=True)
+
+    if as_frame:
+        data_dict['data'] = df.iloc[:, :10]
+        data_dict['frame'] = df
+        data_dict['target'] = df.iloc[:, 10:]
+    else:
+        data_dict['data'] = df.iloc[:, :10].values
+        data_dict['frame'] = None
+        data_dict['target'] = df.iloc[:, 10:].values.flatten()
+
+    output = data_dict
+
+    if return_X_y:
+        output = (data_dict['data'], data_dict['target'])
+
+    return output

--- a/fairlearn/datasets/_fetch_acsincome.py
+++ b/fairlearn/datasets/_fetch_acsincome.py
@@ -10,7 +10,7 @@ from ._constants import _DOWNLOAD_DIRECTORY_NAME
 def fetch_acsincome(*, cache=True, data_home=None,
                     as_frame=False, return_X_y=False):
     """Load the ACS Income dataset.
-    
+
     Download it if necessary.
 
     ==============   ==============
@@ -52,7 +52,7 @@ def fetch_acsincome(*, cache=True, data_home=None,
         Dictionary-like object, with the following attributes.
 
         data : ndarray, shape (1664500, 12)
-            Each row corresponding to the 10 feature values in order as well as 
+            Each row corresponding to the 10 feature values in order as well as
             the state code (ST) and the target varaible (PINCP).
             If ``as_frame`` is True, ``data`` is a pandas object.
         target : numpy array of shape (1664500,)
@@ -73,9 +73,9 @@ def fetch_acsincome(*, cache=True, data_home=None,
 
     References
     ----------
-    .. [1] Frances Ding, Moritz Hardt, John Miller, Ludwig Schmidt 
-       "Retiring Adult: New Datasets for Fair Machine Learning"
-      Advances in Neural Information Processing Systems 34, 2021.
+    .. [1] Ding, F., Hardt, M., Miller, J., & Schmidt, L. (2021).
+       "Retiring Adult: New Datasets for Fair Machine Learning."
+       Advances in Neural Information Processing Systems, 34.
 
     """
     if not data_home:

--- a/fairlearn/datasets/_fetch_acsincome.py
+++ b/fairlearn/datasets/_fetch_acsincome.py
@@ -52,8 +52,11 @@ def fetch_acsincome(*, cache=True, data_home=None,
         object.
 
     states: list, default=None
-        List containing state abbreviations. If None, data from all 50 US
-        states, including Puerto Rico, will be returned.
+        List containing two letter (capitalized) state abbreviations.
+        If None, data from all 50 US states, including Puerto Rico, will be returned.
+        The state abbreviations and codes can be found on page 1 of the data dictionary at ACS PUMS
+        https://www2.census.gov/programs-surveys/acs/tech_docs/pums/data_dict/PUMS_Data_Dictionary_2018.pdf
+        and are reproduced in the `_STATE_CODES` dictionary below.
 
     Returns
     -------

--- a/fairlearn/datasets/_fetch_acsincome.py
+++ b/fairlearn/datasets/_fetch_acsincome.py
@@ -75,7 +75,7 @@ def fetch_acsincome(*, cache=True, data_home=None,
         DESCR : string
             Description of the ACSIncome dataset.
 
-    (data, target) : tuple of (numpy.ndarray, numpy.ndarray) or (pandas.DataFrame, pandas.Series)
+    (data, target) : tuple of (numpy.ndarray, numpy.ndarray)
         if ``return_X_y`` is True and ``as_frame`` is False
 
     (data, target) : tuple of (pandas.DataFrame, pandas.Series)

--- a/fairlearn/datasets/_fetch_acsincome.py
+++ b/fairlearn/datasets/_fetch_acsincome.py
@@ -20,9 +20,10 @@ def fetch_acsincome(*, cache=True, data_home=None,
     Target                     real
     ==============   ==============
 
-    Source: Paper: Frances Ding (2021) [1]_
+    Source: Paper: Ding et al. (2021) [1]_
+            and corresponding repository https://github.com/zykls/folktables/
 
-    .. versionadded:: 0.8.0
+    .. versionadded:: 0.7.1
 
     Parameters
     ----------
@@ -53,7 +54,7 @@ def fetch_acsincome(*, cache=True, data_home=None,
 
         data : ndarray, shape (1664500, 12)
             Each row corresponding to the 10 feature values in order as well as
-            the state code (ST) and the target varaible (PINCP).
+            the state code (ST) and the target variable (PINCP).
             If ``as_frame`` is True, ``data`` is a pandas object.
         target : numpy array of shape (1664500,)
             Integer denoting each person's income.

--- a/fairlearn/datasets/_fetch_acsincome.py
+++ b/fairlearn/datasets/_fetch_acsincome.py
@@ -64,7 +64,7 @@ def fetch_acsincome(*, cache=True, data_home=None,
             Each row corresponding to the 10 feature values in order.
             If ``as_frame`` is True, ``data`` is a pandas object.
         target : numpy array of shape (1664500,)
-            Integer denoting each person's income.
+            Integer denoting each person's annual income.
             A threshold can be applied as a postprocessing step to frame this
             as a binary classification problem.
             If ``as_frame`` is True, ``target`` is a pandas object.

--- a/fairlearn/datasets/_fetch_acsincome.py
+++ b/fairlearn/datasets/_fetch_acsincome.py
@@ -1,0 +1,90 @@
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
+# Licensed under the MIT License.
+
+import pathlib
+
+from sklearn.datasets import fetch_openml
+from ._constants import _DOWNLOAD_DIRECTORY_NAME
+
+
+def fetch_acsincome(*, cache=True, data_home=None,
+                    as_frame=False, return_X_y=False):
+    """Load the ACS Income dataset.
+    
+    Download it if necessary.
+
+    ==============   ==============
+    Samples total           1664500
+    Dimensionality               12
+    Features                   real
+    Target                     real
+    ==============   ==============
+
+    Source: Paper: Frances Ding (2021) [1]_
+
+    .. versionadded:: 0.8.0
+
+    Parameters
+    ----------
+    cache : bool, default=True
+        Whether to cache downloaded datasets using joblib.
+
+    data_home : str, default=None
+        Specify another download and cache folder for the datasets.
+        By default, all scikit-learn data is stored in '~/.fairlearn-data'
+        subfolders.
+
+    as_frame : bool, default=False
+        If True, the data is a pandas DataFrame including columns with
+        appropriate dtypes (numeric, string or categorical). The target is
+        a pandas DataFrame or Series depending on the number of target_columns.
+        The Bunch will contain a ``frame`` attribute with the target and the
+        data. If ``return_X_y`` is True, then ``(data, target)`` will be pandas
+        DataFrames or Series as describe above.
+
+    return_X_y : bool, default=False
+        If True, returns ``(data.data, data.target)`` instead of a Bunch
+        object.
+
+    Returns
+    -------
+    dataset : :obj:`~sklearn.utils.Bunch`
+        Dictionary-like object, with the following attributes.
+
+        data : ndarray, shape (1664500, 12)
+            Each row corresponding to the 10 feature values in order as well as 
+            the state code (ST) and the target varaible (PINCP).
+            If ``as_frame`` is True, ``data`` is a pandas object.
+        target : numpy array of shape (1664500,)
+            Integer denoting each person's income.
+            A threshold can be applied as a postprocessing step to frame this
+            as a binary classification problem.
+            If ``as_frame`` is True, ``target`` is a pandas object.
+        feature_names : list of length 12
+            Array of ordered feature names used in the dataset.
+        DESCR : string
+            Description of the ACSIncome dataset.
+
+    (data, target) : tuple of (numpy.ndarray, numpy.ndarray) or (pandas.DataFrame, pandas.Series)
+        if ``return_X_y`` is True and ``as_frame`` is False
+
+    (data, target) : tuple of (pandas.DataFrame, pandas.Series)
+        if ``return_X_y`` is True and ``as_frame`` is True
+
+    References
+    ----------
+    .. [1] Frances Ding, Moritz Hardt, John Miller, Ludwig Schmidt 
+       "Retiring Adult: New Datasets for Fair Machine Learning"
+      Advances in Neural Information Processing Systems 34, 2021.
+
+    """
+    if not data_home:
+        data_home = pathlib.Path().home() / _DOWNLOAD_DIRECTORY_NAME
+
+    return fetch_openml(
+        data_id=43137,
+        data_home=data_home,
+        cache=cache,
+        as_frame=as_frame,
+        return_X_y=return_X_y,
+    )

--- a/fairlearn/datasets/_fetch_acsincome.py
+++ b/fairlearn/datasets/_fetch_acsincome.py
@@ -32,7 +32,7 @@ def fetch_acsincome(*, cache=True, data_home=None,
 
     data_home : str, default=None
         Specify another download and cache folder for the datasets.
-        By default, all scikit-learn data is stored in '~/.fairlearn-data'
+        By default, all fairlearn data is stored in '~/.fairlearn-data'
         subfolders.
 
     as_frame : bool, default=False

--- a/fairlearn/datasets/_fetch_acsincome.py
+++ b/fairlearn/datasets/_fetch_acsincome.py
@@ -56,7 +56,6 @@ def fetch_acsincome(*, cache=True, data_home=None,
         If None, data from all 50 US states, including Puerto Rico, will be returned.
         The state abbreviations and codes can be found on page 1 of the data dictionary at ACS PUMS
         https://www2.census.gov/programs-surveys/acs/tech_docs/pums/data_dict/PUMS_Data_Dictionary_2018.pdf
-        and are reproduced in the `_STATE_CODES` dictionary below.
 
     Returns
     -------
@@ -101,8 +100,24 @@ def fetch_acsincome(*, cache=True, data_home=None,
                     'SD': '46', 'TN': '47', 'TX': '48', 'UT': '49', 'VT': '50',
                     'VA': '51', 'WA': '53', 'WV': '54', 'WI': '55', 'WY': '56',
                     'PR': '72'}
-    if states is None:
+    # number of features
+    _NUM_FEATS = 10
+
+    # check that user-provided state abbreviations are valid
+    if states is not None:
+        states = [state.upper() for state in states]
+        for state in states:
+            try:
+                _STATE_CODES[state]
+            except KeyError:
+                raise KeyError(f'Error with state code: {state}\n'
+                               f'State code must be a two letter abbreviation'
+                               f'from the list {list(_STATE_CODES.keys())}\n'
+                               f'Note that PR is the abbreviation for Puerto Rico.'
+                               )
+    else:
         states = _STATE_CODES.keys()
+
     if not data_home:
         data_home = pathlib.Path().home() / _DOWNLOAD_DIRECTORY_NAME
 
@@ -127,13 +142,13 @@ def fetch_acsincome(*, cache=True, data_home=None,
     df.drop('ST', axis=1, inplace=True)
 
     if as_frame:
-        data_dict['data'] = df.iloc[:, :10]
+        data_dict['data'] = df.iloc[:, :_NUM_FEATS]
         data_dict['frame'] = df
-        data_dict['target'] = df.iloc[:, 10:]
+        data_dict['target'] = df.iloc[:, _NUM_FEATS]
     else:
-        data_dict['data'] = df.iloc[:, :10].values
+        data_dict['data'] = df.iloc[:, :_NUM_FEATS].values
         data_dict['frame'] = None
-        data_dict['target'] = df.iloc[:, 10:].values.flatten()
+        data_dict['target'] = df.iloc[:, _NUM_FEATS].values
 
     output = data_dict
 

--- a/fairlearn/datasets/_fetch_adult.py
+++ b/fairlearn/datasets/_fetch_adult.py
@@ -34,7 +34,7 @@ def fetch_adult(*, cache=True, data_home=None,
 
     data_home : str, default=None
         Specify another download and cache folder for the datasets.
-        By default, all scikit-learn data is stored in '~/.fairlearn-data'
+        By default, all fairlearn data is stored in '~/.fairlearn-data'
         subfolders.
 
     as_frame : bool, default=False

--- a/fairlearn/datasets/_fetch_adult.py
+++ b/fairlearn/datasets/_fetch_adult.py
@@ -10,6 +10,7 @@ from ._constants import _DOWNLOAD_DIRECTORY_NAME
 def fetch_adult(*, cache=True, data_home=None,
                 as_frame=False, return_X_y=False):
     """Load the UCI Adult dataset (binary classification).
+
     Read more in the :ref:`User Guide <boston_housing_data>`.
 
     Download it if necessary.

--- a/fairlearn/datasets/_fetch_adult.py
+++ b/fairlearn/datasets/_fetch_adult.py
@@ -66,7 +66,7 @@ def fetch_adult(*, cache=True, data_home=None,
         DESCR : string
             Description of the UCI Adult dataset.
 
-    (data, target) : tuple of (numpy.ndarray, numpy.ndarray) or (pandas.DataFrame, pandas.Series)
+    (data, target) : tuple of (numpy.ndarray, numpy.ndarray)
         if ``return_X_y`` is True and ``as_frame`` is False
 
     (data, target) : tuple of (pandas.DataFrame, pandas.Series)

--- a/fairlearn/datasets/_fetch_adult.py
+++ b/fairlearn/datasets/_fetch_adult.py
@@ -10,15 +10,16 @@ from ._constants import _DOWNLOAD_DIRECTORY_NAME
 def fetch_adult(*, cache=True, data_home=None,
                 as_frame=False, return_X_y=False):
     """Load the UCI Adult dataset (binary classification).
+    Read more in the :ref:`User Guide <boston_housing_data>`.
 
     Download it if necessary.
 
-    ==============   ==============
-    Samples total             48842
-    Dimensionality               14
-    Features                   real
-    Classes                       2
-    ==============   ==============
+    ==============   ====================
+    Samples total                   48842
+    Dimensionality                     14
+    Features         numeric, categorical
+    Classes                             2
+    ==============   ====================
 
     Source: UCI Repository [1]_ , Paper: R. Kohavi (1996) [2]_
 

--- a/fairlearn/datasets/_fetch_bank_marketing.py
+++ b/fairlearn/datasets/_fetch_bank_marketing.py
@@ -39,7 +39,7 @@ def fetch_bank_marketing(*, cache=True, data_home=None,
 
     data_home : str, default=None
         Specify another download and cache folder for the datasets.
-        By default, all data is stored in '~/.fairlearn-data'
+        By default, all fairlearn data is stored in '~/.fairlearn-data'
         subfolders.
 
     as_frame : bool, default=False

--- a/fairlearn/datasets/_fetch_bank_marketing.py
+++ b/fairlearn/datasets/_fetch_bank_marketing.py
@@ -72,7 +72,7 @@ def fetch_bank_marketing(*, cache=True, data_home=None,
         DESCR : string
             Description of the UCI bank marketing dataset.
 
-    (data, target) : tuple of (numpy.ndarray, numpy.ndarray) or (pandas.DataFrame, pandas.Series)
+    (data, target) : tuple of (numpy.ndarray, numpy.ndarray)
         if ``return_X_y`` is True and ``as_frame`` is False
 
     (data, target) : tuple of (pandas.DataFrame, pandas.Series)

--- a/fairlearn/datasets/_fetch_boston.py
+++ b/fairlearn/datasets/_fetch_boston.py
@@ -101,7 +101,7 @@ def fetch_boston(*, cache=True, data_home=None,
         DESCR : string
             Description of the Boston housing dataset.
 
-    (data, target) : tuple of (numpy.ndarray, numpy.ndarray) or (pandas.DataFrame, pandas.Series)
+    (data, target) : tuple of (numpy.ndarray, numpy.ndarray)
         if ``return_X_y`` is True and ``as_frame`` is False
 
     (data, target) : tuple of (pandas.DataFrame, pandas.Series)

--- a/fairlearn/datasets/_fetch_boston.py
+++ b/fairlearn/datasets/_fetch_boston.py
@@ -64,7 +64,7 @@ def fetch_boston(*, cache=True, data_home=None,
 
     data_home : str, default=None
         Specify another download and cache folder for the datasets.
-        By default, all scikit-learn data is stored in '~/.fairlearn-data'
+        By default, all fairlearn data is stored in '~/.fairlearn-data'
         subfolders.
 
     as_frame : bool, default=False


### PR DESCRIPTION
This PR introduces documentation describing the ACSIncome dataset, which is 1 of 5 datasets created and published by Ding et al. (2021) [link](https://arxiv.org/pdf/2108.04884.pdf). The documentation summarizes the features and target variable of the dataset. It also reorganizes the documentation files in preparation for adding the other datasets from Ding et al. However, in the spirit of [Lutz' Law](https://twitter.com/romanlutz13/status/1451289545627086849), the other datasets will be left for future PRs.

Looking forward to your comments. Thanks in advance for reviewing!



