### PR TITLE
Fixed quickstart page

### DIFF
--- a/examples/plot_quickstart.py
+++ b/examples/plot_quickstart.py
@@ -12,6 +12,7 @@ from fairlearn.metrics import (
     MetricFrame,
     false_positive_rate,
     true_positive_rate,
+    true_negative_rate,
     selection_rate,
     count,
 )
@@ -35,7 +36,7 @@ metrics = {
     "precision": precision_score,
     "recall": recall_score,
     "false positive rate": false_positive_rate,
-    "true positive rate": true_positive_rate,
+    "true negative rate": true_negative_rate,
     "selection rate": selection_rate,
     "count": count,
 }

--- a/examples/plot_quickstart.py
+++ b/examples/plot_quickstart.py
@@ -11,14 +11,13 @@ MetricFrame visualizations
 from fairlearn.metrics import (
     MetricFrame,
     false_positive_rate,
-    true_positive_rate,
-    true_negative_rate,
+    false_negative_rate,
     selection_rate,
     count,
 )
 import pandas as pd
 from sklearn.datasets import fetch_openml
-from sklearn.metrics import accuracy_score, precision_score, recall_score
+from sklearn.metrics import accuracy_score, precision_score
 from sklearn.tree import DecisionTreeClassifier
 
 data = fetch_openml(data_id=1590, as_frame=True)
@@ -34,9 +33,8 @@ y_pred = classifier.predict(X)
 metrics = {
     "accuracy": accuracy_score,
     "precision": precision_score,
-    "recall": recall_score,
     "false positive rate": false_positive_rate,
-    "true negative rate": true_negative_rate,
+    "false negative rate": false_negative_rate,
     "selection rate": selection_rate,
     "count": count,
 }


### PR DESCRIPTION
Before:
- Fairlearn quickstart page showed both recall and true positive rate, which are the same metrics, on its plots.

Now:
- Replaced true positive rate with true negative rate on the plots.