### PR TITLE
Fix test in MetricFrame

### DIFF
--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -22,7 +22,8 @@ _VALID_ERROR_STRING = ['raise', 'coerce']
 _VALID_GROUPING_FUNCTION = ['min', 'max']
 
 _SF_DICT_CONVERSION_FAILURE = "DataFrame.from_dict() failed on sensitive features. " \
-    "Please ensure each array is strictly 1-D."
+    "Please ensure each array is strictly 1-D. " \
+    "The __cause__ field of this exception may contain further information."
 _BAD_FEATURE_LENGTH = "Received a feature of length {0} when length {1} was expected"
 _SUBGROUP_COUNT_WARNING = "Found {0} subgroups. Evaluation may be slow"
 _FEATURE_LIST_NONSCALAR = "Feature lists must be of scalar types"

--- a/test/unit/metrics/test_metricframe_process_features.py
+++ b/test/unit/metrics/test_metricframe_process_features.py
@@ -100,9 +100,6 @@ class TestSingleFeature():
             _ = target._process_features("Unused", raw_feature, y_true)
         assert msg == ve.value.args[0]
         assert ve.value.__cause__ is not None
-        assert isinstance(ve.value.__cause__, ValueError)
-        # Ensure we got the gnomic pandas message
-        assert ve.value.__cause__.args[0] == 'If using all scalar values, you must pass an index'
 
 
 class TestTwoFeatures():

--- a/test/unit/metrics/test_metricframe_process_features.py
+++ b/test/unit/metrics/test_metricframe_process_features.py
@@ -95,7 +95,8 @@ class TestSingleFeature():
         raw_feature = {'Mine!': np.asarray(r_f).reshape(-1, 1)}
         target = _get_raw_MetricFrame()
         msg = "DataFrame.from_dict() failed on sensitive features. "\
-            "Please ensure each array is strictly 1-D."
+            "Please ensure each array is strictly 1-D. "\
+            "The __cause__ field of this exception may contain further information."
         with pytest.raises(ValueError) as ve:
             _ = target._process_features("Unused", raw_feature, y_true)
         assert msg == ve.value.args[0]


### PR DESCRIPTION
An update to `pandas` (with Python 3.9) changed an error message from `DataFrame.from_dict()`. One of our tests was unnecessarily examining this error message, and hence started failing. Remove this check, and change the message in our exception.

Closes #1012 