### PR TITLE
Fix other ML packages tests

### DIFF
--- a/test_othermlpackages/conda-tensorflow.yaml
+++ b/test_othermlpackages/conda-tensorflow.yaml
@@ -7,4 +7,5 @@ dependencies:
 - pip>=19.1.1
 - pytest
 - pip:
-   - scikeras[tensorflow] # Latest TF not on conda-forge
+   - scikeras
+   - tensorflow # Latest TF not on conda-forge

--- a/test_othermlpackages/conda-tensorflow.yaml
+++ b/test_othermlpackages/conda-tensorflow.yaml
@@ -6,6 +6,5 @@ dependencies:
 - python==3.8
 - pip>=19.1.1
 - pytest
-- tensorflow>=2.4
+- tensorflow>=2.7.0
 - scikeras
-- pip:

--- a/test_othermlpackages/conda-tensorflow.yaml
+++ b/test_othermlpackages/conda-tensorflow.yaml
@@ -7,5 +7,4 @@ dependencies:
 - pip>=19.1.1
 - pytest
 - pip:
-   - scikeras
-   - tensorflow # Latest TF not on conda-forge
+   - scikeras[tensorflow] # Latest TF not on conda-forge

--- a/test_othermlpackages/conda-tensorflow.yaml
+++ b/test_othermlpackages/conda-tensorflow.yaml
@@ -6,4 +6,6 @@ dependencies:
 - python==3.8
 - pip>=19.1.1
 - pytest
-- scikeras
+pip:
+   - scikeras
+   - tensorflow # Latest TF not on conda-forge

--- a/test_othermlpackages/conda-tensorflow.yaml
+++ b/test_othermlpackages/conda-tensorflow.yaml
@@ -6,5 +6,4 @@ dependencies:
 - python==3.8
 - pip>=19.1.1
 - pytest
-- tensorflow>=2.7.0
 - scikeras

--- a/test_othermlpackages/conda-tensorflow.yaml
+++ b/test_othermlpackages/conda-tensorflow.yaml
@@ -7,5 +7,5 @@ dependencies:
 - pip>=19.1.1
 - pytest
 - tensorflow>=2.4
+- scikeras
 - pip:
-   - scikeras

--- a/test_othermlpackages/conda-tensorflow.yaml
+++ b/test_othermlpackages/conda-tensorflow.yaml
@@ -6,6 +6,6 @@ dependencies:
 - python==3.8
 - pip>=19.1.1
 - pytest
-pip:
+- pip:
    - scikeras
    - tensorflow # Latest TF not on conda-forge

--- a/test_othermlpackages/conda-xgboost.yaml
+++ b/test_othermlpackages/conda-xgboost.yaml
@@ -7,6 +7,7 @@ dependencies:
 - pip>=19.1.1
 - pytest
 - xgboost
+- pandas
 
 # Note xgboost not available for Windows on conda-forge
 # See

--- a/test_othermlpackages/conda-xgboost.yaml
+++ b/test_othermlpackages/conda-xgboost.yaml
@@ -7,7 +7,7 @@ dependencies:
 - pip>=19.1.1
 - pytest
 - xgboost
-- pandas
+- pandas<1.4 # Capped for xgboost only
 
 # Note xgboost not available for Windows on conda-forge
 # See


### PR DESCRIPTION
Fix a couple of issues with our tests with other ML packages:

- The latest version of `pandas` objects to how `xgboost` was using it (specifically `FutureWarning: pandas.Int64Index is deprecated and will be removed from pandas in a future version. Use pandas.Index with the appropriate dtype instead.`). Temporarily exclude this version of `pandas` with an upper bound
- It appears that `conda-forge` had the latest `scikeras` but not the latest `tensorflow` to match it. Switch to installing both from `pip`

Have filed #1015 as a reminder to watch `xgboost` for an update to be compatible with the latest `pandas`.