### PR TITLE
DOC: Add code example for ThresholdOptimizer #894

### DIFF
--- a/fairlearn/postprocessing/_threshold_optimizer.py
+++ b/fairlearn/postprocessing/_threshold_optimizer.py
@@ -211,6 +211,61 @@ class ThresholdOptimizer(BaseEstimator, MetaEstimatorMixin):
        Supervised Learning," arXiv.org, 07-Oct-2016.
        [Online]. Available: https://arxiv.org/abs/1610.02413.
 
+    Examples
+    --------
+    >>> from fairlearn.postprocessing import ThresholdOptimizer
+    >>> from fairlearn.metrics import MetricFrame, selection_rate
+    >>> from sklearn.metrics import accuracy_score
+    >>> from sklearn.linear_model import LogisticRegression
+    >>> from sklearn.model_selection import train_test_split
+    >>> from sklearn.preprocessing import StandardScaler
+    >>> from sklearn.pipeline import Pipeline
+    >>> from sklearn.metrics import balanced_accuracy_score
+    >>> import numpy as np
+
+    First we create some artificial data and fit an unmitigated pipeline to it
+
+    >>> X                  = np.array([[0], [1], [2], [3], [4], [5], [6], [7], [8], [9]])
+    >>> y                  = np.array([ 1 ,  1 ,  1 ,  1 ,  0,   0 ,  1 ,  0 ,  0 ,  0 ])
+    >>> sensitive_features = np.array(["a", "b", "a", "a", "b", "a", "b", "b", "a", "b"])
+    >>> X_train, X_test, y_train, y_test, sensitive_train, sensitive_test = train_test_split(
+    ...                                                                     X,
+    ...                                                                     y,
+    ...                                                                     sensitive_features,
+    ...                                                                     stratify=y,
+    ...                                                                     random_state=1)
+    >>> unmitigated_pipeline = Pipeline(steps=[
+    ...                         ("preprocessing", StandardScaler()),
+    ...                         ("logistic_regression", LogisticRegression(max_iter=1000))])
+    >>> unmitigated_pipeline.fit(X_train, y_train)
+
+    Now we instantiate the ThresholdOptimizer with the logistic regression estimator
+
+    >>> postprocess_est = ThresholdOptimizer(
+    ...                    estimator=unmitigated_pipeline,
+    ...                    constraints="false_negative_rate_parity",
+    ...                    objective="balanced_accuracy_score",
+    ...                    prefit=True,
+    ...                    predict_method='predict_proba')
+    >>> postprocess_est.fit(X_train, Y_train, sensitive_features=sensitive_train)
+
+    Record and evaluate the output of the trained ThresholdOptimizer on test data
+
+    >>> Y_pred_postprocess = postprocess_est.predict(X_test, sensitive_features=sensitive_test)
+    >>> metrics = {"selection_rate": selection_rate}
+    >>> metricframe_postprocess = MetricFrame(
+    ...                            metrics=metrics,
+    ...                            y_true=y_test,
+    ...                            y_pred=Y_pred_postprocess,
+    ...                            sensitive_features=sensitive_test)
+
+    Access the disaggregated metrics via a pandas Series
+
+    >>> metricframe_postprocess.by_group # doctest: +NORMALIZE_WHITESPACE
+                        selection_rate
+    sensitive_feature_0
+    a                             1.0
+    b                             1.0
     """
 
     def __init__(


### PR DESCRIPTION
Hereby my first PR for adding a code example for the ThresholdOptimizer, as mentioned in #894. I used the [existing example](https://fairlearn.org/main/api_reference/fairlearn.metrics.html) for the `MetricFrame` and the Scipy tutorial `https://github.com/fairlearn/talks/blob/main/2021_scipy_tutorial/fairness-in-AI-systems-instructors.ipynb` for inspiration. It's quite a long example, because the `ThresholdOptimizer` needs another estimated whose output is postprocessed.

![code_example_threshold](https://user-images.githubusercontent.com/33757199/153172931-d6d355de-0550-41e6-a976-04418a71d01b.png)
