### PR TITLE
Update Windows image

### DIFF
--- a/devops/PR-Gate.yml
+++ b/devops/PR-Gate.yml
@@ -22,7 +22,7 @@ jobs:
 
 - template: templates/all-tests-job-template.yml
   parameters:
-    platforms:  { Windows: vs2017-win2016 }
+    platforms:  { Windows: windows-latest }
     installationType: 'PipLocal'
     pyVersions: [3.7]
     freezeArtifactStem: $(FreezeArtifactStem)

--- a/devops/nightly-requirements-fixed.yml
+++ b/devops/nightly-requirements-fixed.yml
@@ -24,7 +24,7 @@ pool:
 jobs:
 - template: templates/all-tests-job-template.yml
   parameters:
-    platforms:  { Linux: ubuntu-latest, Windows: vs2017-win2016 }
+    platforms:  { Linux: ubuntu-latest, Windows: windows-latest }
     installationType: 'PipLocal'
     pyVersions: [3.7, 3.8]
     freezeArtifactStem: $(FreezeArtifactStem)

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -22,7 +22,7 @@ pool:
 jobs:
 - template: templates/all-tests-job-template.yml
   parameters:
-    platforms:  { Linux: ubuntu-latest, Windows: vs2017-win2016 }
+    platforms:  { Linux: ubuntu-latest, Windows: windows-latest }
     installationType: 'PipLocal'
     pyVersions: [3.7, 3.8, 3.9]
     freezeArtifactStem: $(FreezeArtifactStem)

--- a/devops/pypi-release-new.yml
+++ b/devops/pypi-release-new.yml
@@ -129,7 +129,7 @@ stages:
   jobs:
     - template: templates/all-tests-job-template.yml
       parameters:
-        platforms: { Linux: ubuntu-latest, Windows: vs2017-win2016 }
+        platforms: { Linux: ubuntu-latest, Windows: windows-latest }
         installationType: 'WheelArtifact'
         pyVersions: [3.7, 3.8, 3.9]
         freezeArtifactStem: $(freezeArtifactStem)
@@ -220,7 +220,7 @@ stages:
   jobs:
   - template: templates/all-tests-job-template.yml
     parameters:
-      platforms:  { Linux: ubuntu-latest, Windows: vs2017-win2016 }
+      platforms:  { Linux: ubuntu-latest, Windows: windows-latest }
       pyVersions: [3.7, 3.8, 3.9]
       freezeArtifactStem: $(freezeArtifactStem)
       freezeFileStem: $(freezeFileStem)

--- a/devops/pypi-release-new.yml
+++ b/devops/pypi-release-new.yml
@@ -44,7 +44,7 @@ stages:
   jobs:
   - template: templates/all-tests-job-template.yml
     parameters:
-      platforms:  { Linux: ubuntu-latest, Windows: vs2017-win2016 }
+      platforms:  { Linux: ubuntu-latest, Windows: windows-latest }
       installationType: 'PipLocal'
       pyVersions: [3.7, 3.8, 3.9]
       freezeArtifactStem: $(freezeArtifactStem)

--- a/devops/templates/all-tests-job-template.yml
+++ b/devops/templates/all-tests-job-template.yml
@@ -14,7 +14,7 @@
 # three parameters
 
 parameters:
-  platforms: { Linux: ubuntu-latest, Windows: vs2017-win2016 }
+  platforms: { Linux: ubuntu-latest, Windows: windows-latest }
   testRunTypes: ['Unit', 'Notebooks']
   installationType:
   pyVersions: [3.7, 3.8, 3.9]


### PR DESCRIPTION
The Windows image we have been using in our build is scheduled for retirement. See [this issue](https://github.com/actions/virtual-environments/issues/4312) for more details. Change to use the `windows-latest` image.