### PR TITLE
Wrap roc_auc_score in _create_group_metric_set()

### DIFF
--- a/fairlearn/metrics/_group_metric_set.py
+++ b/fairlearn/metrics/_group_metric_set.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
-import logging
+import warnings
 
 import sklearn.metrics as skm
 from sklearn import preprocessing
@@ -18,8 +18,6 @@ from ._extra_metrics import (_balanced_root_mean_squared_error,
                              count)
 from ._metric_frame import MetricFrame
 from ._input_manipulations import _convert_to_ndarray_and_squeeze
-
-logger = logging.getLogger(__name__)
 
 _Y_TRUE = 'trueY'
 _Y_PRED = 'predictedY'
@@ -79,7 +77,7 @@ class func_wrapper:
             result = self.metric_function(y_true, y_pred)
         except ValueError:
             msg = "Evaluation of {0} failed. Substituting 0"
-            logger.warning(msg.format(self.metric_function.__name__))
+            warnings.warn(msg.format(self.metric_function.__name__))
         return result
 
 

--- a/fairlearn/metrics/_group_metric_set.py
+++ b/fairlearn/metrics/_group_metric_set.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
+import logging
+
 import sklearn.metrics as skm
 from sklearn import preprocessing
 
@@ -16,6 +18,8 @@ from ._extra_metrics import (_balanced_root_mean_squared_error,
                              count)
 from ._metric_frame import MetricFrame
 from ._input_manipulations import _convert_to_ndarray_and_squeeze
+
+logger = logging.getLogger(__name__)
 
 _Y_TRUE = 'trueY'
 _Y_PRED = 'predictedY'
@@ -64,6 +68,21 @@ SELECTION_RATE = "selection_rate"
 SPECIFICITY_SCORE = "specificity_score"
 ZERO_ONE_LOSS = "zero_one_loss"
 
+
+class func_wrapper:
+    def __init__(self, metric_function):
+        self.metric_function = metric_function
+
+    def __call__(self, y_true, y_pred):
+        result = 0
+        try:
+            result = self.metric_function(y_true, y_pred)
+        except ValueError:
+            msg = "Evaluation of {0} failed. Substituting 0"
+            logger.warning(msg.format(self.metric_function.__name__))
+        return result
+
+
 BINARY_CLASSIFICATION_METRICS = {}
 BINARY_CLASSIFICATION_METRICS[ACCURACY_SCORE] = skm.accuracy_score
 BINARY_CLASSIFICATION_METRICS[COUNT] = count
@@ -74,7 +93,7 @@ BINARY_CLASSIFICATION_METRICS[MEAN_UNDERPREDICTION] = _mean_underprediction
 BINARY_CLASSIFICATION_METRICS[MISS_RATE] = false_negative_rate
 BINARY_CLASSIFICATION_METRICS[PRECISION_SCORE] = skm.precision_score
 BINARY_CLASSIFICATION_METRICS[RECALL_SCORE] = skm.recall_score
-BINARY_CLASSIFICATION_METRICS[ROC_AUC_SCORE] = skm.roc_auc_score
+BINARY_CLASSIFICATION_METRICS[ROC_AUC_SCORE] = func_wrapper(skm.roc_auc_score)
 BINARY_CLASSIFICATION_METRICS[SELECTION_RATE] = selection_rate
 BINARY_CLASSIFICATION_METRICS[SPECIFICITY_SCORE] = true_negative_rate
 

--- a/fairlearn/metrics/_group_metric_set.py
+++ b/fairlearn/metrics/_group_metric_set.py
@@ -6,41 +6,45 @@ import warnings
 import sklearn.metrics as skm
 from sklearn import preprocessing
 
-from ._extra_metrics import (_balanced_root_mean_squared_error,
-                             _mean_overprediction,
-                             _mean_underprediction,
-                             _root_mean_squared_error,
-                             false_negative_rate,
-                             false_positive_rate,
-                             mean_prediction,
-                             selection_rate,
-                             true_negative_rate,
-                             count)
+from ._extra_metrics import (
+    _balanced_root_mean_squared_error,
+    _mean_overprediction,
+    _mean_underprediction,
+    _root_mean_squared_error,
+    false_negative_rate,
+    false_positive_rate,
+    mean_prediction,
+    selection_rate,
+    true_negative_rate,
+    count,
+)
 from ._metric_frame import MetricFrame
 from ._input_manipulations import _convert_to_ndarray_and_squeeze
 
-_Y_TRUE = 'trueY'
-_Y_PRED = 'predictedY'
-_PRECOMPUTED_METRICS = 'precomputedMetrics'
-_GLOBAL = 'global'
-_BINS = 'bins'
-_PRECOMPUTED_BINS = 'precomputedFeatureBins'
-_BIN_VECTOR = 'binVector'
-_BIN_LABELS = 'binLabels'
-_FEATURE_BIN_NAME = 'featureBinName'
-_PREDICTION_TYPE = 'predictionType'
-_PREDICTION_BINARY_CLASSIFICATION = 'binaryClassification'
-_PREDICTION_PROBABILITY = 'probability'
-_PREDICTION_REGRESSION = 'regression'
-_MODEL_NAMES = 'modelNames'
-_SCHEMA = 'schemaType'
-_DASHBOARD_DICTIONARY = 'dashboardDictionary'
-_VERSION = 'schemaVersion'
+_Y_TRUE = "trueY"
+_Y_PRED = "predictedY"
+_PRECOMPUTED_METRICS = "precomputedMetrics"
+_GLOBAL = "global"
+_BINS = "bins"
+_PRECOMPUTED_BINS = "precomputedFeatureBins"
+_BIN_VECTOR = "binVector"
+_BIN_LABELS = "binLabels"
+_FEATURE_BIN_NAME = "featureBinName"
+_PREDICTION_TYPE = "predictionType"
+_PREDICTION_BINARY_CLASSIFICATION = "binaryClassification"
+_PREDICTION_PROBABILITY = "probability"
+_PREDICTION_REGRESSION = "regression"
+_MODEL_NAMES = "modelNames"
+_SCHEMA = "schemaType"
+_DASHBOARD_DICTIONARY = "dashboardDictionary"
+_VERSION = "schemaVersion"
 
-BINARY_CLASSIFICATION = 'binary_classification'
-PROBABILITY = 'probability'
-REGRESSION = 'regression'
-_allowed_prediction_types = frozenset([BINARY_CLASSIFICATION, PROBABILITY, REGRESSION])
+BINARY_CLASSIFICATION = "binary_classification"
+PROBABILITY = "probability"
+REGRESSION = "regression"
+_allowed_prediction_types = frozenset(
+    [BINARY_CLASSIFICATION, PROBABILITY, REGRESSION]
+)
 
 # The following keys need to match those of _metric_methods in
 # _fairlearn_dashboard.py
@@ -104,7 +108,9 @@ REGRESSION_METRICS[ROOT_MEAN_SQUARED_ERROR] = _root_mean_squared_error
 REGRESSION_METRICS[R2_SCORE] = skm.r2_score
 
 PROBABILITY_METRICS = {}
-PROBABILITY_METRICS[BALANCED_ROOT_MEAN_SQUARED_ERROR] = _balanced_root_mean_squared_error
+PROBABILITY_METRICS[
+    BALANCED_ROOT_MEAN_SQUARED_ERROR
+] = _balanced_root_mean_squared_error
 PROBABILITY_METRICS[COUNT] = count
 PROBABILITY_METRICS[LOG_LOSS] = skm.log_loss
 PROBABILITY_METRICS[MEAN_ABSOLUTE_ERROR] = skm.mean_absolute_error
@@ -148,10 +154,9 @@ def _process_predictions(predictions):
     return names, preds
 
 
-def _create_group_metric_set(y_true,
-                             predictions,
-                             sensitive_features,
-                             prediction_type):
+def _create_group_metric_set(
+    y_true, predictions, sensitive_features, prediction_type
+):
     """Create a dictionary matching the Dashboard's cache."""
     result = dict()
     result[_SCHEMA] = _DASHBOARD_DICTIONARY
@@ -159,8 +164,9 @@ def _create_group_metric_set(y_true,
 
     if prediction_type not in _allowed_prediction_types:
         msg_format = "prediction_type '{0}' not in {1}"
-        msg = msg_format.format(prediction_type, sorted(
-            list(_allowed_prediction_types)))
+        msg = msg_format.format(
+            prediction_type, sorted(list(_allowed_prediction_types))
+        )
         raise ValueError(msg)
 
     function_dict = None
@@ -175,7 +181,8 @@ def _create_group_metric_set(y_true,
         function_dict = PROBABILITY_METRICS
     else:
         raise NotImplementedError(
-            "No support yet for {0}".format(prediction_type))
+            "No support yet for {0}".format(prediction_type)
+        )
 
     # Sort out y_true
     _yt = _convert_to_ndarray_and_squeeze(y_true)
@@ -193,10 +200,12 @@ def _create_group_metric_set(y_true,
         for prediction in result[_Y_PRED]:
             metric_dict = dict()
             for metric_key, metric_func in function_dict.items():
-                gmr = MetricFrame(metrics=metric_func,
-                                  y_true=result[_Y_TRUE],
-                                  y_pred=prediction,
-                                  sensitive_features=g[_BIN_VECTOR])
+                gmr = MetricFrame(
+                    metrics=metric_func,
+                    y_true=result[_Y_TRUE],
+                    y_pred=prediction,
+                    sensitive_features=g[_BIN_VECTOR],
+                )
                 curr_dict = dict()
                 curr_dict[_GLOBAL] = gmr.overall
                 curr_dict[_BINS] = list(gmr.by_group)

--- a/test/unit/metrics/test_create_group_metric_set.py
+++ b/test/unit/metrics/test_create_group_metric_set.py
@@ -19,34 +19,36 @@ _BC_2P_3F = "bc-2p-3f.json"
 
 def validate_dashboard_dictionary(dashboard_dict):
     """Ensure dictionary is a valid Dashboard."""
-    schema_type = dashboard_dict['schemaType']
-    assert schema_type == 'dashboardDictionary'
-    schema_version = dashboard_dict['schemaVersion']
+    schema_type = dashboard_dict["schemaType"]
+    assert schema_type == "dashboardDictionary"
+    schema_version = dashboard_dict["schemaVersion"]
     # Will want to update the following prior to release
     assert schema_version == 0
 
-    pred_type = dashboard_dict['predictionType']
-    assert pred_type in {'binaryClassification', 'regression', 'probability'}
-    len_y_true = len(dashboard_dict['trueY'])
-    num_y_pred = len(dashboard_dict['predictedY'])
-    for y_pred in dashboard_dict['predictedY']:
+    pred_type = dashboard_dict["predictionType"]
+    assert pred_type in {"binaryClassification", "regression", "probability"}
+    len_y_true = len(dashboard_dict["trueY"])
+    num_y_pred = len(dashboard_dict["predictedY"])
+    for y_pred in dashboard_dict["predictedY"]:
         assert len(y_pred) == len_y_true
 
-    len_model_names = len(dashboard_dict['modelNames'])
+    len_model_names = len(dashboard_dict["modelNames"])
     assert len_model_names == num_y_pred
 
-    num_sf = len(dashboard_dict['precomputedFeatureBins'])
-    for sf in dashboard_dict['precomputedFeatureBins']:
-        sf_vector = sf['binVector']
+    num_sf = len(dashboard_dict["precomputedFeatureBins"])
+    for sf in dashboard_dict["precomputedFeatureBins"]:
+        sf_vector = sf["binVector"]
         assert len(sf_vector) == len_y_true
         for val in sf_vector:
             assert isinstance(val, int)
-        sf_classes = sf['binLabels']
+        sf_classes = sf["binLabels"]
         assert len(sf_classes) == 1 + max(sf_vector)
 
-    expected_keys = sorted(list(dashboard_dict['precomputedMetrics'][0][0].keys()))
-    assert len(dashboard_dict['precomputedMetrics']) == num_sf
-    for metrics_arr in dashboard_dict['precomputedMetrics']:
+    expected_keys = sorted(
+        list(dashboard_dict["precomputedMetrics"][0][0].keys())
+    )
+    assert len(dashboard_dict["precomputedMetrics"]) == num_sf
+    for metrics_arr in dashboard_dict["precomputedMetrics"]:
         assert len(metrics_arr) == num_y_pred
         for m in metrics_arr:
             keys = sorted(list(m.keys()))
@@ -63,22 +65,22 @@ class TestProcessSensitiveFeatures:
         result = _process_sensitive_features(sf)
         assert isinstance(result, list)
         assert len(result) == 1
-        assert result[0]['featureBinName'] == sf_name
-        assert result[0]['binVector'] == [0, 1, 1, 0]
-        assert result[0]['binLabels'] == ["1", "3"]
+        assert result[0]["featureBinName"] == sf_name
+        assert result[0]["binVector"] == [0, 1, 1, 0]
+        assert result[0]["binLabels"] == ["1", "3"]
 
     @pytest.mark.parametrize("transform_feature", conversions_for_1d)
     def test_smoke_string_groups(self, transform_feature):
         sf_name = "My SF"
-        sf_vals = transform_feature(['b', 'a', 'c', 'a', 'b'])
+        sf_vals = transform_feature(["b", "a", "c", "a", "b"])
 
         sf = {sf_name: sf_vals}
         result = _process_sensitive_features(sf)
         assert isinstance(result, list)
         assert len(result) == 1
-        assert result[0]['featureBinName'] == sf_name
-        assert result[0]['binVector'] == [1, 0, 2, 0, 1]
-        assert result[0]['binLabels'] == ["a", "b", "c"]
+        assert result[0]["featureBinName"] == sf_name
+        assert result[0]["binVector"] == [1, 0, 2, 0, 1]
+        assert result[0]["binLabels"] == ["a", "b", "c"]
 
     def test_result_is_sorted(self):
         sf_vals = [1, 2, 3, 1]
@@ -88,9 +90,9 @@ class TestProcessSensitiveFeatures:
         assert isinstance(result, list)
         assert len(result) == 3
         for r in result:
-            assert r['binVector'] == [0, 1, 2, 0]
-            assert r['binLabels'] == ['1', '2', '3']
-        result_names = [r['featureBinName'] for r in result]
+            assert r["binVector"] == [0, 1, 2, 0]
+            assert r["binLabels"] == ["1", "2", "3"]
+        result_names = [r["featureBinName"] for r in result]
         assert result_names == ["a", "b", "c"]
 
 
@@ -113,10 +115,9 @@ class TestProcessPredictions:
     @pytest.mark.parametrize("transform_y_1", conversions_for_1d)
     @pytest.mark.parametrize("transform_y_2", conversions_for_1d)
     @pytest.mark.parametrize("transform_y_3", conversions_for_1d)
-    def test_results_are_sorted(self,
-                                transform_y_1,
-                                transform_y_2,
-                                transform_y_3):
+    def test_results_are_sorted(
+        self, transform_y_1, transform_y_2, transform_y_3
+    ):
         y_p1 = transform_y_1([0, 0, 1, 1])
         y_p2 = transform_y_2([0, 1, 0, 1])
         y_p3 = transform_y_3([1, 1, 0, 0])
@@ -138,17 +139,16 @@ class TestCreateGroupMetricSet:
     def test_round_trip_1p_1f(self, t_y_t, t_y_p, t_sf):
         expected = load_sample_dashboard(_BC_1P_1F)
 
-        y_true = t_y_t(expected['trueY'])
-        y_pred = {expected['modelNames'][0]: t_y_p(expected['predictedY'][0])}
+        y_true = t_y_t(expected["trueY"])
+        y_pred = {expected["modelNames"][0]: t_y_p(expected["predictedY"][0])}
 
-        sf_file = expected['precomputedFeatureBins'][0]
-        sf = [sf_file['binLabels'][x] for x in sf_file['binVector']]
-        sensitive_feature = {sf_file['featureBinName']: t_sf(sf)}
+        sf_file = expected["precomputedFeatureBins"][0]
+        sf = [sf_file["binLabels"][x] for x in sf_file["binVector"]]
+        sensitive_feature = {sf_file["featureBinName"]: t_sf(sf)}
 
-        actual = _create_group_metric_set(y_true,
-                                          y_pred,
-                                          sensitive_feature,
-                                          'binary_classification')
+        actual = _create_group_metric_set(
+            y_true, y_pred, sensitive_feature, "binary_classification"
+        )
         validate_dashboard_dictionary(actual)
         assert expected == actual
 
@@ -158,23 +158,22 @@ class TestCreateGroupMetricSet:
     def test_round_trip_2p_3f(self, t_y_t, t_y_p, t_sf):
         expected = load_sample_dashboard(_BC_2P_3F)
 
-        y_true = t_y_t(expected['trueY'])
+        y_true = t_y_t(expected["trueY"])
 
         y_pred = {}
         y_p_ts = [t_y_p, lambda x: x]  # Only transform one y_p
-        for i, name in enumerate(expected['modelNames']):
-            y_pred[name] = y_p_ts[i](expected['predictedY'][i])
+        for i, name in enumerate(expected["modelNames"]):
+            y_pred[name] = y_p_ts[i](expected["predictedY"][i])
 
         sensitive_features = {}
         t_sfs = [lambda x: x, t_sf, lambda x: x]  # Only transform one sf
-        for i, sf_file in enumerate(expected['precomputedFeatureBins']):
-            sf = [sf_file['binLabels'][x] for x in sf_file['binVector']]
-            sensitive_features[sf_file['featureBinName']] = t_sfs[i](sf)
+        for i, sf_file in enumerate(expected["precomputedFeatureBins"]):
+            sf = [sf_file["binLabels"][x] for x in sf_file["binVector"]]
+            sensitive_features[sf_file["featureBinName"]] = t_sfs[i](sf)
 
-        actual = _create_group_metric_set(y_true,
-                                          y_pred,
-                                          sensitive_features,
-                                          'binary_classification')
+        actual = _create_group_metric_set(
+            y_true, y_pred, sensitive_features, "binary_classification"
+        )
         validate_dashboard_dictionary(actual)
         assert expected == actual
 
@@ -183,36 +182,41 @@ class TestCreateGroupMetricSet:
         y_p = [1, 1, 1, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1, 0]
         s_f = [0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1]
 
-        expected = MetricFrame(metrics={'accuracy_score': skm.accuracy_score,
-                                        'roc_auc_score': skm.roc_auc_score},
-                               y_true=y_t,
-                               y_pred=y_p,
-                               sensitive_features=s_f)
+        expected = MetricFrame(
+            metrics={
+                "accuracy_score": skm.accuracy_score,
+                "roc_auc_score": skm.roc_auc_score,
+            },
+            y_true=y_t,
+            y_pred=y_p,
+            sensitive_features=s_f,
+        )
 
         predictions = {"some model": y_p}
         sensitive_feature = {"my sf": s_f}
 
-        actual = _create_group_metric_set(y_t,
-                                          predictions,
-                                          sensitive_feature,
-                                          'binary_classification')
+        actual = _create_group_metric_set(
+            y_t, predictions, sensitive_feature, "binary_classification"
+        )
 
         # Do some sanity checks
         validate_dashboard_dictionary(actual)
-        assert actual['trueY'] == y_t
-        assert actual['predictedY'][0] == y_p
-        assert actual['precomputedFeatureBins'][0]['binVector'] == s_f
-        assert len(actual['precomputedMetrics'][0][0]) == 12
+        assert actual["trueY"] == y_t
+        assert actual["predictedY"][0] == y_p
+        assert actual["precomputedFeatureBins"][0]["binVector"] == s_f
+        assert len(actual["precomputedMetrics"][0][0]) == 12
 
         # Cross check the two metrics we computed
         # Comparisons simplified because s_f was already {0,1}
-        actual_acc = actual['precomputedMetrics'][0][0]['accuracy_score']
-        assert actual_acc['global'] == expected.overall['accuracy_score']
-        assert actual_acc['bins'] == list(expected.by_group['accuracy_score'])
+        actual_acc = actual["precomputedMetrics"][0][0]["accuracy_score"]
+        assert actual_acc["global"] == expected.overall["accuracy_score"]
+        assert actual_acc["bins"] == list(expected.by_group["accuracy_score"])
 
-        actual_roc = actual['precomputedMetrics'][0][0]['balanced_accuracy_score']
-        assert actual_roc['global'] == expected.overall['roc_auc_score']
-        assert actual_roc['bins'] == list(expected.by_group['roc_auc_score'])
+        actual_roc = actual["precomputedMetrics"][0][0][
+            "balanced_accuracy_score"
+        ]
+        assert actual_roc["global"] == expected.overall["roc_auc_score"]
+        assert actual_roc["bins"] == list(expected.by_group["roc_auc_score"])
 
     def test_roc_auc_single_class(self, recwarn):
         # Note that y_t and s_f are identical, so subgroup evaluation will fail for
@@ -224,17 +228,18 @@ class TestCreateGroupMetricSet:
         predictions = {"some model": y_p}
         sensitive_feature = {"my sf": s_f}
 
-        actual = _create_group_metric_set(y_t,
-                                          predictions,
-                                          sensitive_feature,
-                                          'binary_classification')
+        actual = _create_group_metric_set(
+            y_t, predictions, sensitive_feature, "binary_classification"
+        )
 
         # Check that the error case was intercepted for roc_auc_score
         validate_dashboard_dictionary(actual)
-        actual_roc = actual['precomputedMetrics'][0][0]['balanced_accuracy_score']
+        actual_roc = actual["precomputedMetrics"][0][0][
+            "balanced_accuracy_score"
+        ]
         expected_all_roc = skm.roc_auc_score(y_t, y_p)
-        assert actual_roc['global'] == expected_all_roc
-        assert actual_roc['bins'] == [0, 0] # We substituted zero
+        assert actual_roc["global"] == expected_all_roc
+        assert actual_roc["bins"] == [0, 0]  # We substituted zero
         # Check that the right warnings were issued
         assert len(recwarn) == 4
         msgs = sorted([str(x.message) for x in recwarn])
@@ -254,26 +259,46 @@ class TestCreateGroupMetricSet:
         sensitive_feature = {"my sf": s_f}
 
         # Using the `regression` prediction type should not crash
-        result = _create_group_metric_set(y_t,
-                                          predictions,
-                                          sensitive_feature,
-                                          'regression')
-        assert result['predictionType'] == 'regression'
-        assert len(result['precomputedMetrics'][0][0]) == 6
+        result = _create_group_metric_set(
+            y_t, predictions, sensitive_feature, "regression"
+        )
+        assert result["predictionType"] == "regression"
+        assert len(result["precomputedMetrics"][0][0]) == 6
 
     def test_probability_prediction_type(self):
         # For probability, y_p can have real values [0, 1]
         y_t = [0, 1, 1, 0, 1, 1, 1, 0, 0, 1, 1, 0, 1, 0, 1, 1, 1, 1, 0, 0, 1]
-        y_p = [0.9, 1, 1, 0.1, 1, 1, 0.8, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1, 0]
+        y_p = [
+            0.9,
+            1,
+            1,
+            0.1,
+            1,
+            1,
+            0.8,
+            0,
+            0,
+            0,
+            1,
+            1,
+            1,
+            1,
+            0,
+            0,
+            1,
+            1,
+            0,
+            1,
+            0,
+        ]
         s_f = [0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1]
 
         predictions = {"some model": y_p}
         sensitive_feature = {"my sf": s_f}
 
         # Using the `probability` prediction type should not crash
-        result = _create_group_metric_set(y_t,
-                                          predictions,
-                                          sensitive_feature,
-                                          'probability')
-        assert result['predictionType'] == 'probability'
-        assert len(result['precomputedMetrics'][0][0]) == 10
+        result = _create_group_metric_set(
+            y_t, predictions, sensitive_feature, "probability"
+        )
+        assert result["predictionType"] == "probability"
+        assert len(result["precomputedMetrics"][0][0]) == 10


### PR DESCRIPTION
Add a wrapper to the call to `roc_auc_score()` in `_create_group_metric_set()`. This deals with the case where only one class is present in the data (especially for subgroups). If this is encountered, then a warning is issued and a value of zero substituted. This is similar to how `recall_score()` operates (and the test picks up on the warning issued by `recall_score()` as well).