### PR TITLE
Doc build bug fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,15 +30,13 @@ jobs:
 
       - run:
           name: 'BUG REPRO'
-          command: |
-            sudo apt-get install npm
+          command: sudo apt-get install npm
 
       - run:
           name: 'BUG REPRO'
-          command: |
-            sudo npm install -g --silent gh-pages@2.0.1
+          command: sudo npm install -g --silent gh-pages@2.0.1
 
-       - run:
+      - run:
           name: 'BUG REPRO'
           command: |
             git config user.email "ci-build@fairlearn.org"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - run:
           name: 'BUG REPRO'
           command: |
-            sudo apt-get install npm
+            # sudo apt-get install npm
 
       - run:
           name: 'BUG REPRO'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,11 @@ jobs:
           command: sudo apt update
 
       - run:
+          name: 'BUG REPRO'
+          command: |
+            npm install -g --silent gh-pages@2.0.1
+
+      - run:
           name: Install pandoc
           command: sudo apt-get install pandoc pandoc-citeproc
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,12 +31,18 @@ jobs:
       - run:
           name: 'BUG REPRO'
           command: |
-            # sudo apt-get install npm
+            sudo apt-get install npm
 
       - run:
           name: 'BUG REPRO'
           command: |
             sudo npm install -g --silent gh-pages@2.0.1
+
+       - run:
+          name: 'BUG REPRO'
+          command: |
+            git config user.email "ci-build@fairlearn.org"
+            git config user.name "ci-build"
 
       - run:
           name: Install pandoc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,12 +31,12 @@ jobs:
       - run:
           name: 'BUG REPRO'
           command: |
-            sudo apt-get install npm
+            echo sudo apt-get install npm
 
       - run:
           name: 'BUG REPRO'
           command: |
-            npm install -g --silent gh-pages@2.0.1
+            sudo npm install -g --silent gh-pages@2.0.1
 
       - run:
           name: Install pandoc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,10 @@ jobs:
           name: 'BUG REPRO'
           command: |
             sudo apt-get install npm
+
+      - run:
+          name: 'BUG REPRO'
+          command: |
             npm install -g --silent gh-pages@2.0.1
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,20 +29,6 @@ jobs:
           command: sudo apt update
 
       - run:
-          name: 'BUG REPRO'
-          command: sudo apt-get install npm
-
-      - run:
-          name: 'BUG REPRO'
-          command: sudo npm install -g --silent gh-pages@2.0.1
-
-      - run:
-          name: 'BUG REPRO'
-          command: |
-            git config user.email "ci-build@fairlearn.org"
-            git config user.name "ci-build"
-
-      - run:
           name: Install pandoc
           command: sudo apt-get install pandoc pandoc-citeproc
 
@@ -137,9 +123,16 @@ jobs:
           command: echo "fairlearn.org" > docs/_build/html/CNAME
 
       - run:
-          name: 'Install gh-pages and configure dependencies'
+          name: Install npm
+          command: sudo apt-get install npm
+
+      - run:
+          name: Install gh-pages
+          command: sudo npm install -g --silent gh-pages@2.0.1
+
+      - run:
+          name: Configure git
           command: |
-            npm install -g --silent gh-pages@2.0.1
             git config user.email "ci-build@fairlearn.org"
             git config user.name "ci-build"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
       - run:
           name: 'BUG REPRO'
           command: |
+            sudo apt-get install npm
             npm install -g --silent gh-pages@2.0.1
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - run:
           name: 'BUG REPRO'
           command: |
-            echo sudo apt-get install npm
+            sudo apt-get install npm
 
       - run:
           name: 'BUG REPRO'


### PR DESCRIPTION
Fixing the publish stage of the doc build, which has been broken since #1046 .

The new image lacked `npm`, so install it via `apt-get`. When `npm` itself is run, it also needs to be superuser.