### PR TITLE
Further deploy doc fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,8 @@ jobs:
 
       - run:
           name: 'Push to GitHub Pages repository'
-          command: gh-pages --dotfiles --message "Updates" --dist docs/_build/html --repo https://github.com/fairlearn/fairlearn.github.io.git --branch master
+          # Next is only acceptable because this is running in a docker container which is not persisted
+          command: sudo gh-pages --dotfiles --message "Updates" --dist docs/_build/html --repo https://github.com/fairlearn/fairlearn.github.io.git --branch master
 
 # This workflow defines the ordering, in this case build-doc needs to happen
 # before deploy-doc.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,6 +143,7 @@ jobs:
       - run:
           name: 'Push to GitHub Pages repository'
           # Next is only acceptable because this is running in a docker container which is not persisted
+          # See https://github.com/tschaub/gh-pages/issues/422
           command: sudo gh-pages --dotfiles --message "Updates" --dist docs/_build/html --repo https://github.com/fairlearn/fairlearn.github.io.git --branch master
 
 # This workflow defines the ordering, in this case build-doc needs to happen


### PR DESCRIPTION
## Description

Another attempted fix for the doc deployment issue caused by the update to a new CircleCI image. This PR changes the script to run `gh-pages` as superuser in an attempt to work around the following issue:
https://github.com/tschaub/gh-pages/issues/422

## Tests
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] This *is* the documentation
- [ ] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
