### PR TITLE
Adding user guide documentation to API

### DIFF
--- a/fairlearn/datasets/_fetch_acs_income.py
+++ b/fairlearn/datasets/_fetch_acs_income.py
@@ -26,7 +26,7 @@ def fetch_acs_income(*, cache=True, data_home=None,
 
     Source: Paper: Ding et al. (2021) [1]_
             and corresponding repository https://github.com/zykls/folktables/
-    
+
     Read more in the :ref:`User Guide <acsincome_data>`.
 
     .. versionadded:: 0.8.0

--- a/fairlearn/datasets/_fetch_acs_income.py
+++ b/fairlearn/datasets/_fetch_acs_income.py
@@ -29,8 +29,8 @@ def fetch_acs_income(*, cache=True, data_home=None,
     Source: Paper: Ding et al. (2021) [1]_
             and corresponding repository https://github.com/zykls/folktables/
     
-     Read more in the :ref:`User Guide <acsincome_data>`.
-
+    Read more in the :ref:`User Guide <acsincome_data>`.
+    
     .. versionadded:: 0.8.0
 
     Parameters

--- a/fairlearn/datasets/_fetch_acs_income.py
+++ b/fairlearn/datasets/_fetch_acs_income.py
@@ -15,8 +15,6 @@ def fetch_acs_income(*, cache=True, data_home=None,
                      ):
     """Load the ACS Income dataset (regression).
 
-    Read more in the :ref:`User Guide <acsincome_data>`.
-
     Download it if necessary.
 
     ==============   ====================
@@ -30,7 +28,7 @@ def fetch_acs_income(*, cache=True, data_home=None,
             and corresponding repository https://github.com/zykls/folktables/
     
     Read more in the :ref:`User Guide <acsincome_data>`.
-    
+
     .. versionadded:: 0.8.0
 
     Parameters

--- a/fairlearn/datasets/_fetch_acs_income.py
+++ b/fairlearn/datasets/_fetch_acs_income.py
@@ -28,6 +28,8 @@ def fetch_acs_income(*, cache=True, data_home=None,
 
     Source: Paper: Ding et al. (2021) [1]_
             and corresponding repository https://github.com/zykls/folktables/
+    
+     Read more in the :ref:`User Guide <acsincome_data>`.
 
     .. versionadded:: 0.8.0
 

--- a/fairlearn/datasets/_fetch_adult.py
+++ b/fairlearn/datasets/_fetch_adult.py
@@ -27,6 +27,8 @@ def fetch_adult(*, cache=True, data_home=None,
     Prediction task is to determine whether a person makes over $50,000 a
     year.
 
+    Read more in the :ref:`User Guide <adult_data>`.
+
     .. versionadded:: 0.5.0
 
     Parameters

--- a/fairlearn/datasets/_fetch_boston.py
+++ b/fairlearn/datasets/_fetch_boston.py
@@ -55,6 +55,8 @@ def fetch_boston(*, cache=True, data_home=None,
     MEDV     Median value of owner-occupied homes in $1000's
     =======  ======================================================================
 
+     Read more in the :ref:`User Guide <boston_housing_data>`.
+
     .. versionadded:: 0.5.0
 
     Parameters

--- a/fairlearn/metrics/_disparities.py
+++ b/fairlearn/metrics/_disparities.py
@@ -21,6 +21,8 @@ def demographic_parity_difference(
     :math:`E[h(X) | A=a]`, across all values :math:`a` of the sensitive feature(s).
     The demographic parity difference of 0 means that all groups have the same selection rate.
 
+    Read more in the :ref:`User Guide <disparity_metrics>`.
+
     Parameters
     ----------
     y_true : array-like
@@ -66,6 +68,8 @@ def demographic_parity_ratio(
     between the smallest and the largest group-level selection rate,
     :math:`E[h(X) | A=a]`, across all values :math:`a` of the sensitive feature(s).
     The demographic parity ratio of 1 means that all groups have the same selection rate.
+
+    Read more in the :ref:`User Guide <disparity_metrics>`.
 
     Parameters
     ----------
@@ -116,6 +120,8 @@ def equalized_odds_difference(
     The equalized odds difference of 0 means that all groups have the same
     true positive, true negative, false positive, and false negative rates.
 
+    Read more in the :ref:`User Guide <disparity_metrics>`.
+
     Parameters
     ----------
     y_true : array-like
@@ -160,6 +166,8 @@ def equalized_odds_ratio(
     :math:`P[h(X)=1 | A=a, Y=0]`.
     The equalized odds ratio of 1 means that all groups have the same
     true positive, true negative, false positive, and false negative rates.
+
+    Read more in the :ref:`User Guide <disparity_metrics>`.
 
     Parameters
     ----------

--- a/fairlearn/metrics/_extra_metrics.py
+++ b/fairlearn/metrics/_extra_metrics.py
@@ -83,6 +83,8 @@ def true_positive_rate(y_true,
                        pos_label=None) -> float:
     r"""Calculate the true positive rate (also called sensitivity, recall, or hit rate).
 
+    Read more in the :ref:`User Guide <scalar_metric_results>`.
+
     Parameters
     ----------
     y_true : array-like
@@ -116,6 +118,8 @@ def true_negative_rate(y_true,
                        sample_weight=None,
                        pos_label=None) -> float:
     r"""Calculate the true negative rate (also called specificity or selectivity).
+
+    Read more in the :ref:`User Guide <scalar_metric_results>`.
 
     Parameters
     ----------
@@ -151,6 +155,8 @@ def false_positive_rate(y_true,
                         pos_label=None) -> float:
     r"""Calculate the false positive rate (also called fall-out).
 
+    Read more in the :ref:`User Guide <scalar_metric_results>`.
+
     Parameters
     ----------
     y_true : array-like
@@ -184,6 +190,8 @@ def false_negative_rate(y_true,
                         sample_weight=None,
                         pos_label=None) -> float:
     r"""Calculate the false negative rate (also called miss rate).
+
+    Read more in the :ref:`User Guide <scalar_metric_results>`.
 
     Parameters
     ----------
@@ -223,6 +231,8 @@ def count(y_true, y_pred) -> int:
 
     The ``y_true`` argument is used to make this calculation. For consistency with
     other metric functions, the ``y_pred`` argument is required, but ignored.
+
+    Read more in the :ref:`User Guide <metrics_with_grouping>`.
 
     Parameters
     ----------

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -169,6 +169,8 @@ class MetricFrame:
     feature(s). The name 'control features' refers to the statistical practice
     of 'controlling' for a variable.
 
+    Read more in the :ref:`User Guide <metrics_with_grouping>`.
+
     Parameters
     ----------
     metrics : callable or dict
@@ -407,6 +409,8 @@ class MetricFrame:
     def overall(self) -> Union[Any, pd.Series, pd.DataFrame]:
         """Return the underlying metrics evaluated on the whole dataset.
 
+           Read more in the :ref:`User Guide <control_features_metrics>`.
+
         Returns
         -------
         typing.Any or pandas.Series or pandas.DataFrame
@@ -449,6 +453,8 @@ class MetricFrame:
         The collection is defined by the combination of classes in the
         sensitive and control features. The exact type depends on
         the specification of the metric function.
+
+        Read more in the :ref:`User Guide <control_features_metrics>`.
 
         Returns
         -------
@@ -609,6 +615,8 @@ class MetricFrame:
         whether control features are present, and whether the metric functions
         were specified as a single callable or a dictionary.
 
+        Read more in the :ref:`User Guide <metrics_with_grouping>`.
+
         Parameters
         ----------
         errors: {'raise', 'coerce'}, default 'raise'
@@ -634,6 +642,8 @@ class MetricFrame:
         functions return scalar values). The exact return type depends on
         whether control features are present, and whether the metric functions
         were specified as a single callable or a dictionary.
+
+        Read more in the :ref:`User Guide <metrics_with_grouping>`.
 
         Parameters
         ----------
@@ -670,6 +680,8 @@ class MetricFrame:
         corresponding value from :attr:`.overall` (if there are control
         features, then :attr:`.overall` is multivalued for each metric).
         The result is the absolute maximum of these values.
+
+        Read more in the :ref:`User Guide <control_features_metrics>`.
 
         Parameters
         ----------
@@ -729,6 +741,8 @@ class MetricFrame:
         features, then :attr:`.overall` is multivalued for each metric),
         expressing the ratio as a number less than 1.
         The result is the minimum of these values.
+
+        Read more in the :ref:`User Guide <metrics_with_grouping>`.
 
         Parameters
         ----------

--- a/fairlearn/metrics/_selection_rate.py
+++ b/fairlearn/metrics/_selection_rate.py
@@ -20,6 +20,7 @@ def selection_rate(y_true,
     The argument `pos_label` specifies the 'good' outcome. For consistency with
     other metric functions, the ``y_true`` argument is required, but ignored.
 
+    Read more in the :ref:`User Guide <scalar_metric_results>`.
 
     Parameters
     ----------

--- a/fairlearn/postprocessing/_interpolated_thresholder.py
+++ b/fairlearn/postprocessing/_interpolated_thresholder.py
@@ -23,6 +23,8 @@ class InterpolatedThresholder(BaseEstimator, MetaEstimatorMixin):
     Based on the values of sensitive features, it then applies a randomized thresholding
     transformation according to the provided `interpolation_dict`.
 
+    Read more in the :ref:`User Guide <postprocessing>`.
+
     Parameters
     ----------
     estimator :

--- a/fairlearn/postprocessing/_threshold_operation.py
+++ b/fairlearn/postprocessing/_threshold_operation.py
@@ -9,6 +9,8 @@ class ThresholdOperation():
     The function can be evaluated at arbitrary points (usually the scores returned from
     unconstrained predictors) to return a bool value.
 
+    Read more in the :ref:`User Guide <postprocessing>`.
+
     :param operator: the threshold operator, can be either '>' or '<'
     :type operator: str
     :param threshold: the threshold, can be numpy.inf or -numpy.inf

--- a/fairlearn/postprocessing/_threshold_optimizer.py
+++ b/fairlearn/postprocessing/_threshold_optimizer.py
@@ -129,6 +129,8 @@ class ThresholdOptimizer(BaseEstimator, MetaEstimatorMixin):
     provided estimator. The thresholds are chosen to optimize the provided
     performance objective subject to the provided fairness constraints.
 
+    Read more in the :ref:`User Guide <postprocessing>`.
+
     Parameters
     ----------
     estimator : object

--- a/fairlearn/preprocessing/_correlation_remover.py
+++ b/fairlearn/preprocessing/_correlation_remover.py
@@ -16,6 +16,8 @@ class CorrelationRemover(BaseEstimator, TransformerMixin):
     in order to remove their correlation with the sensitive feature columns while retaining
     as much information as possible (as measured by the least-squares error).
 
+    Read more in the :ref:`User Guide <preprocessing>`.
+
     Parameters
     ----------
         sensitive_feature_ids : list

--- a/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
+++ b/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
@@ -22,6 +22,8 @@ class ExponentiatedGradient(BaseEstimator, MetaEstimatorMixin):
     The exponentiated gradient algorithm is described in detail by
     :footcite:t:`agarwal2018reductions`.
 
+    Read more in the :ref:`User Guide <exponentiated_gradient>`.
+
     .. versionchanged:: 0.3.0
         Was a function before, not a class
 

--- a/fairlearn/reductions/_grid_search/grid_search.py
+++ b/fairlearn/reductions/_grid_search/grid_search.py
@@ -25,6 +25,8 @@ class GridSearch(BaseEstimator, MetaEstimatorMixin):
     The approach used is taken from section 3.4 of
     :footcite:t:`agarwal2018reductions`.
 
+    Read more in the :ref:`User Guide <grid_search>`.
+
     .. versionadded:: 0.3.0
 
     .. versionchanged:: 0.4.6

--- a/fairlearn/reductions/_moments/bounded_group_loss.py
+++ b/fairlearn/reductions/_moments/bounded_group_loss.py
@@ -12,6 +12,8 @@ from fairlearn.utils._input_validation import _validate_and_reformat_input
 class ConditionalLossMoment(LossMoment):
     r"""A moment for constraining the mean loss or the worst-case loss by a group.
 
+    Read more in the :ref:`User Guide <bounded_group_loss>`.
+
     Parameters
     ----------
     loss : {SquareLoss, AbsoluteLoss}
@@ -103,7 +105,10 @@ ConditionalLossMoment.__module__ = "fairlearn.reductions"
 
 
 class MeanLoss(ConditionalLossMoment):
-    """Moment for evaluating the mean loss."""
+    """Moment for evaluating the mean loss. 
+    
+    Read more in the :ref:`User Guide <constraints_regression>`.
+    """
 
     def __init__(self, loss):
         super().__init__(loss, upper_bound=None, no_groups=True)
@@ -120,7 +125,10 @@ class BoundedGroupLoss(ConditionalLossMoment):
 
 
 class SquareLoss:
-    """Class to evaluate the square loss."""
+    """Class to evaluate the square loss.
+    
+    Read more in the :ref:`User Guide <constraints_regression>`.
+    """
 
     def __init__(self, min_val, max_val):
         self.min_val = min_val
@@ -135,7 +143,10 @@ class SquareLoss:
 
 
 class AbsoluteLoss:
-    """Class to evaluate absolute loss."""
+    """Class to evaluate absolute loss.
+    
+    Read more in the :ref:`User Guide <constraints_regression>`.
+    """
 
     def __init__(self, min_val, max_val):
         self.min_val = min_val
@@ -155,7 +166,10 @@ AbsoluteLoss.__module__ = "fairlearn.reductions"
 
 
 class ZeroOneLoss(AbsoluteLoss):
-    """Class to evaluate a zero-one loss."""
+    """Class to evaluate a zero-one loss.
+    
+    Read more in the :ref:`User Guide <constraints_regression>`.
+    """
 
     def __init__(self):
         super().__init__(0, 1)

--- a/fairlearn/reductions/_moments/bounded_group_loss.py
+++ b/fairlearn/reductions/_moments/bounded_group_loss.py
@@ -105,7 +105,9 @@ ConditionalLossMoment.__module__ = "fairlearn.reductions"
 
 
 class MeanLoss(ConditionalLossMoment):
-    """Moment for evaluating the mean loss. Read more in the :ref:`User Guide <constraints_regression>`.
+    """Moment for evaluating the mean loss.
+
+    Read more in the :ref:`User Guide <constraints_regression>`.
     """
 
     def __init__(self, loss):
@@ -113,7 +115,9 @@ class MeanLoss(ConditionalLossMoment):
 
 
 class BoundedGroupLoss(ConditionalLossMoment):
-    """Moment for constraining the worst-case loss by a group. For more information refer to the :ref:`user guide <bounded_group_loss>`.
+    """Moment for constraining the worst-case loss by a group.
+
+    For more information refer to the :ref:`user guide <bounded_group_loss>`.
     """
 
     def __init__(self, loss, *, upper_bound=None):
@@ -121,7 +125,9 @@ class BoundedGroupLoss(ConditionalLossMoment):
 
 
 class SquareLoss:
-    """Class to evaluate the square loss. Read more in the :ref:`User Guide <constraints_regression>`.
+    """Class to evaluate the square loss.
+
+    Read more in the :ref:`User Guide <constraints_regression>`.
     """
 
     def __init__(self, min_val, max_val):
@@ -137,7 +143,9 @@ class SquareLoss:
 
 
 class AbsoluteLoss:
-    """Class to evaluate absolute loss. Read more in the :ref:`User Guide <constraints_regression>`.
+    """Class to evaluate absolute loss.
+
+    Read more in the :ref:`User Guide <constraints_regression>`.
     """
 
     def __init__(self, min_val, max_val):
@@ -158,7 +166,9 @@ AbsoluteLoss.__module__ = "fairlearn.reductions"
 
 
 class ZeroOneLoss(AbsoluteLoss):
-    """Class to evaluate a zero-one loss. Read more in the :ref:`User Guide <constraints_regression>`.
+    """Class to evaluate a zero-one loss.
+
+    Read more in the :ref:`User Guide <constraints_regression>`.
     """
 
     def __init__(self):

--- a/fairlearn/reductions/_moments/bounded_group_loss.py
+++ b/fairlearn/reductions/_moments/bounded_group_loss.py
@@ -105,9 +105,7 @@ ConditionalLossMoment.__module__ = "fairlearn.reductions"
 
 
 class MeanLoss(ConditionalLossMoment):
-    """Moment for evaluating the mean loss. 
-    
-    Read more in the :ref:`User Guide <constraints_regression>`.
+    """Moment for evaluating the mean loss. Read more in the :ref:`User Guide <constraints_regression>`.
     """
 
     def __init__(self, loss):
@@ -115,9 +113,7 @@ class MeanLoss(ConditionalLossMoment):
 
 
 class BoundedGroupLoss(ConditionalLossMoment):
-    """Moment for constraining the worst-case loss by a group.
-
-    For more information refer to the :ref:`user guide <bounded_group_loss>`.
+    """Moment for constraining the worst-case loss by a group. For more information refer to the :ref:`user guide <bounded_group_loss>`.
     """
 
     def __init__(self, loss, *, upper_bound=None):
@@ -125,9 +121,7 @@ class BoundedGroupLoss(ConditionalLossMoment):
 
 
 class SquareLoss:
-    """Class to evaluate the square loss.
-    
-    Read more in the :ref:`User Guide <constraints_regression>`.
+    """Class to evaluate the square loss. Read more in the :ref:`User Guide <constraints_regression>`.
     """
 
     def __init__(self, min_val, max_val):
@@ -143,9 +137,7 @@ class SquareLoss:
 
 
 class AbsoluteLoss:
-    """Class to evaluate absolute loss.
-    
-    Read more in the :ref:`User Guide <constraints_regression>`.
+    """Class to evaluate absolute loss. Read more in the :ref:`User Guide <constraints_regression>`.
     """
 
     def __init__(self, min_val, max_val):
@@ -166,9 +158,7 @@ AbsoluteLoss.__module__ = "fairlearn.reductions"
 
 
 class ZeroOneLoss(AbsoluteLoss):
-    """Class to evaluate a zero-one loss.
-    
-    Read more in the :ref:`User Guide <constraints_regression>`.
+    """Class to evaluate a zero-one loss. Read more in the :ref:`User Guide <constraints_regression>`.
     """
 
     def __init__(self):

--- a/fairlearn/reductions/_moments/error_rate.py
+++ b/fairlearn/reductions/_moments/error_rate.py
@@ -31,6 +31,8 @@ class ErrorRate(ClassificationMoment):
     and false negative errors respectively. The standard misclassification
     error corresponds to :math:`c_{FP}=c_{FN}=1.0`.
 
+    Read more in the :ref:`User Guide <error_rate_parity>`.
+
     Parameters
     ----------
     costs : dict

--- a/fairlearn/reductions/_moments/moment.py
+++ b/fairlearn/reductions/_moments/moment.py
@@ -20,6 +20,8 @@ class Moment:
     of :class:`Moment` objects to describe both the optimization objective
     and the fairness constraints
     imposed on the solution. This is an abstract class for all such objects.
+
+    Read more in the :ref:`User Guide <reductions>`.
     """
 
     def __init__(self):

--- a/fairlearn/reductions/_moments/utility_parity.py
+++ b/fairlearn/reductions/_moments/utility_parity.py
@@ -65,6 +65,8 @@ class UtilityParity(ClassificationMoment):
     - The characters `+` and `-`, corresponding to the Lagrange multipliers
       for positive and negative violations of the constraint
 
+    Read more in the :ref:`User Guide <constraints_binary_classification>`.
+
     Parameters
     ----------
     difference_bound : float
@@ -279,6 +281,8 @@ class DemographicParity(UtilityParity):
     .. math::
       P[h(X) = 1 | A = a, C = c] = P[h(X) = 1 | C = c] \; \forall a, c
 
+    Read more in the :ref:`User Guide <demographic_parity>`.
+
     """
 
     short_name = "DemographicParity"
@@ -331,6 +335,8 @@ class TruePositiveRateParity(UtilityParity):
     stratify the data, with the constraint applied within
     each stratum, but not between strata.
 
+    Read more in the :ref:`User Guide <true_positive_rate_parity>`.
+
     """
 
     short_name = "TruePositiveRateParity"
@@ -378,6 +384,8 @@ class FalsePositiveRateParity(UtilityParity):
     stratify the data, with the constraint applied within
     each stratum, but not between strata.
 
+    Read more in the :ref:`User Guide <false_positive_rate_parity>`.
+
     """
 
     short_name = "FalsePositiveRateParity"
@@ -424,6 +432,8 @@ class EqualizedOdds(UtilityParity):
     stratify the data, with the constraint applied within
     each stratum, but not between strata.
 
+    Read more in the :ref:`User Guide <equalized_odds>`.
+
     """
 
     short_name = "EqualizedOdds"
@@ -464,6 +474,8 @@ class ErrorRateParity(UtilityParity):
     This :class:`~Moment` also supports control features, which can be used to
     stratify the data, with the constraint applied within
     each stratum, but not between strata.
+
+    Read more in the :ref:`User Guide <error_rate_parity>`.
 
     """
 


### PR DESCRIPTION
## Description
This PR addresses issue #730 by adding links to the user guide in many of the API function and class definitions. For some of the classes and functions, like those referenced in the preprocessing, postprocessing, and reductions modules, the corresponding user guide documentation has not been written yet (but has placeholders). In those cases, I added a placeholder reference to the appropriate section in anticipation of that documentation being added someday. If a function or class didn't have user guide representation, either written or planned, I did not add a reference. Please let me know if I should go back and add references for everything by estimating where the user guide documentation would go. Tagging @romanlutz and @hildeweerts for their reviews!

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [ ] user guide added or updated
- [X] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
N/A
