### PR TITLE
MNT add lint PR to git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,12 @@
+# Since git version 2.23, git-blame has a feature to ignore
+# certain commits.
+#
+# This file contains a list of commits that are not likely what
+# you are looking for in `git blame`. You can set this file as
+# a default ignore file for blame by running the following
+# command.
+#
+# $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# PR #1083: Lint the code-base with black
+d5950c081a3460660bbf1439ea77d528ee958879


### PR DESCRIPTION
Following up on https://github.com/fairlearn/fairlearn/pull/1083, this PR adds that commit to `.git-blame-ignore-revs`. This should automatically fix the blame on github, and locally it can be enabled by:

    git config blame.ignoreRevsFile .git-blame-ignore-revs


cc @romanlutz @hildeweerts @riedgar-ms for an easy review.