### PR TITLE
FIX fix multiversion links

### DIFF
--- a/docs/_static/versions.json
+++ b/docs/_static/versions.json
@@ -2,26 +2,26 @@
     {
         "name": "v0.7.0 (stable)",
         "version": "0.7.0",
-        "url": "https://fairlearn.org/0.7.0/index.html"
+        "url": "https://fairlearn.org/0.7.0/"
     },
     {
         "name": "v0.6.2",
         "version": "0.6.2",
-        "url": "https://fairlearn.org/0.6.2/index.html"
+        "url": "https://fairlearn.org/0.6.2/"
     },
     {
         "name": "v0.5.0",
         "version": "0.5.0",
-        "url": "https://fairlearn.org/0.5.0/index.html"
+        "url": "https://fairlearn.org/0.5.0/"
     },
     {
         "name": "v0.4.6",
         "version": "0.4.6",
-        "url": "https://fairlearn.org/0.4.6/index.html"
+        "url": "https://fairlearn.org/0.4.6/"
     },
     {
         "name": "v0.8 (dev)",
         "version": "main",
-        "url": "https://fairlearn.org/main/index.html"
+        "url": "https://fairlearn.org/main/"
     }
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -135,7 +135,7 @@ html_theme_options = {
     ],
     "show_prev_next": False,
     "switcher": {
-        "json_url": "https://github.com/fairlearn/fairlearn/blob/12bf019eeb439206ead92734fa38dbae38a39e62/docs/_static/versions.json",
+        "json_url": "https://github.com/adrinjalali/fairlearn/blob/doc/version/linkfix/docs/_static/versions.json",
         "version_match": tag_or_branch,
     },
     "navbar_start": ["navbar-logo", "version-switcher"],

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -135,7 +135,7 @@ html_theme_options = {
     ],
     "show_prev_next": False,
     "switcher": {
-        "json_url": "https://fairlearn.org/main/_static/versions.json",
+        "json_url": "https://github.com/fairlearn/fairlearn/blob/12bf019eeb439206ead92734fa38dbae38a39e62/docs/_static/versions.json",
         "version_match": tag_or_branch,
     },
     "navbar_start": ["navbar-logo", "version-switcher"],

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -135,7 +135,7 @@ html_theme_options = {
     ],
     "show_prev_next": False,
     "switcher": {
-        "json_url": "https://github.com/adrinjalali/fairlearn/blob/doc/version/linkfix/docs/_static/versions.json",
+        "json_url": "https://fairlearn.org/main/_static/versions.json",
         "version_match": tag_or_branch,
     },
     "navbar_start": ["navbar-logo", "version-switcher"],


### PR DESCRIPTION
It seems the documentation [here](https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/configuring.html#add-a-dropdown-to-switch-between-docs-versions) might be misleading and the links shouldn't have the `index.html` at the end.