### PR TITLE
Add hyperlink from example notebooks (sphinx-gallery) to API doc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -166,6 +166,7 @@ pygments_style = "sphinx"
 # included in the gallery, but its plot is available for
 # the quickstart
 sphinx_gallery_conf = {
+    "reference_url": {"fairlearn": None},
     "examples_dirs": "../examples",
     "gallery_dirs": "auto_examples",
     # pypandoc enables rst to md conversion in downloadable notebooks


### PR DESCRIPTION
towards #1061, a simple update to sphinx-gallery seems to do the trip. Keen to see if more needs to be done @romanlutz @hildeweerts 
