### PR TITLE
[NOCHECKIN] Confidence Intervals using bootstrap

### DIFF
--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -621,6 +621,10 @@ Bootstrapping works as follows:
 3. Fit a distribution to this set of metric values
 4. Obtain the desired confidence intervals from that distribution
 
+Since bootstrapping involves random resampling, results will not
+be precisely reproducible between runs.
+However, as :code:`n_boot` is increased, the values found should
+converge.
 Let us look at an example:
 
 .. doctest:: assessment_metrics

--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -664,17 +664,39 @@ intervals:
     C    0.625000
     Name: accuracy_score, dtype: float64
     >>> metric_ci.by_group_ci
-    [(0.025, SF
+    [(0.025,
+    SF
     A    0.000000
-    B    0.090909
-    C    0.285714
-    Name: accuracy_score, dtype: float64), (0.975, SF
-    A    0.600
-    B    0.625
-    C    1.000
+    B    0.105278
+    C    0.333333
+    Name: accuracy_score, dtype: float64),
+    (0.975,
+    SF
+    A    0.621429
+    B    0.608077
+    C    0.952500
     Name: accuracy_score, dtype: float64)]
 
+So here, we see that group 'B' has a nominal value of 0.333, with its 95% confidence
+interval running from 0.105 to 0.608.
+Finally, confidence intervals are also provided for the :method:`MetricFrame.difference`
+and :method:`MetricFrame.ratio` methods.
+For example:
 
+
+.. doctest:: assessment_metrics
+    :options:  +NORMALIZE_WHITESPACE
+
+    >>> metric_ci.difference(method='between_groups')
+    0.325
+    >>> metric_ci.difference_group_ci
+    [(0.025, 0.10214826839826842), (0.975, 0.7585227272727271)]
+
+What we see here is that the largest difference between any two of the groups
+marked by the sensitive feature is nominally 0.325, but the 95% confidence interval
+ranges from 0.102 to 0.759. This is quite a range, but not unexpected when
+we have such a small number of samples in our original dataset and we are taking
+a difference between two similar values.
 
 
 .. _plot:

--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -589,6 +589,57 @@ For more examples, please
 see the :ref:`sphx_glr_auto_examples_plot_new_metrics.py` notebook in the
 :ref:`examples`.
 
+.. _bootstrap:
+
+Confidence Intervals with Bootstrapping
+---------------------------------------
+
+It is a truth universally acknowledged, that a person in possession of
+a statistic, must be in want of an error bar.
+The only question is whether or not the person is aware of their want.
+Two aspects of fairness metrics make this particularly acute:
+
+1. Some of the subgroups defined by the sensitive features may be much
+   smaller than the overall sample size, leading to high levels of
+   random noise
+2. We often then wish to measure the disparity between two such subgroups.
+   While this means taking a difference or a ratio of the metrics,
+   the errors will always add (in quadrature)
+
+To address the need for error estimates, :class:`MetricFrame` provides
+a means of estimating confidence intervals for scalar metrics by using
+a process known as bootstrapping.
+This avoids the need for an analytic form for the error to be provided
+for each metric computed.
+
+Bootstrapping works as follows:
+
+1. Generate a large number of synthetic datasets by sampling the
+   target dataset *with replacement* (i.e. a given sample from the target
+   dataset may appear more than once in a synthetic dataset)
+2. Compute the metric value for each of these synthetic datasets
+3. Fit a distribution to this set of metric values
+4. Obtain the desired confidence intervals from that distribution
+
+Let us look at an example:
+
+.. doctest:: assessment_metrics
+    :options:  +NORMALIZE_WHITESPACE
+
+    >>> # Enable bootstrapping with the n_boot parameter
+    >>> metric_ci = MetricFrame(metrics=skm.accuracy_score,
+    ...                         y_true=decision,
+    ...                         y_pred=prediction,
+    ...                         sensitive_features={'SF' : sensitive_feature},
+    ...                         n_boot=100)
+    >>> metric_ci.overall
+    0.1
+    >>> metric_ci.overall_ci
+    0.1
+
+
+
+
 .. _plot:
 
 Plotting

--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -633,9 +633,46 @@ Let us look at an example:
     ...                         sensitive_features={'SF' : sensitive_feature},
     ...                         n_boot=100)
     >>> metric_ci.overall
-    0.1
+    0.4
     >>> metric_ci.overall_ci
-    0.1
+    [(0.025, 0.23333333333333334), (0.975, 0.6)]
+
+We have turned on bootstrapping by setting the :code:`n_boot` parameter;
+in this case, we have requested that 100 synthetic datasets be generated
+to create the statistics.
+We see that the :attr:`MetricFrame.overall` property is unchanged.
+However, we can also access the :attr:`MetricFrame.overall_ci` property
+which contains estimates of the confidence interval.
+By default, the bootstrapping algorithm computes the 95% confidence
+interval, which ranges from the 25th millile to the 975th millile.
+The :attr:`MetricFrame.overall_ci` has returned a list of binary tuples.
+The first entry in each tuple indicates the position within the distribution
+(which are 0.025 and 0.975 for the default confidence interval), while
+the second entry in each tuple is the metric value.
+For this case, we see that we can be 95% certain that the overall
+accuracy lies between 0.23 and 0.6 (and has a nominal value of 0.4).
+We can also examine the statistics for each group, and their confidence
+intervals:
+
+.. doctest:: assessment_metrics
+    :options:  +NORMALIZE_WHITESPACE
+
+    >>> metric_ci.by_group
+    SF
+    A    0.300000
+    B    0.333333
+    C    0.625000
+    Name: accuracy_score, dtype: float64
+    >>> metric_ci.by_group_ci
+    [(0.025, SF
+    A    0.000000
+    B    0.090909
+    C    0.285714
+    Name: accuracy_score, dtype: float64), (0.975, SF
+    A    0.600
+    B    0.625
+    C    1.000
+    Name: accuracy_score, dtype: float64)]
 
 
 

--- a/fairlearn/metrics/_bootstrap.py
+++ b/fairlearn/metrics/_bootstrap.py
@@ -9,102 +9,136 @@ import numpy as np
 from scipy.stats import norm
 import numbers
 
+
 def process_ci_bounds(ci, ci_method, precision=6):
-    '''Parses user inputs to construct confidence intervals from bootstrap.
-       This function interprets integer and float inputs as the desired
-       width of a two-sided confidence interval, and lists and tuples as
-       exact quantiles to retrieve.
+    """Parses user inputs to construct confidence intervals from bootstrap.
+    This function interprets integer and float inputs as the desired
+    width of a two-sided confidence interval, and lists and tuples as
+    exact quantiles to retrieve.
 
-       Parameters
-        ----------
-        ci : float, list, tuple
-        Determines the quantiles reported for confidence intervals. All entries must
-        be in the range [0, 1]. A single float is interpreted as the width of the 
-        desired confidence interval (e.g. 0.95 is a 95% interval), while a List or Tuple
-        reports exact quantiles from the empirical bootstrap distribution 
-        (e.g. (0, 0.33, 0.5, 0.66, 1) will calculate the min, 33rd, 50th, 66th, and max quantiles).
-        
-        method: str
-        One of {'percentile', 'bias-corrected'}. Used to validate CI inputs.
+    Parameters
+     ----------
+     ci : float, list, tuple
+     Determines the quantiles reported for confidence intervals. All entries must
+     be in the range [0, 1]. A single float is interpreted as the width of the
+     desired confidence interval (e.g. 0.95 is a 95% interval), while a List or Tuple
+     reports exact quantiles from the empirical bootstrap distribution
+     (e.g. (0, 0.33, 0.5, 0.66, 1) will calculate the min, 33rd, 50th, 66th, and max quantiles).
 
-        precision: int
-        Number of decimals of precision to round quantile calculations to.
-    '''
-    if ci_method not in ['percentile', 'bias-corrected']:
-        raise ValueError(f"Parameter ci_method: {ci_method} must be set to 'percentile' or 'bias-corrected'.")
+     method: str
+     One of {'percentile', 'bias-corrected'}. Used to validate CI inputs.
+
+     precision: int
+     Number of decimals of precision to round quantile calculations to.
+    """
+    if ci_method not in ["percentile", "bias-corrected"]:
+        raise ValueError(
+            f"Parameter ci_method: {ci_method} must be set to 'percentile' or"
+            " 'bias-corrected'."
+        )
 
     if isinstance(ci, (int, float)) and (0 <= ci <= 1):
-        return tuple(np.round((0.5 - ci/2, 0.5 + ci/2), decimals=precision))
+        return tuple(np.round((0.5 - ci / 2, 0.5 + ci / 2), decimals=precision))
 
     elif isinstance(ci, (tuple, list)):
         if all(((0 <= x <= 1) for x in ci)):
             return tuple(ci)
         else:
-            raise ValueError(f"All desired confidence interval bounds must be within [0, 1].")
+            raise ValueError(
+                f"All desired confidence interval bounds must be within [0, 1]."
+            )
 
     else:
-        raise ValueError(f"Input to 'ci' of type {type(ci)} must be of type int, float, tuple, or list.")
-    
+        raise ValueError(
+            f"Input to 'ci' of type {type(ci)} must be of type int, float, tuple, or"
+            " list."
+        )
 
-def create_ci_output(bootstrap_runs, ci, sample_estimate, interval_type='percentile'):
-    '''Calculates and formats confidence intervals from bootstrap samples.'''
-    
-    #--- Check if there is significant bias in sample statistics ---
+
+def create_ci_output(bootstrap_runs, ci, sample_estimate, interval_type="percentile"):
+    """Calculates and formats confidence intervals from bootstrap samples."""
+
+    # --- Check if there is significant bias in sample statistics ---
     bootstrap_mean = np.mean(bootstrap_runs, axis=0)
 
     # Need to use this incredibly odd workaround to support frames with "object" dtypes
     # object typed frames are produced by default from .__group()
-    bootstrap_std = np.sqrt(np.var(bootstrap_runs, axis=0, dtype='float64'))
+    bootstrap_std = np.sqrt(np.var(bootstrap_runs, axis=0, dtype="float64"))
     bias = bootstrap_mean - sample_estimate
-    bias_adjusted_mean_estimate = 2*sample_estimate - bootstrap_mean # Might be useful to publish?
+    bias_adjusted_mean_estimate = (
+        2 * sample_estimate - bootstrap_mean
+    )  # Might be useful to publish?
 
     # Efron and Tibshirani (1993) guidance on identifying "large" bias via bootstrap
     high_bias_regions = np.abs(bias) >= (0.25 * bootstrap_std)
     if np.any(high_bias_regions):
-        #TODO: Add bias indication regions into warning. Simply printing all "high_bias_regions" is overwhelming.
+        # TODO: Add bias indication regions into warning. Simply printing all "high_bias_regions" is overwhelming.
         warn(
             f"""Some statistics calculated by MetricFrame are detected to have high bias 
             Consider setting `ci_method` == 'bias-corrected' to mitigate inaccuracies in
             confidence interval calculations."""
         )
 
-    #--- Bootstrap quantile summary calculations ---
+    # --- Bootstrap quantile summary calculations ---
 
     # Adjust which quantiles we sample from the empirical bootstrap distribution if bias correcting
-    if interval_type == 'bias-corrected':
+    if interval_type == "bias-corrected":
         # Follows Efron and Tibshirani (1993)
         # with an additional adjustment for overestimating bias in the presence of ties
         num_less = np.sum([x < sample_estimate for x in bootstrap_runs], axis=0)
         num_equal = np.sum([x == sample_estimate for x in bootstrap_runs], axis=0)
-        prop_less = (num_less + num_equal/2) / len(bootstrap_runs)
+        prop_less = (num_less + num_equal / 2) / len(bootstrap_runs)
         z0 = norm.ppf(prop_less)
         z_alphas = norm.ppf(ci)
-        adjusted_ci = [norm.cdf(2*z0 + alpha) for alpha in z_alphas]
+        adjusted_ci = [norm.cdf(2 * z0 + alpha) for alpha in z_alphas]
     else:
         # Match bias adjusted ci datastructures for downstream code
-        adjusted_ci = np.repeat(ci, np.prod(sample_estimate.shape)).reshape((len(ci), *sample_estimate.shape))
-
+        adjusted_ci = np.repeat(ci, np.prod(sample_estimate.shape)).reshape(
+            (len(ci), *sample_estimate.shape)
+        )
 
     # Potentially slow loop -- cannot seem to vectorize because we need a different set of quantiles for each cell
     # TODO: Look into optimizing this further
     quantiles = []
-    for user_ci, q in zip(ci, adjusted_ci): # Calculated based on adjusted_ci values but store with user requested
+    for user_ci, q in zip(
+        ci, adjusted_ci
+    ):  # Calculated based on adjusted_ci values but store with user requested
         bootstrap_quantile = np.zeros_like(sample_estimate)
         for index, index_quantile in np.ndenumerate(q):
-            bootstrap_quantile[index] = np.quantile([x.iloc[index] if isinstance(x, (pd.Series, pd.DataFrame)) else x for x in bootstrap_runs], q=index_quantile, axis=0)
+            bootstrap_quantile[index] = np.quantile(
+                [
+                    x.iloc[index] if isinstance(x, (pd.Series, pd.DataFrame)) else x
+                    for x in bootstrap_runs
+                ],
+                q=index_quantile,
+                axis=0,
+            )
 
         # Reshape CI outputs to look like original MetricFrame outputs
         if isinstance(sample_estimate, numbers.Number):
             quantiles.append((user_ci, bootstrap_quantile[()]))
-    
+
         elif isinstance(sample_estimate, pd.Series):
-            quantiles.append((user_ci, pd.Series(bootstrap_quantile, index=sample_estimate.index)))
+            quantiles.append(
+                (user_ci, pd.Series(bootstrap_quantile, index=sample_estimate.index))
+            )
 
         elif isinstance(sample_estimate, pd.DataFrame):
             quantiles.append(
-                (user_ci, pd.DataFrame(bootstrap_quantile, index=sample_estimate.index, columns=sample_estimate.columns))
+                (
+                    user_ci,
+                    pd.DataFrame(
+                        bootstrap_quantile,
+                        index=sample_estimate.index,
+                        columns=sample_estimate.columns,
+                    ),
+                )
             )
         else:
-            raise ValueError(f"Datatype: {type(sample_estimate)} is unsupported in create_ci_output bootstrap function. Must be one of type 'Number', 'Pandas Series', 'Pandas DataFrame'.")
-    
+            raise ValueError(
+                f"Datatype: {type(sample_estimate)} is unsupported in create_ci_output"
+                " bootstrap function. Must be one of type 'Number', 'Pandas Series',"
+                " 'Pandas DataFrame'."
+            )
+
     return quantiles

--- a/fairlearn/metrics/_bootstrap.py
+++ b/fairlearn/metrics/_bootstrap.py
@@ -1,0 +1,110 @@
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
+# Licensed under the MIT License.
+
+"""Utility functions for bootstrap calculations (used for confidence intervals)."""
+
+from warnings import warn
+import pandas as pd
+import numpy as np
+from scipy.stats import norm
+import numbers
+
+def process_ci_bounds(ci, ci_method, precision=6):
+    '''Parses user inputs to construct confidence intervals from bootstrap.
+       This function interprets integer and float inputs as the desired
+       width of a two-sided confidence interval, and lists and tuples as
+       exact quantiles to retrieve.
+
+       Parameters
+        ----------
+        ci : float, list, tuple
+        Determines the quantiles reported for confidence intervals. All entries must
+        be in the range [0, 1]. A single float is interpreted as the width of the 
+        desired confidence interval (e.g. 0.95 is a 95% interval), while a List or Tuple
+        reports exact quantiles from the empirical bootstrap distribution 
+        (e.g. (0, 0.33, 0.5, 0.66, 1) will calculate the min, 33rd, 50th, 66th, and max quantiles).
+        
+        method: str
+        One of {'percentile', 'bias-corrected'}. Used to validate CI inputs.
+
+        precision: int
+        Number of decimals of precision to round quantile calculations to.
+    '''
+    if ci_method not in ['percentile', 'bias-corrected']:
+        raise ValueError(f"Parameter ci_method: {ci_method} must be set to 'percentile' or 'bias-corrected'.")
+
+    if isinstance(ci, (int, float)) and (0 <= ci <= 1):
+        return tuple(np.round((0.5 - ci/2, 0.5 + ci/2), decimals=precision))
+
+    elif isinstance(ci, (tuple, list)):
+        if all(((0 <= x <= 1) for x in ci)):
+            return tuple(ci)
+        else:
+            raise ValueError(f"All desired confidence interval bounds must be within [0, 1].")
+
+    else:
+        raise ValueError(f"Input to 'ci' of type {type(ci)} must be of type int, float, tuple, or list.")
+    
+
+def create_ci_output(bootstrap_runs, ci, sample_estimate, interval_type='percentile'):
+    '''Calculates and formats confidence intervals from bootstrap samples.'''
+    
+    #--- Check if there is significant bias in sample statistics ---
+    bootstrap_mean = np.mean(bootstrap_runs, axis=0)
+
+    # Need to use this incredibly odd workaround to support frames with "object" dtypes
+    # object typed frames are produced by default from .__group()
+    bootstrap_std = np.sqrt(np.var(bootstrap_runs, axis=0, dtype='float64'))
+    bias = bootstrap_mean - sample_estimate
+    bias_adjusted_mean_estimate = 2*sample_estimate - bootstrap_mean # Might be useful to publish?
+
+    # Efron and Tibshirani (1993) guidance on identifying "large" bias via bootstrap
+    high_bias_regions = np.abs(bias) >= (0.25 * bootstrap_std)
+    if np.any(high_bias_regions):
+        #TODO: Add bias indication regions into warning. Simply printing all "high_bias_regions" is overwhelming.
+        warn(
+            f"""Some statistics calculated by MetricFrame are detected to have high bias 
+            Consider setting `ci_method` == 'bias-corrected' to mitigate inaccuracies in
+            confidence interval calculations."""
+        )
+
+    #--- Bootstrap quantile summary calculations ---
+
+    # Adjust which quantiles we sample from the empirical bootstrap distribution if bias correcting
+    if interval_type == 'bias-corrected':
+        # Follows Efron and Tibshirani (1993)
+        # with an additional adjustment for overestimating bias in the presence of ties
+        num_less = np.sum([x < sample_estimate for x in bootstrap_runs], axis=0)
+        num_equal = np.sum([x == sample_estimate for x in bootstrap_runs], axis=0)
+        prop_less = (num_less + num_equal/2) / len(bootstrap_runs)
+        z0 = norm.ppf(prop_less)
+        z_alphas = norm.ppf(ci)
+        adjusted_ci = [norm.cdf(2*z0 + alpha) for alpha in z_alphas]
+    else:
+        # Match bias adjusted ci datastructures for downstream code
+        adjusted_ci = np.repeat(ci, np.prod(sample_estimate.shape)).reshape((len(ci), *sample_estimate.shape))
+
+
+    # Potentially slow loop -- cannot seem to vectorize because we need a different set of quantiles for each cell
+    # TODO: Look into optimizing this further
+    quantiles = []
+    for user_ci, q in zip(ci, adjusted_ci): # Calculated based on adjusted_ci values but store with user requested
+        bootstrap_quantile = np.zeros_like(sample_estimate)
+        for index, index_quantile in np.ndenumerate(q):
+            bootstrap_quantile[index] = np.quantile([x.iloc[index] if isinstance(x, (pd.Series, pd.DataFrame)) else x for x in bootstrap_runs], q=index_quantile, axis=0)
+
+        # Reshape CI outputs to look like original MetricFrame outputs
+        if isinstance(sample_estimate, numbers.Number):
+            quantiles.append((user_ci, bootstrap_quantile[()]))
+    
+        elif isinstance(sample_estimate, pd.Series):
+            quantiles.append((user_ci, pd.Series(bootstrap_quantile, index=sample_estimate.index)))
+
+        elif isinstance(sample_estimate, pd.DataFrame):
+            quantiles.append(
+                (user_ci, pd.DataFrame(bootstrap_quantile, index=sample_estimate.index, columns=sample_estimate.columns))
+            )
+        else:
+            raise ValueError(f"Datatype: {type(sample_estimate)} is unsupported in create_ci_output bootstrap function. Must be one of type 'Number', 'Pandas Series', 'Pandas DataFrame'.")
+    
+    return quantiles

--- a/fairlearn/metrics/_bootstrap.py
+++ b/fairlearn/metrics/_bootstrap.py
@@ -90,7 +90,7 @@ def create_ci_output(bootstrap_runs, ci, sample_estimate, interval_type="percent
         prop_less = (num_less + num_equal / 2) / len(bootstrap_runs)
         z0 = norm.ppf(prop_less)
         z_alphas = norm.ppf(ci)
-        adjusted_ci = [norm.cdf(2 * z0 + alpha) for alpha in z_alphas]
+        adjusted_ci = [norm.cdf(2 * z0 + z_alpha) for z_alpha in z_alphas]
     else:
         # Match bias adjusted ci datastructures for downstream code
         adjusted_ci = np.repeat(ci, np.prod(sample_estimate.shape)).reshape(

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -5,7 +5,8 @@ import copy
 import logging
 import warnings
 from functools import wraps
-from typing import Any, Callable, Dict, List, Optional, Union
+from joblib import Parallel, delayed
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -15,6 +16,8 @@ from fairlearn.metrics._input_manipulations import _convert_to_ndarray_and_squee
 
 from ._annotated_metric_function import AnnotatedMetricFunction
 from ._group_feature import GroupFeature
+
+from ._bootstrap import process_ci_bounds, create_ci_output
 
 logger = logging.getLogger(__name__)
 
@@ -223,6 +226,27 @@ class MetricFrame:
         .. deprecated:: 0.7.0
             `metric` will be removed in version 0.10.0, use `metrics` instead.
 
+    n_boot : int
+        Used to produce confidence intervals. This parameter controls the number of
+        bootstrap iterations MetricFrame runs to estimate uncertainty in each metric.
+        For best results, it is recommended to set this to 100 or more. Setting to None
+        disables confidence interval functionality. Confidence intervals are currently 
+        not supported on complex metrics that yield multiple outputs.
+    ci : float, list, tuple
+        Determines the quantiles reported for confidence intervals. All entries must
+        be in the range [0, 1]. A single float is interpreted as the width of the 
+        desired confidence interval (e.g. 0.95 is a 95% interval), while a List or Tuple
+        reports exact quantiles from the empirical bootstrap distribution 
+        (e.g. (0, 0.33, 0.5, 0.66, 1) will calculate the min, 33rd, 50th, 66th, and max quantiles).
+    ci_method: str
+        One of {'percentile', 'bias-corrected'}. This method determines the algorithm used to 
+        produce valid confidence intervals from the bootstrap distribution. 'percentine' returns
+        quantiles directly from the empirical bootstrap distribution. 'bias-corrected' estimates 
+        the statistical bias in the bootstrap estimates of each metric and adjusts the interval.
+    n_jobs : int
+        The number of jobs to run in parallel. Only used for confidence interval calculations.
+        None means 1 unless in a joblib.parallel_backend context. -1 means using all processors. 
+
     Examples
     --------
     >>> from fairlearn.metrics import MetricFrame, selection_rate
@@ -309,6 +333,10 @@ class MetricFrame:
         sample_params: Optional[
             Union[Dict[str, Any], Dict[str, Dict[str, Any]]]
         ] = None,
+        n_boot: Optional[int] = None,
+        ci: Union[float, List[float], Tuple[float]] = 0.95,
+        ci_method: str = 'percentile',
+        n_jobs: int = 1
     ):
         """Read a placeholder comment."""
         check_consistent_length(y_true, y_pred)
@@ -364,6 +392,67 @@ class MetricFrame:
             all_data, annotated_funcs, grouping_features
         )
 
+        # Calculate uncertainty intervals using bootstrapped versions of data
+        def _bootstrap_metrics_calc(data):
+            overall_frame = self._build_overall_frame(data, annotated_funcs, cf_list, self._cf_names)
+            by_group_frame = self._build_by_group_frame(data, annotated_funcs, grouping_features)
+            group_min_frame = self.__group(by_group_frame, 'min', errors='coerce')
+            group_max_frame = self.__group(by_group_frame, 'max', errors='coerce')
+
+            overall_calc_frame, by_group_calc_frame = overall_frame, by_group_frame
+            if self._user_supplied_callable: # This logic is borrowed from .overall/.by_group -- refactor?
+                by_group_calc_frame = by_group_frame.iloc[:, 0]
+                if self.control_levels:
+                    overall_calc_frame = overall_frame.iloc[:, 0]
+                else:
+                    overall_calc_frame = overall_frame.iloc[0]
+
+            diff_overall_frame = self.__difference(by_group_calc_frame, overall_calc_frame)
+            diff_group_frame = self.__difference(by_group_calc_frame, group_min_frame)
+            ratio_overall_frame = self._calc_ratio_overall(by_group_calc_frame, overall_calc_frame)
+            ratio_group_frame = group_min_frame / group_max_frame
+
+
+            return overall_frame, by_group_frame, group_min_frame, group_max_frame, \
+                diff_group_frame, diff_overall_frame, ratio_group_frame, ratio_overall_frame
+
+        self._overall_ci, self._by_group_ci = None, None
+        self.difference_overall_ci, self.difference_group_ci = None, None
+        self.ratio_overall_ci, self.ratio_groups_ci = None, None
+        self.group_min_ci, self.group_max_ci = None, None
+
+        if n_boot is not None:
+            # Calculate all outputs across entire data sample to assist bootstrap bias calculations
+            # NOTE: Consider caching these results for on-demand regular calls?
+            try: # TODO: Find a better way of checking for functions with non-scalar return types.
+                group_min_output = self.__group(self._by_group, 'min')
+                group_max_output = self.__group(self._by_group, 'max')
+                difference_group_output = self.__difference(self.by_group, group_min_output)
+                difference_overall_output = self.__difference(self.by_group, self.overall)
+                ratio_group_output = group_min_output / group_max_output
+                ratio_overall_output = self._calc_ratio_overall(self.by_group, self.overall)
+            except:
+                raise ValueError("Metrics with non-scalar outputs do not currently support confidence intervals. \
+                    Set n_boot=None to disable confidence interval calculation.")
+
+            ci = process_ci_bounds(ci, ci_method)
+            parallel_output = Parallel(n_jobs=n_jobs)(
+                delayed(_bootstrap_metrics_calc)(all_data.sample(frac=1, replace=True))
+                for _ in range(n_boot)
+            )
+            overall_runs, by_group_runs, group_min_runs, group_max_runs, \
+                diff_group_runs, diff_overall_runs, ratio_group_runs, ratio_overall_runs = list(zip(*parallel_output))
+
+            # Summarize results, using main output as a prototype to provide appropriate index/columns.
+            self._overall_ci = create_ci_output(overall_runs, ci, sample_estimate=self._overall, interval_type=ci_method)
+            self._by_group_ci = create_ci_output(by_group_runs, ci, sample_estimate=self._by_group, interval_type=ci_method)
+            self.group_min_ci = create_ci_output(group_min_runs, ci, sample_estimate=group_min_output, interval_type=ci_method)
+            self.group_max_ci = create_ci_output(group_max_runs, ci, sample_estimate=group_max_output, interval_type=ci_method)
+            self.difference_group_ci = create_ci_output(diff_group_runs, ci, sample_estimate=difference_group_output, interval_type=ci_method)
+            self.difference_overall_ci = create_ci_output(diff_overall_runs, ci, sample_estimate=difference_overall_output, interval_type=ci_method)
+            self.ratio_group_ci = create_ci_output(ratio_group_runs, ci, sample_estimate=ratio_group_output, interval_type=ci_method)
+            self.ratio_overall_ci = create_ci_output(ratio_overall_runs, ci, sample_estimate=ratio_overall_output, interval_type=ci_method)
+
     @property
     def overall(self) -> Union[Any, pd.Series, pd.DataFrame]:
         """Return the underlying metrics evaluated on the whole dataset.
@@ -406,6 +495,21 @@ class MetricFrame:
             return self._overall
 
     @property
+    def overall_ci(self) -> Optional[List[Tuple[float, Union[pd.Series, pd.DataFrame]]]]:
+        '''Return estimates of overall confidence intervals calculated via bootstrap.'''
+
+        if self._overall_ci:
+            if self._user_supplied_callable:
+                if self.control_levels:
+                    return [(quantile, output.iloc[:, 0]) for quantile, output in self._overall_ci]
+                else:
+                    return [(quantile, output.iloc[0]) for quantile, output in self._overall_ci]
+            else:
+                return self._overall_ci
+
+        return None
+
+    @property
     def by_group(self) -> Union[pd.Series, pd.DataFrame]:
         """Return the collection of metrics evaluated for each subgroup.
 
@@ -436,6 +540,18 @@ class MetricFrame:
             return self._by_group.iloc[:, 0]
         else:
             return self._by_group
+
+    @property
+    def by_group_ci(self) -> Optional[List[Dict[float, Union[pd.Series, pd.DataFrame]]]]:
+        '''Return estimates of by_group confidence intervals calculated via bootstrap.'''
+
+        if self._by_group_ci:
+            if self._user_supplied_callable:
+                return [(quantile, output.iloc[:, 0]) for quantile, output in self._by_group_ci]
+            else:
+                return self._by_group_ci
+
+        return None
 
     @property
     def control_levels(self) -> List[str]:

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -434,7 +434,7 @@ class MetricFrame:
             )
 
         self._overall_ci, self._by_group_ci = None, None
-        self.difference_overall_ci, self.difference_group_ci = None, None
+        self._difference_overall_ci, self._difference_group_ci = None, None
         self.ratio_overall_ci, self.ratio_groups_ci = None, None
         self._group_min_ci, self._group_max_ci = None, None
 
@@ -500,13 +500,13 @@ class MetricFrame:
                 sample_estimate=group_max_output,
                 interval_type=ci_method,
             )
-            self.difference_group_ci = create_ci_output(
+            self._difference_group_ci = create_ci_output(
                 diff_group_runs,
                 self._quantiles,
                 sample_estimate=difference_group_output,
                 interval_type=ci_method,
             )
-            self.difference_overall_ci = create_ci_output(
+            self._difference_overall_ci = create_ci_output(
                 diff_overall_runs,
                 self._quantiles,
                 sample_estimate=difference_overall_output,
@@ -818,7 +818,6 @@ class MetricFrame:
         """
         return self.__group(self._by_group, "min", errors)
 
-    
     @property
     def group_max_ci(self):
         if self._group_max_ci:
@@ -901,6 +900,23 @@ class MetricFrame:
             )
 
         return self.__difference(self.by_group, subtrahend)
+
+    def difference_ci(self, method='between_groups'):
+        result = None
+        if method == 'between_groups':
+            if self._difference_group_ci:
+                result = [
+                    output for _, output in self._difference_group_ci
+                ]
+        elif method == 'to_overall':
+            if self._difference_overall_ci:
+                result = [output for _, output in self._difference_overall_ci]
+        else:
+            raise ValueError(
+                "Unrecognised method '{0}' in difference_ci() call".format(method)
+            )
+
+        return result
 
     def _calc_ratio_overall(self, by_group_frame, overall_frame):
         def ratio_sub_one(x):

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -480,7 +480,10 @@ class MetricFrame:
 
             # Summarize results, using main output as a prototype to provide appropriate index/columns.
             self._overall_ci = create_ci_output(
-                overall_runs, self._quantiles, sample_estimate=self._overall, interval_type=ci_method
+                overall_runs,
+                self._quantiles,
+                sample_estimate=self._overall,
+                interval_type=ci_method,
             )
             self._by_group_ci = create_ci_output(
                 by_group_runs,
@@ -585,19 +588,11 @@ class MetricFrame:
         if self._overall_ci:
             if self._user_supplied_callable:
                 if self.control_levels:
-                    return [
-                        output.iloc[:, 0]
-                        for _, output in self._overall_ci
-                    ]
+                    return [output.iloc[:, 0] for _, output in self._overall_ci]
                 else:
-                    return [
-                        output.iloc[0]
-                        for _, output in self._overall_ci
-                    ]
+                    return [output.iloc[0] for _, output in self._overall_ci]
             else:
-                return [
-                    output for _, output in self._overall_ci
-                ]
+                return [output for _, output in self._overall_ci]
 
         return None
 
@@ -637,18 +632,14 @@ class MetricFrame:
     def by_group_ci(
         self,
     ) -> Optional[List[Dict[float, Union[pd.Series, pd.DataFrame]]]]:
-        """Return estimates of by_group confidence intervals calculated via bootstrap."""
+        """Return estimates of by_group confidence intervals calculated via bootstrap.
+        """
 
         if self._by_group_ci:
             if self._user_supplied_callable:
-                return [
-                    output.iloc[:, 0]
-                    for _, output in self._by_group_ci
-                ]
+                return [output.iloc[:, 0] for _, output in self._by_group_ci]
             else:
-                return [
-                    output for _, output in self._by_group_ci
-                ]
+                return [output for _, output in self._by_group_ci]
 
         return None
 
@@ -821,25 +812,20 @@ class MetricFrame:
     @property
     def group_max_ci(self):
         if self._group_max_ci:
-            return [
-                output for _, output in self._group_max_ci
-            ]
+            return [output for _, output in self._group_max_ci]
 
         return None
 
     @property
     def group_min_ci(self):
         if self._group_min_ci:
-            return [
-                output for _, output in self._group_min_ci
-            ]
+            return [output for _, output in self._group_min_ci]
 
         return None
 
     def __difference(
         self, by_group_frame: Union[pd.Series, pd.DataFrame], subtrahend: pd.DataFrame
     ) -> Union[Any, pd.Series, pd.DataFrame]:
-
         mf = by_group_frame.copy()
         if isinstance(mf, pd.Series):
             mf = mf.map(lambda x: x if np.isscalar(x) else np.nan)
@@ -901,14 +887,12 @@ class MetricFrame:
 
         return self.__difference(self.by_group, subtrahend)
 
-    def difference_ci(self, method='between_groups'):
+    def difference_ci(self, method="between_groups"):
         result = None
-        if method == 'between_groups':
+        if method == "between_groups":
             if self._difference_group_ci:
-                result = [
-                    output for _, output in self._difference_group_ci
-                ]
-        elif method == 'to_overall':
+                result = [output for _, output in self._difference_group_ci]
+        elif method == "to_overall":
             if self._difference_overall_ci:
                 result = [output for _, output in self._difference_overall_ci]
         else:
@@ -1007,7 +991,8 @@ class MetricFrame:
     def _process_functions(
         self, metric, sample_params, all_data: pd.DataFrame
     ) -> Dict[str, AnnotatedMetricFunction]:
-        """Get the underlying metrics into :class:`fairlearn.metrics.AnnotatedMetricFunction` objects."""  # noqa: E501
+        """Get the underlying metrics into :class:`fairlearn.metrics.AnnotatedMetricFunction` objects.
+        """  # noqa: E501
         self._user_supplied_callable = True
         func_dict = dict()
 

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -392,7 +392,7 @@ class MetricFrame:
             all_data, annotated_funcs, grouping_features
         )
 
-        # Calculate uncertainty intervals using bootstrapped versions of data
+        # Calculate quantiles using bootstrapped versions of data
         def _bootstrap_metrics_calc(data):
             overall_frame = self._build_overall_frame(
                 data, annotated_funcs, cf_list, self._cf_names

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -454,12 +454,12 @@ class MetricFrame:
                 ratio_overall_output = self._calc_ratio_overall(
                     self.by_group, self.overall
                 )
-            except:
+            except Exception as e:
                 raise ValueError(
-                    "Metrics with non-scalar outputs do not currently support"
-                    " confidence intervals.                     Set n_boot=None to"
-                    " disable confidence interval calculation."
-                )
+                    "Bootstrap calculation failed. See inner exception for more details."
+                    " This is often caused by one or more of the supplied metric functions"
+                    " having a non-scalar return value."
+                ) from e
 
             ci = process_ci_bounds(ci, ci_method)
             parallel_output = Parallel(n_jobs=n_jobs)(

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -435,7 +435,7 @@ class MetricFrame:
 
         self._overall_ci, self._by_group_ci = None, None
         self._difference_overall_ci, self._difference_group_ci = None, None
-        self.ratio_overall_ci, self.ratio_groups_ci = None, None
+        self._ratio_overall_ci, self._ratio_group_ci = None, None
         self._group_min_ci, self._group_max_ci = None, None
 
         self._quantiles = None
@@ -515,13 +515,13 @@ class MetricFrame:
                 sample_estimate=difference_overall_output,
                 interval_type=ci_method,
             )
-            self.ratio_group_ci = create_ci_output(
+            self._ratio_group_ci = create_ci_output(
                 ratio_group_runs,
                 self._quantiles,
                 sample_estimate=ratio_group_output,
                 interval_type=ci_method,
             )
-            self.ratio_overall_ci = create_ci_output(
+            self._ratio_overall_ci = create_ci_output(
                 ratio_overall_runs,
                 self._quantiles,
                 sample_estimate=ratio_overall_output,
@@ -985,6 +985,21 @@ class MetricFrame:
             result = self._calc_ratio_overall(self.by_group, self.overall)
         else:
             raise ValueError("Unrecognised method '{0}' in ratio() call".format(method))
+
+        return result
+
+    def ratio_ci(self, method="between_groups"):
+        result = None
+        if method == "between_groups":
+            if self._ratio_group_ci:
+                result = [output for _, output in self._ratio_group_ci]
+        elif method == "to_overall":
+            if self._ratio_overall_ci:
+                result = [output for _, output in self._ratio_overall_ci]
+        else:
+            raise ValueError(
+                "Unrecognised method '{0}' in ratio_ci() call".format(method)
+            )
 
         return result
 

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -640,8 +640,8 @@ class MetricFrame:
         if self._by_group_ci:
             if self._user_supplied_callable:
                 return [
-                    (quantile, output.iloc[:, 0])
-                    for quantile, output in self._by_group_ci
+                    output.iloc[:, 0]
+                    for _, output in self._by_group_ci
                 ]
             else:
                 return self._by_group_ci

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -586,13 +586,13 @@ class MetricFrame:
             if self._user_supplied_callable:
                 if self.control_levels:
                     return [
-                        (quantile, output.iloc[:, 0])
-                        for quantile, output in self._overall_ci
+                        output.iloc[:, 0]
+                        for _, output in self._overall_ci
                     ]
                 else:
                     return [
-                        (quantile, output.iloc[0])
-                        for quantile, output in self._overall_ci
+                        output.iloc[0]
+                        for _, output in self._overall_ci
                     ]
             else:
                 return self._overall_ci

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -869,16 +869,23 @@ class MetricFrame:
         return self.__difference(self.by_group, subtrahend)
 
     def _calc_ratio_overall(self, by_group_frame, overall_frame):
+
+        def ratio_sub_one(x):
+            if x > 1:
+                return 1 / x
+            else:
+                return x
+
         if self._user_supplied_callable:
             tmp = by_group_frame / overall_frame
             if self.control_levels:
                 result = (
-                    tmp.transform(lambda x: min(x, 1 / x))
+                    tmp.transform(ratio_sub_one)
                     .groupby(level=self.control_levels)
                     .min()
                 )
             else:
-                result = tmp.transform(lambda x: min(x, 1 / x)).min()
+                result = tmp.transform(ratio_sub_one).min()
         else:
             if self.control_levels:
                 # It's easiest to give in to the DataFrame columns preference
@@ -887,12 +894,6 @@ class MetricFrame:
                 ) / self.overall.unstack(level=self.control_levels)
             else:
                 ratios = self.by_group / self.overall
-
-            def ratio_sub_one(x):
-                if x > 1:
-                    return 1 / x
-                else:
-                    return x
 
             ratios = ratios.apply(lambda x: x.transform(ratio_sub_one))
             if not self.control_levels:

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -456,9 +456,9 @@ class MetricFrame:
                 )
             except Exception as e:
                 raise ValueError(
-                    "Bootstrap calculation failed. See inner exception for more details."
-                    " This is often caused by one or more of the supplied metric functions"
-                    " having a non-scalar return value."
+                    "Bootstrap calculation failed. See inner exception for more"
+                    " details. This is often caused by one or more of the supplied"
+                    " metric functions having a non-scalar return value."
                 ) from e
 
             ci = process_ci_bounds(ci, ci_method)
@@ -869,7 +869,6 @@ class MetricFrame:
         return self.__difference(self.by_group, subtrahend)
 
     def _calc_ratio_overall(self, by_group_frame, overall_frame):
-
         def ratio_sub_one(x):
             if x > 1:
                 return 1 / x

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -436,7 +436,7 @@ class MetricFrame:
         self._overall_ci, self._by_group_ci = None, None
         self.difference_overall_ci, self.difference_group_ci = None, None
         self.ratio_overall_ci, self.ratio_groups_ci = None, None
-        self.group_min_ci, self.group_max_ci = None, None
+        self._group_min_ci, self._group_max_ci = None, None
 
         self._quantiles = None
         if n_boot is not None:
@@ -488,13 +488,13 @@ class MetricFrame:
                 sample_estimate=self._by_group,
                 interval_type=ci_method,
             )
-            self.group_min_ci = create_ci_output(
+            self._group_min_ci = create_ci_output(
                 group_min_runs,
                 self._quantiles,
                 sample_estimate=group_min_output,
                 interval_type=ci_method,
             )
-            self.group_max_ci = create_ci_output(
+            self._group_max_ci = create_ci_output(
                 group_max_runs,
                 self._quantiles,
                 sample_estimate=group_max_output,
@@ -817,6 +817,25 @@ class MetricFrame:
             follows the table in :attr:`.MetricFrame.overall`.
         """
         return self.__group(self._by_group, "min", errors)
+
+    
+    @property
+    def group_max_ci(self):
+        if self._group_max_ci:
+            return [
+                output for _, output in self._group_max_ci
+            ]
+
+        return None
+
+    @property
+    def group_min_ci(self):
+        if self._group_min_ci:
+            return [
+                output for _, output in self._group_min_ci
+            ]
+
+        return None
 
     def __difference(
         self, by_group_frame: Union[pd.Series, pd.DataFrame], subtrahend: pd.DataFrame

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -528,7 +528,7 @@ class MetricFrame:
     @property
     def quantiles_(self) -> Optional[Tuple]:
         """Return the bootstrap confidence intervals.
-        
+
         This will be :code:`None` if :code:`n_boot` was :code:`None`.
         Otherwise it will be a tuple listing the quantiles
         for which all confidence intervals have been calculated
@@ -595,7 +595,9 @@ class MetricFrame:
                         for _, output in self._overall_ci
                     ]
             else:
-                return self._overall_ci
+                return [
+                    output for _, output in self._overall_ci
+                ]
 
         return None
 
@@ -644,7 +646,9 @@ class MetricFrame:
                     for _, output in self._by_group_ci
                 ]
             else:
-                return self._by_group_ci
+                return [
+                    output for _, output in self._by_group_ci
+                ]
 
         return None
 

--- a/test/unit/metrics/test_metricframe_aggregates.py
+++ b/test/unit/metrics/test_metricframe_aggregates.py
@@ -125,6 +125,20 @@ class Test1m1sf0cf:
             expected_ratio_overall, rel=1e-10, abs=1e-16
         )
 
+    def test_ratio_zero_divide(self):
+        # Simple test to check on zero division
+        my_prec = functools.partial(skm.precision_score, zero_division=0)
+        my_prec.__name__ = "precision_score_zero_div"
+
+        mf = metrics.MetricFrame(
+            metrics=my_prec,
+            y_true = [1, 0],
+            y_pred = [1, 0],
+            sensitive_features=['a', 'b']
+        )
+
+        assert mf.ratio(method='to_overall') == 0
+
 
 class Test1m1sf0cfFnDict:
     # Key difference is that the function is supplied as a dict

--- a/test/unit/metrics/test_metricframe_aggregates.py
+++ b/test/unit/metrics/test_metricframe_aggregates.py
@@ -131,13 +131,10 @@ class Test1m1sf0cf:
         my_prec.__name__ = "precision_score_zero_div"
 
         mf = metrics.MetricFrame(
-            metrics=my_prec,
-            y_true = [1, 0],
-            y_pred = [1, 0],
-            sensitive_features=['a', 'b']
+            metrics=my_prec, y_true=[1, 0], y_pred=[1, 0], sensitive_features=["a", "b"]
         )
 
-        assert mf.ratio(method='to_overall') == 0
+        assert mf.ratio(method="to_overall") == 0
 
 
 class Test1m1sf0cfFnDict:

--- a/test/unit/metrics/test_metricframe_bootstrap.py
+++ b/test/unit/metrics/test_metricframe_bootstrap.py
@@ -16,9 +16,9 @@ from .data_for_test import y_t, y_p, s_w, g_1, g_2, g_3, g_4
 
 metric = [
     skm.recall_score,
-    #skm.precision_score,
-    #skm.accuracy_score,
-    #skm.balanced_accuracy_score,
+    # skm.precision_score,
+    # skm.accuracy_score,
+    # skm.balanced_accuracy_score,
 ]
 
 ci_options = [0.95, 0.05, [0.2, 0.4, 0.6, 0.8]]
@@ -39,18 +39,11 @@ def check_all_bootstrap_output_shapes(mf):
     for ci_output in mf.group_max_ci:
         assert mf.group_max().shape == ci_output.shape
 
-    for method in ['to_overall', 'between_groups']:
+    for method in ["to_overall", "between_groups"]:
         for ci_output in mf.difference_ci(method=method):
             assert mf.difference(method=method).shape == ci_output.shape
-
-    assert all(
-        mf.ratio(method="to_overall").shape == ci_output.shape
-        for _, ci_output in mf.ratio_overall_ci
-    )
-    assert all(
-        mf.ratio(method="between_groups").shape == ci_output.shape
-        for _, ci_output in mf.ratio_group_ci
-    )
+        for ci_output in mf.ratio_ci(method=method):
+            assert mf.ratio(method=method).shape == ci_output.shape
 
 
 def check_all_bootstrap_directions(mf):
@@ -64,8 +57,8 @@ def check_all_bootstrap_directions(mf):
     assert check_direction(mf.group_max_ci)
     assert check_direction(mf.difference_ci(method="to_overall"))
     assert check_direction(mf.difference_ci(method="between_groups"))
-    assert check_direction(mf.ratio_overall_ci)
-    assert check_direction(mf.ratio_group_ci)
+    assert check_direction(mf.ratio_ci(method="to_overall"))
+    assert check_direction(mf.ratio_ci(method="between_groups"))
 
 
 @pytest.mark.parametrize("metric_fn", metric)

--- a/test/unit/metrics/test_metricframe_bootstrap.py
+++ b/test/unit/metrics/test_metricframe_bootstrap.py
@@ -16,9 +16,9 @@ from .data_for_test import y_t, y_p, s_w, g_1, g_2, g_3, g_4
 
 metric = [
     skm.recall_score,
-    skm.precision_score,
-    skm.accuracy_score,
-    skm.balanced_accuracy_score,
+    #skm.precision_score,
+    #skm.accuracy_score,
+    #skm.balanced_accuracy_score,
 ]
 
 ci_options = [0.95, 0.05, [0.2, 0.4, 0.6, 0.8]]
@@ -29,8 +29,10 @@ ci_methods = ["percentile", "bias-corrected"]
 
 def check_all_bootstrap_output_shapes(mf):
     # Check if all .*_ci outputs are same shape as regular outputs
-    assert all(mf.overall.shape == ci_output.shape for _, ci_output in mf.overall_ci)
-    assert all(mf.by_group.shape == ci_output.shape for _, ci_output in mf.by_group_ci)
+    for ci_output in mf.overall_ci:
+        assert mf.overall.shape == ci_output.shape
+    for ci_output in mf.by_group_ci:
+        assert mf.by_group.shape == ci_output.shape
     assert all(
         mf.group_min().shape == ci_output.shape for _, ci_output in mf.group_min_ci
     )

--- a/test/unit/metrics/test_metricframe_bootstrap.py
+++ b/test/unit/metrics/test_metricframe_bootstrap.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
-# These functions are borrowed from "test_metricframe_by_group.py" 
+# These functions are borrowed from "test_metricframe_by_group.py"
 # with additional checks for bootstrap related operations.
 
 import numpy as np
@@ -14,26 +14,46 @@ from fairlearn.metrics import MetricFrame
 from .data_for_test import y_t, y_p, s_w, g_1, g_2, g_3, g_4
 
 
-metric = [skm.recall_score,
-          skm.precision_score,
-          skm.accuracy_score,
-          skm.balanced_accuracy_score]
+metric = [
+    skm.recall_score,
+    skm.precision_score,
+    skm.accuracy_score,
+    skm.balanced_accuracy_score,
+]
 
 ci_options = [0.95, 0.05, [0.2, 0.4, 0.6, 0.8]]
-ci_methods = ['percentile', 'bias-corrected']
+ci_methods = ["percentile", "bias-corrected"]
 
 # Bootstrap test helper functions
 
+
 def check_all_bootstrap_output_shapes(mf):
     # Check if all .*_ci outputs are same shape as regular outputs
-    assert all(mf.overall.shape == ci_output.shape for _, ci_output in mf.overall_ci) 
+    assert all(mf.overall.shape == ci_output.shape for _, ci_output in mf.overall_ci)
     assert all(mf.by_group.shape == ci_output.shape for _, ci_output in mf.by_group_ci)
-    assert all(mf.group_min().shape == ci_output.shape for _, ci_output in mf.group_min_ci)
-    assert all(mf.group_max().shape == ci_output.shape for _, ci_output in mf.group_max_ci)
-    assert all(mf.difference(method='to_overall').shape == ci_output.shape for _, ci_output in mf.difference_overall_ci)
-    assert all(mf.difference(method='between_groups').shape == ci_output.shape for _, ci_output in mf.difference_group_ci)
-    assert all(mf.ratio(method='to_overall').shape == ci_output.shape for _, ci_output in mf.ratio_overall_ci)
-    assert all(mf.ratio(method='between_groups').shape == ci_output.shape for _, ci_output in mf.ratio_group_ci)
+    assert all(
+        mf.group_min().shape == ci_output.shape for _, ci_output in mf.group_min_ci
+    )
+    assert all(
+        mf.group_max().shape == ci_output.shape for _, ci_output in mf.group_max_ci
+    )
+    assert all(
+        mf.difference(method="to_overall").shape == ci_output.shape
+        for _, ci_output in mf.difference_overall_ci
+    )
+    assert all(
+        mf.difference(method="between_groups").shape == ci_output.shape
+        for _, ci_output in mf.difference_group_ci
+    )
+    assert all(
+        mf.ratio(method="to_overall").shape == ci_output.shape
+        for _, ci_output in mf.ratio_overall_ci
+    )
+    assert all(
+        mf.ratio(method="between_groups").shape == ci_output.shape
+        for _, ci_output in mf.ratio_group_ci
+    )
+
 
 def check_all_bootstrap_directions(mf):
     def check_direction(ci_outputs):
@@ -49,24 +69,31 @@ def check_all_bootstrap_directions(mf):
     assert check_direction(mf.ratio_overall_ci)
     assert check_direction(mf.ratio_group_ci)
 
+
 @pytest.mark.parametrize("metric_fn", metric)
 @pytest.mark.parametrize("ci_opt", ci_options)
 @pytest.mark.parametrize("ci_method", ci_methods)
 def test_1m_1sf_0cf(metric_fn, ci_opt, ci_method):
-    target = MetricFrame(metrics=metric_fn, y_true=y_t, y_pred=y_p,
-                         sensitive_features=g_1, 
-                         n_boot=10, ci=ci_opt, ci_method=ci_method)
+    target = MetricFrame(
+        metrics=metric_fn,
+        y_true=y_t,
+        y_pred=y_p,
+        sensitive_features=g_1,
+        n_boot=10,
+        ci=ci_opt,
+        ci_method=ci_method,
+    )
     assert target._user_supplied_callable is True
 
     assert isinstance(target.by_group, pd.Series)
     assert len(target.by_group) == 2
-    assert np.array_equal(target.by_group.index.names, ['sensitive_feature_0'])
-    mask_a = (g_1 == 'aa')
-    mask_b = (g_1 == 'ba')
+    assert np.array_equal(target.by_group.index.names, ["sensitive_feature_0"])
+    mask_a = g_1 == "aa"
+    mask_b = g_1 == "ba"
     metric_a = metric_fn(y_t[mask_a], y_p[mask_a])
     metric_b = metric_fn(y_t[mask_b], y_p[mask_b])
-    assert target.by_group['aa'] == metric_a
-    assert target.by_group['ba'] == metric_b
+    assert target.by_group["aa"] == metric_a
+    assert target.by_group["ba"] == metric_b
 
     check_all_bootstrap_output_shapes(target)
     check_all_bootstrap_directions(target)
@@ -76,20 +103,26 @@ def test_1m_1sf_0cf(metric_fn, ci_opt, ci_method):
 @pytest.mark.parametrize("ci_opt", ci_options)
 @pytest.mark.parametrize("ci_method", ci_methods)
 def test_1m_1sf_0cf_metric_dict(metric_fn, ci_opt, ci_method):
-    target = MetricFrame(metrics={metric_fn.__name__: metric_fn}, y_true=y_t, y_pred=y_p,
-                         sensitive_features=g_1, 
-                         n_boot=10, ci=ci_opt, ci_method=ci_method)
+    target = MetricFrame(
+        metrics={metric_fn.__name__: metric_fn},
+        y_true=y_t,
+        y_pred=y_p,
+        sensitive_features=g_1,
+        n_boot=10,
+        ci=ci_opt,
+        ci_method=ci_method,
+    )
     assert target._user_supplied_callable is False
 
     assert isinstance(target.by_group, pd.DataFrame)
     assert target.by_group.shape == (2, 1)
-    assert np.array_equal(target.by_group.index.names, ['sensitive_feature_0'])
-    mask_a = (g_1 == 'aa')
-    mask_b = (g_1 == 'ba')
+    assert np.array_equal(target.by_group.index.names, ["sensitive_feature_0"])
+    mask_a = g_1 == "aa"
+    mask_b = g_1 == "ba"
     metric_a = metric_fn(y_t[mask_a], y_p[mask_a])
     metric_b = metric_fn(y_t[mask_b], y_p[mask_b])
-    assert target.by_group[metric_fn.__name__]['aa'] == metric_a
-    assert target.by_group[metric_fn.__name__]['ba'] == metric_b
+    assert target.by_group[metric_fn.__name__]["aa"] == metric_a
+    assert target.by_group[metric_fn.__name__]["ba"] == metric_b
 
     check_all_bootstrap_output_shapes(target)
     check_all_bootstrap_directions(target)
@@ -99,30 +132,37 @@ def test_1m_1sf_0cf_metric_dict(metric_fn, ci_opt, ci_method):
 @pytest.mark.parametrize("ci_opt", ci_options)
 @pytest.mark.parametrize("ci_method", ci_methods)
 def test_1m_1sf_1cf(metric_fn, ci_opt, ci_method):
-    target = MetricFrame(metrics=metric_fn, y_true=y_t, y_pred=y_p,
-                         sensitive_features=g_1,
-                         control_features=g_2, 
-                         n_boot=10, ci=ci_opt, ci_method=ci_method)
+    target = MetricFrame(
+        metrics=metric_fn,
+        y_true=y_t,
+        y_pred=y_p,
+        sensitive_features=g_1,
+        control_features=g_2,
+        n_boot=10,
+        ci=ci_opt,
+        ci_method=ci_method,
+    )
     assert target._user_supplied_callable is True
 
     assert isinstance(target.by_group, pd.Series)
     assert len(target.by_group) == 4
-    assert np.array_equal(target.by_group.index.names,
-                          ['control_feature_0', 'sensitive_feature_0'])
+    assert np.array_equal(
+        target.by_group.index.names, ["control_feature_0", "sensitive_feature_0"]
+    )
 
-    mask_a_f = np.logical_and((g_1 == 'aa'), (g_2 == 'f'))
-    mask_a_g = np.logical_and((g_1 == 'aa'), (g_2 == 'g'))
-    mask_b_f = np.logical_and((g_1 == 'ba'), (g_2 == 'f'))
-    mask_b_g = np.logical_and((g_1 == 'ba'), (g_2 == 'g'))
+    mask_a_f = np.logical_and((g_1 == "aa"), (g_2 == "f"))
+    mask_a_g = np.logical_and((g_1 == "aa"), (g_2 == "g"))
+    mask_b_f = np.logical_and((g_1 == "ba"), (g_2 == "f"))
+    mask_b_g = np.logical_and((g_1 == "ba"), (g_2 == "g"))
 
     exp_a_f = metric_fn(y_t[mask_a_f], y_p[mask_a_f])
     exp_a_g = metric_fn(y_t[mask_a_g], y_p[mask_a_g])
     exp_b_f = metric_fn(y_t[mask_b_f], y_p[mask_b_f])
     exp_b_g = metric_fn(y_t[mask_b_g], y_p[mask_b_g])
-    assert target.by_group[('f', 'aa')] == exp_a_f
-    assert target.by_group[('f', 'ba')] == exp_b_f
-    assert target.by_group[('g', 'aa')] == exp_a_g
-    assert target.by_group[('g', 'ba')] == exp_b_g
+    assert target.by_group[("f", "aa")] == exp_a_f
+    assert target.by_group[("f", "ba")] == exp_b_f
+    assert target.by_group[("g", "aa")] == exp_a_g
+    assert target.by_group[("g", "ba")] == exp_b_g
 
     check_all_bootstrap_output_shapes(target)
     check_all_bootstrap_directions(target)
@@ -132,72 +172,90 @@ def test_1m_1sf_1cf(metric_fn, ci_opt, ci_method):
 @pytest.mark.parametrize("ci_opt", ci_options)
 @pytest.mark.parametrize("ci_method", ci_methods)
 def test_1m_1sf_1cf_metric_dict(metric_fn, ci_opt, ci_method):
-    target = MetricFrame(metrics={metric_fn.__name__: metric_fn}, y_true=y_t, y_pred=y_p,
-                         sensitive_features=g_1,
-                         control_features=g_2,
-                         n_boot=10, ci=ci_opt, ci_method=ci_method)
+    target = MetricFrame(
+        metrics={metric_fn.__name__: metric_fn},
+        y_true=y_t,
+        y_pred=y_p,
+        sensitive_features=g_1,
+        control_features=g_2,
+        n_boot=10,
+        ci=ci_opt,
+        ci_method=ci_method,
+    )
     assert target._user_supplied_callable is False
 
     assert isinstance(target.by_group, pd.DataFrame)
     assert target.by_group.shape == (4, 1)
-    assert np.array_equal(target.by_group.index.names,
-                          ['control_feature_0', 'sensitive_feature_0'])
+    assert np.array_equal(
+        target.by_group.index.names, ["control_feature_0", "sensitive_feature_0"]
+    )
 
-    mask_a_f = np.logical_and((g_1 == 'aa'), (g_2 == 'f'))
-    mask_a_g = np.logical_and((g_1 == 'aa'), (g_2 == 'g'))
-    mask_b_f = np.logical_and((g_1 == 'ba'), (g_2 == 'f'))
-    mask_b_g = np.logical_and((g_1 == 'ba'), (g_2 == 'g'))
+    mask_a_f = np.logical_and((g_1 == "aa"), (g_2 == "f"))
+    mask_a_g = np.logical_and((g_1 == "aa"), (g_2 == "g"))
+    mask_b_f = np.logical_and((g_1 == "ba"), (g_2 == "f"))
+    mask_b_g = np.logical_and((g_1 == "ba"), (g_2 == "g"))
 
     exp_a_f = metric_fn(y_t[mask_a_f], y_p[mask_a_f])
     exp_a_g = metric_fn(y_t[mask_a_g], y_p[mask_a_g])
     exp_b_f = metric_fn(y_t[mask_b_f], y_p[mask_b_f])
     exp_b_g = metric_fn(y_t[mask_b_g], y_p[mask_b_g])
-    assert target.by_group[metric_fn.__name__][('f', 'aa')] == exp_a_f
-    assert target.by_group[metric_fn.__name__][('f', 'ba')] == exp_b_f
-    assert target.by_group[metric_fn.__name__][('g', 'aa')] == exp_a_g
-    assert target.by_group[metric_fn.__name__][('g', 'ba')] == exp_b_g
+    assert target.by_group[metric_fn.__name__][("f", "aa")] == exp_a_f
+    assert target.by_group[metric_fn.__name__][("f", "ba")] == exp_b_f
+    assert target.by_group[metric_fn.__name__][("g", "aa")] == exp_a_g
+    assert target.by_group[metric_fn.__name__][("g", "ba")] == exp_b_g
 
     check_all_bootstrap_output_shapes(target)
     check_all_bootstrap_directions(target)
 
+
 @pytest.mark.parametrize("ci_opt", ci_options)
 @pytest.mark.parametrize("ci_method", ci_methods)
 def test_2m_2sf_2cf(ci_opt, ci_method):
-    funcs = {'recall': skm.recall_score, 'prec': skm.precision_score}
-    s_p = {'recall': {'sample_weight': s_w}}
+    funcs = {"recall": skm.recall_score, "prec": skm.precision_score}
+    s_p = {"recall": {"sample_weight": s_w}}
     sf = np.stack([g_1, g_3], axis=1)
-    cf = {'cf1': g_2, 'cf2': g_4}
+    cf = {"cf1": g_2, "cf2": g_4}
 
-    target = MetricFrame(metrics=funcs, y_true=y_t, y_pred=y_p,
-                         sensitive_features=sf,
-                         control_features=cf,
-                         sample_params=s_p,
-                         n_boot=10, ci=ci_opt, ci_method=ci_method)
+    target = MetricFrame(
+        metrics=funcs,
+        y_true=y_t,
+        y_pred=y_p,
+        sensitive_features=sf,
+        control_features=cf,
+        sample_params=s_p,
+        n_boot=10,
+        ci=ci_opt,
+        ci_method=ci_method,
+    )
     assert target._user_supplied_callable is False
 
     assert isinstance(target.by_group, pd.DataFrame)
     assert target.by_group.shape == (16, 2)
-    assert np.array_equal(target.by_group.index.names,
-                          ['cf1', 'cf2', 'sensitive_feature_0', 'sensitive_feature_1'])
+    assert np.array_equal(
+        target.by_group.index.names,
+        ["cf1", "cf2", "sensitive_feature_0", "sensitive_feature_1"],
+    )
 
     # Only check some isolated results, rather than all 32
-    mask_a_f = np.logical_and((g_1 == 'aa'), (g_2 == 'f'))
-    mask_b_g = np.logical_and((g_1 == 'ba'), (g_2 == 'g'))
-    mask_k_q = np.logical_and((g_3 == 'kk'), (g_4 == 'q'))
+    mask_a_f = np.logical_and((g_1 == "aa"), (g_2 == "f"))
+    mask_b_g = np.logical_and((g_1 == "ba"), (g_2 == "g"))
+    mask_k_q = np.logical_and((g_3 == "kk"), (g_4 == "q"))
 
     mask_f_q_a_k = np.logical_and(mask_a_f, mask_k_q)
-    recall_f_q_a_k = skm.recall_score(y_t[mask_f_q_a_k], y_p[mask_f_q_a_k],
-                                      sample_weight=s_w[mask_f_q_a_k])
+    recall_f_q_a_k = skm.recall_score(
+        y_t[mask_f_q_a_k], y_p[mask_f_q_a_k], sample_weight=s_w[mask_f_q_a_k]
+    )
     prec_f_q_a_k = skm.precision_score(y_t[mask_f_q_a_k], y_p[mask_f_q_a_k])
-    assert target.by_group['recall'][('f', 'q', 'aa', 'kk')] == recall_f_q_a_k
-    assert target.by_group['prec'][('f', 'q', 'aa', 'kk')] == prec_f_q_a_k
+    assert target.by_group["recall"][("f", "q", "aa", "kk")] == recall_f_q_a_k
+    assert target.by_group["prec"][("f", "q", "aa", "kk")] == prec_f_q_a_k
 
     mask_g_q_b_k = np.logical_and(mask_b_g, mask_k_q)
-    recall_g_q_b_k = skm.recall_score(y_t[mask_g_q_b_k], y_p[mask_g_q_b_k],
-                                      sample_weight=s_w[mask_g_q_b_k])
+    recall_g_q_b_k = skm.recall_score(
+        y_t[mask_g_q_b_k], y_p[mask_g_q_b_k], sample_weight=s_w[mask_g_q_b_k]
+    )
     prec_g_q_b_k = skm.precision_score(y_t[mask_g_q_b_k], y_p[mask_g_q_b_k])
-    assert target.by_group['recall'][('g', 'q', 'ba', 'kk')] == recall_g_q_b_k
-    assert target.by_group['prec'][('g', 'q', 'ba', 'kk')] == prec_g_q_b_k
+    assert target.by_group["recall"][("g", "q", "ba", "kk")] == recall_g_q_b_k
+    assert target.by_group["prec"][("g", "q", "ba", "kk")] == prec_g_q_b_k
 
     check_all_bootstrap_output_shapes(target)
     check_all_bootstrap_directions(target)

--- a/test/unit/metrics/test_metricframe_bootstrap.py
+++ b/test/unit/metrics/test_metricframe_bootstrap.py
@@ -1,0 +1,203 @@
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
+# Licensed under the MIT License.
+
+# These functions are borrowed from "test_metricframe_by_group.py" 
+# with additional checks for bootstrap related operations.
+
+import numpy as np
+import pandas as pd
+import pytest
+import sklearn.metrics as skm
+
+from fairlearn.metrics import MetricFrame
+
+from .data_for_test import y_t, y_p, s_w, g_1, g_2, g_3, g_4
+
+
+metric = [skm.recall_score,
+          skm.precision_score,
+          skm.accuracy_score,
+          skm.balanced_accuracy_score]
+
+ci_options = [0.95, 0.05, [0.2, 0.4, 0.6, 0.8]]
+ci_methods = ['percentile', 'bias-corrected']
+
+# Bootstrap test helper functions
+
+def check_all_bootstrap_output_shapes(mf):
+    # Check if all .*_ci outputs are same shape as regular outputs
+    assert all(mf.overall.shape == ci_output.shape for _, ci_output in mf.overall_ci) 
+    assert all(mf.by_group.shape == ci_output.shape for _, ci_output in mf.by_group_ci)
+    assert all(mf.group_min().shape == ci_output.shape for _, ci_output in mf.group_min_ci)
+    assert all(mf.group_max().shape == ci_output.shape for _, ci_output in mf.group_max_ci)
+    assert all(mf.difference(method='to_overall').shape == ci_output.shape for _, ci_output in mf.difference_overall_ci)
+    assert all(mf.difference(method='between_groups').shape == ci_output.shape for _, ci_output in mf.difference_group_ci)
+    assert all(mf.ratio(method='to_overall').shape == ci_output.shape for _, ci_output in mf.ratio_overall_ci)
+    assert all(mf.ratio(method='between_groups').shape == ci_output.shape for _, ci_output in mf.ratio_group_ci)
+
+def check_all_bootstrap_directions(mf):
+    def check_direction(ci_outputs):
+        # Iterate through all pairs of outputs and check that they are not decreasing
+        return np.all([np.all(f <= s) for f, s in zip(ci_outputs, ci_outputs[1:])])
+
+    assert check_direction(mf.overall_ci)
+    assert check_direction(mf.by_group_ci)
+    assert check_direction(mf.group_min_ci)
+    assert check_direction(mf.group_max_ci)
+    assert check_direction(mf.difference_overall_ci)
+    assert check_direction(mf.difference_group_ci)
+    assert check_direction(mf.ratio_overall_ci)
+    assert check_direction(mf.ratio_group_ci)
+
+@pytest.mark.parametrize("metric_fn", metric)
+@pytest.mark.parametrize("ci_opt", ci_options)
+@pytest.mark.parametrize("ci_method", ci_methods)
+def test_1m_1sf_0cf(metric_fn, ci_opt, ci_method):
+    target = MetricFrame(metrics=metric_fn, y_true=y_t, y_pred=y_p,
+                         sensitive_features=g_1, 
+                         n_boot=10, ci=ci_opt, ci_method=ci_method)
+    assert target._user_supplied_callable is True
+
+    assert isinstance(target.by_group, pd.Series)
+    assert len(target.by_group) == 2
+    assert np.array_equal(target.by_group.index.names, ['sensitive_feature_0'])
+    mask_a = (g_1 == 'aa')
+    mask_b = (g_1 == 'ba')
+    metric_a = metric_fn(y_t[mask_a], y_p[mask_a])
+    metric_b = metric_fn(y_t[mask_b], y_p[mask_b])
+    assert target.by_group['aa'] == metric_a
+    assert target.by_group['ba'] == metric_b
+
+    check_all_bootstrap_output_shapes(target)
+    check_all_bootstrap_directions(target)
+
+
+@pytest.mark.parametrize("metric_fn", metric)
+@pytest.mark.parametrize("ci_opt", ci_options)
+@pytest.mark.parametrize("ci_method", ci_methods)
+def test_1m_1sf_0cf_metric_dict(metric_fn, ci_opt, ci_method):
+    target = MetricFrame(metrics={metric_fn.__name__: metric_fn}, y_true=y_t, y_pred=y_p,
+                         sensitive_features=g_1, 
+                         n_boot=10, ci=ci_opt, ci_method=ci_method)
+    assert target._user_supplied_callable is False
+
+    assert isinstance(target.by_group, pd.DataFrame)
+    assert target.by_group.shape == (2, 1)
+    assert np.array_equal(target.by_group.index.names, ['sensitive_feature_0'])
+    mask_a = (g_1 == 'aa')
+    mask_b = (g_1 == 'ba')
+    metric_a = metric_fn(y_t[mask_a], y_p[mask_a])
+    metric_b = metric_fn(y_t[mask_b], y_p[mask_b])
+    assert target.by_group[metric_fn.__name__]['aa'] == metric_a
+    assert target.by_group[metric_fn.__name__]['ba'] == metric_b
+
+    check_all_bootstrap_output_shapes(target)
+    check_all_bootstrap_directions(target)
+
+
+@pytest.mark.parametrize("metric_fn", metric)
+@pytest.mark.parametrize("ci_opt", ci_options)
+@pytest.mark.parametrize("ci_method", ci_methods)
+def test_1m_1sf_1cf(metric_fn, ci_opt, ci_method):
+    target = MetricFrame(metrics=metric_fn, y_true=y_t, y_pred=y_p,
+                         sensitive_features=g_1,
+                         control_features=g_2, 
+                         n_boot=10, ci=ci_opt, ci_method=ci_method)
+    assert target._user_supplied_callable is True
+
+    assert isinstance(target.by_group, pd.Series)
+    assert len(target.by_group) == 4
+    assert np.array_equal(target.by_group.index.names,
+                          ['control_feature_0', 'sensitive_feature_0'])
+
+    mask_a_f = np.logical_and((g_1 == 'aa'), (g_2 == 'f'))
+    mask_a_g = np.logical_and((g_1 == 'aa'), (g_2 == 'g'))
+    mask_b_f = np.logical_and((g_1 == 'ba'), (g_2 == 'f'))
+    mask_b_g = np.logical_and((g_1 == 'ba'), (g_2 == 'g'))
+
+    exp_a_f = metric_fn(y_t[mask_a_f], y_p[mask_a_f])
+    exp_a_g = metric_fn(y_t[mask_a_g], y_p[mask_a_g])
+    exp_b_f = metric_fn(y_t[mask_b_f], y_p[mask_b_f])
+    exp_b_g = metric_fn(y_t[mask_b_g], y_p[mask_b_g])
+    assert target.by_group[('f', 'aa')] == exp_a_f
+    assert target.by_group[('f', 'ba')] == exp_b_f
+    assert target.by_group[('g', 'aa')] == exp_a_g
+    assert target.by_group[('g', 'ba')] == exp_b_g
+
+    check_all_bootstrap_output_shapes(target)
+    check_all_bootstrap_directions(target)
+
+
+@pytest.mark.parametrize("metric_fn", metric)
+@pytest.mark.parametrize("ci_opt", ci_options)
+@pytest.mark.parametrize("ci_method", ci_methods)
+def test_1m_1sf_1cf_metric_dict(metric_fn, ci_opt, ci_method):
+    target = MetricFrame(metrics={metric_fn.__name__: metric_fn}, y_true=y_t, y_pred=y_p,
+                         sensitive_features=g_1,
+                         control_features=g_2,
+                         n_boot=10, ci=ci_opt, ci_method=ci_method)
+    assert target._user_supplied_callable is False
+
+    assert isinstance(target.by_group, pd.DataFrame)
+    assert target.by_group.shape == (4, 1)
+    assert np.array_equal(target.by_group.index.names,
+                          ['control_feature_0', 'sensitive_feature_0'])
+
+    mask_a_f = np.logical_and((g_1 == 'aa'), (g_2 == 'f'))
+    mask_a_g = np.logical_and((g_1 == 'aa'), (g_2 == 'g'))
+    mask_b_f = np.logical_and((g_1 == 'ba'), (g_2 == 'f'))
+    mask_b_g = np.logical_and((g_1 == 'ba'), (g_2 == 'g'))
+
+    exp_a_f = metric_fn(y_t[mask_a_f], y_p[mask_a_f])
+    exp_a_g = metric_fn(y_t[mask_a_g], y_p[mask_a_g])
+    exp_b_f = metric_fn(y_t[mask_b_f], y_p[mask_b_f])
+    exp_b_g = metric_fn(y_t[mask_b_g], y_p[mask_b_g])
+    assert target.by_group[metric_fn.__name__][('f', 'aa')] == exp_a_f
+    assert target.by_group[metric_fn.__name__][('f', 'ba')] == exp_b_f
+    assert target.by_group[metric_fn.__name__][('g', 'aa')] == exp_a_g
+    assert target.by_group[metric_fn.__name__][('g', 'ba')] == exp_b_g
+
+    check_all_bootstrap_output_shapes(target)
+    check_all_bootstrap_directions(target)
+
+@pytest.mark.parametrize("ci_opt", ci_options)
+@pytest.mark.parametrize("ci_method", ci_methods)
+def test_2m_2sf_2cf(ci_opt, ci_method):
+    funcs = {'recall': skm.recall_score, 'prec': skm.precision_score}
+    s_p = {'recall': {'sample_weight': s_w}}
+    sf = np.stack([g_1, g_3], axis=1)
+    cf = {'cf1': g_2, 'cf2': g_4}
+
+    target = MetricFrame(metrics=funcs, y_true=y_t, y_pred=y_p,
+                         sensitive_features=sf,
+                         control_features=cf,
+                         sample_params=s_p,
+                         n_boot=10, ci=ci_opt, ci_method=ci_method)
+    assert target._user_supplied_callable is False
+
+    assert isinstance(target.by_group, pd.DataFrame)
+    assert target.by_group.shape == (16, 2)
+    assert np.array_equal(target.by_group.index.names,
+                          ['cf1', 'cf2', 'sensitive_feature_0', 'sensitive_feature_1'])
+
+    # Only check some isolated results, rather than all 32
+    mask_a_f = np.logical_and((g_1 == 'aa'), (g_2 == 'f'))
+    mask_b_g = np.logical_and((g_1 == 'ba'), (g_2 == 'g'))
+    mask_k_q = np.logical_and((g_3 == 'kk'), (g_4 == 'q'))
+
+    mask_f_q_a_k = np.logical_and(mask_a_f, mask_k_q)
+    recall_f_q_a_k = skm.recall_score(y_t[mask_f_q_a_k], y_p[mask_f_q_a_k],
+                                      sample_weight=s_w[mask_f_q_a_k])
+    prec_f_q_a_k = skm.precision_score(y_t[mask_f_q_a_k], y_p[mask_f_q_a_k])
+    assert target.by_group['recall'][('f', 'q', 'aa', 'kk')] == recall_f_q_a_k
+    assert target.by_group['prec'][('f', 'q', 'aa', 'kk')] == prec_f_q_a_k
+
+    mask_g_q_b_k = np.logical_and(mask_b_g, mask_k_q)
+    recall_g_q_b_k = skm.recall_score(y_t[mask_g_q_b_k], y_p[mask_g_q_b_k],
+                                      sample_weight=s_w[mask_g_q_b_k])
+    prec_g_q_b_k = skm.precision_score(y_t[mask_g_q_b_k], y_p[mask_g_q_b_k])
+    assert target.by_group['recall'][('g', 'q', 'ba', 'kk')] == recall_g_q_b_k
+    assert target.by_group['prec'][('g', 'q', 'ba', 'kk')] == prec_g_q_b_k
+
+    check_all_bootstrap_output_shapes(target)
+    check_all_bootstrap_directions(target)

--- a/test/unit/metrics/test_metricframe_bootstrap.py
+++ b/test/unit/metrics/test_metricframe_bootstrap.py
@@ -33,12 +33,12 @@ def check_all_bootstrap_output_shapes(mf):
         assert mf.overall.shape == ci_output.shape
     for ci_output in mf.by_group_ci:
         assert mf.by_group.shape == ci_output.shape
-    assert all(
-        mf.group_min().shape == ci_output.shape for _, ci_output in mf.group_min_ci
-    )
-    assert all(
-        mf.group_max().shape == ci_output.shape for _, ci_output in mf.group_max_ci
-    )
+
+    for ci_output in mf.group_min_ci:
+        assert mf.group_min().shape == ci_output.shape
+    for ci_output in mf.group_max_ci:
+        assert mf.group_max().shape == ci_output.shape
+
     assert all(
         mf.difference(method="to_overall").shape == ci_output.shape
         for _, ci_output in mf.difference_overall_ci

--- a/test/unit/metrics/test_metricframe_bootstrap.py
+++ b/test/unit/metrics/test_metricframe_bootstrap.py
@@ -39,14 +39,10 @@ def check_all_bootstrap_output_shapes(mf):
     for ci_output in mf.group_max_ci:
         assert mf.group_max().shape == ci_output.shape
 
-    assert all(
-        mf.difference(method="to_overall").shape == ci_output.shape
-        for _, ci_output in mf.difference_overall_ci
-    )
-    assert all(
-        mf.difference(method="between_groups").shape == ci_output.shape
-        for _, ci_output in mf.difference_group_ci
-    )
+    for method in ['to_overall', 'between_groups']:
+        for ci_output in mf.difference_ci(method=method):
+            assert mf.difference(method=method).shape == ci_output.shape
+
     assert all(
         mf.ratio(method="to_overall").shape == ci_output.shape
         for _, ci_output in mf.ratio_overall_ci
@@ -66,8 +62,8 @@ def check_all_bootstrap_directions(mf):
     assert check_direction(mf.by_group_ci)
     assert check_direction(mf.group_min_ci)
     assert check_direction(mf.group_max_ci)
-    assert check_direction(mf.difference_overall_ci)
-    assert check_direction(mf.difference_group_ci)
+    assert check_direction(mf.difference_ci(method="to_overall"))
+    assert check_direction(mf.difference_ci(method="between_groups"))
     assert check_direction(mf.ratio_overall_ci)
     assert check_direction(mf.ratio_group_ci)
 

--- a/test/unit/metrics/test_metricframe_bootstrap_values.py
+++ b/test/unit/metrics/test_metricframe_bootstrap_values.py
@@ -107,6 +107,16 @@ class TestBootstrapValues:
         assert mf.by_group["A"] == p_A
         assert mf.by_group["B"] == p_B
 
+    def test_quantiles_(self, mf):
+        expected_quantiles = (
+            0.025,
+            0.1587,
+            0.5,
+            0.8413,
+            0.975,
+        )
+        assert mf.quantiles_ == expected_quantiles
+
     def test_overall_ci(self, mf):
         mean = p * n_samples
         sigma = math.sqrt(n_samples * p * (1 - p))

--- a/test/unit/metrics/test_metricframe_bootstrap_values.py
+++ b/test/unit/metrics/test_metricframe_bootstrap_values.py
@@ -128,7 +128,7 @@ class TestBootstrapValues:
             value = mean + (sigma_vals[i] * sigma)
             value_frac = value / n_samples
 
-            assert mf.overall_ci[i][1] == pytest.approx(
+            assert mf.overall_ci[i] == pytest.approx(
                 value_frac, rel=1 / math.sqrt(n_samples)
             )
 

--- a/test/unit/metrics/test_metricframe_bootstrap_values.py
+++ b/test/unit/metrics/test_metricframe_bootstrap_values.py
@@ -150,12 +150,8 @@ class TestBootstrapValues:
             vf_B = v_B / n_B
 
             # Slightly wider tolerance here.... not sure if this should be required
-            assert mf.by_group_ci[i]["A"] == pytest.approx(
-                vf_A, rel=2 / math.sqrt(n_A)
-            )
-            assert mf.by_group_ci[i]["B"] == pytest.approx(
-                vf_B, rel=2 / math.sqrt(n_B)
-            )
+            assert mf.by_group_ci[i]["A"] == pytest.approx(vf_A, rel=2 / math.sqrt(n_A))
+            assert mf.by_group_ci[i]["B"] == pytest.approx(vf_B, rel=2 / math.sqrt(n_B))
 
     def test_difference_between_groups(self, mf):
         # When adding or subtracting, absolute errors

--- a/test/unit/metrics/test_metricframe_bootstrap_values.py
+++ b/test/unit/metrics/test_metricframe_bootstrap_values.py
@@ -159,8 +159,9 @@ class TestBootstrapValues:
         # Only check the one sigma values here
 
         # Start by checking the nominal value
+        bootstrap_result = mf.difference_ci(method="between_groups")
         assert mf.difference(method="between_groups") == pytest.approx(
-            mf.difference_group_ci[2][1], rel=1 / math.sqrt(n_samples)
+            bootstrap_result[2], rel=1 / math.sqrt(n_samples)
         )
 
         # Do the error calculation
@@ -179,8 +180,8 @@ class TestBootstrapValues:
 
         # Check the one sigma values in the output
         assert nominal_acc_AB - acc_sigma_AB == pytest.approx(
-            mf.difference_group_ci[1][1], rel=1 / math.sqrt(n_samples)
+            bootstrap_result[1], rel=1 / math.sqrt(n_samples)
         )
         assert nominal_acc_AB + acc_sigma_AB == pytest.approx(
-            mf.difference_group_ci[3][1], rel=1 / math.sqrt(n_samples)
+            bootstrap_result[3], rel=1 / math.sqrt(n_samples)
         )

--- a/test/unit/metrics/test_metricframe_bootstrap_values.py
+++ b/test/unit/metrics/test_metricframe_bootstrap_values.py
@@ -1,0 +1,180 @@
+# Copyright (c) Microsoft Corporation and Fairlearn contributors.
+# Licensed under the MIT License.
+
+# This collection of tests is to verify the values computed by
+# the bootstrap functionality of MetricFrame. It is based
+# on the fact that if the metric is accuracy for a binary
+# classification problem, then we can use the binomial
+# distribution and approximate it with a gaussian.
+
+import math
+
+import numpy as np
+import pytest
+
+from sklearn.metrics import accuracy_score
+
+from fairlearn.metrics import MetricFrame
+
+# The setup is slightly unorthodx, to allow for splitting of
+# individual tests
+
+# Overall number of samples
+n_samples = 1000
+# Overall fraction correct
+p = 0.5
+# Fraction of group 'A' as proportion of whole
+f_A = 0.6
+# Fraction of group 'A' which are correct
+p_A = 0.8
+
+# Everything after this point is calculated from the above
+
+# Fraction of group 'B' as proportion of whole
+f_B = 1 - f_A
+
+# Calculate numbers of each
+n_A = int(f_A * n_samples)
+n_B = int((1 - f_A) * n_samples)
+
+# Absolute number of group 'A' which are correct
+n_A_correct = int(p_A * n_A)
+
+# And for group 'B'
+n_B_correct = int(n_samples * p) - n_A_correct
+p_B = n_B_correct / n_B
+
+# Absolute numbers which are incorrect
+n_A_incorrect = n_A - n_A_correct
+n_B_incorrect = n_B - n_B_correct
+
+
+@pytest.fixture(scope="session")
+def mf():
+    y_true = np.ones(n_samples)
+    y_pred = np.concatenate(
+        (np.ones(int(n_samples * p)), np.zeros(int(n_samples * (1 - p))))
+    )
+    # Check for rounding errors
+    assert len(y_pred) == n_samples
+    assert n_A + n_B == n_samples
+
+    # Make sure the overall metric is as expected
+    assert accuracy_score(y_true, y_pred) == p
+
+    # Sanity check
+    assert n_A_correct < n_samples * p
+
+    s_f = np.concatenate(
+        (
+            np.full(n_A_correct, "A"),
+            np.full(n_B_correct, "B"),
+            np.full(n_A_incorrect, "A"),
+            np.full(n_B_incorrect, "B"),
+        )
+    )
+
+    # Make sure we have avoided rounding errors
+    assert len(s_f) == n_samples
+
+    # Create the metric frame
+    # The ci argument is set to have the
+    # nominal value, as well as the one and two
+    # sigma values
+    mf = MetricFrame(
+        metrics=accuracy_score,
+        y_true=y_true,
+        y_pred=y_pred,
+        sensitive_features=s_f,
+        n_boot=10000,
+        ci=(
+            0.025,
+            0.1587,
+            0.5,
+            0.8413,
+            0.975,
+        ),  # -2sigma, -sigma, nominal, sigma, 2sigma
+    )
+
+    return mf
+
+
+class TestBootstrapValues:
+    def test_overall(self, mf):
+        assert mf.overall == p
+
+    def test_by_group(self, mf):
+        assert mf.by_group["A"] == p_A
+        assert mf.by_group["B"] == p_B
+
+    def test_overall_ci(self, mf):
+        mean = p * n_samples
+        sigma = math.sqrt(n_samples * p * (1 - p))
+
+        # Following corresponds to the ci argument to MetricFrame
+        sigma_vals = [-2, -1, 0, 1, 2]
+
+        for i in range(len(sigma_vals)):
+            value = mean + (sigma_vals[i] * sigma)
+            value_frac = value / n_samples
+
+            assert mf.overall_ci[i][1] == pytest.approx(
+                value_frac, rel=1 / math.sqrt(n_samples)
+            )
+
+    def test_by_group_ci(self, mf):
+        mean_A = p_A * n_A
+        sigma_A = math.sqrt(n_A * p_A * (1 - p_A))
+
+        mean_B = p_B * n_B
+        sigma_B = math.sqrt(n_B * p_B * (1 - p_B))
+
+        # Following corresponds to the ci argument to MetricFrame
+        sigma_vals = [-2, -1, 0, 1, 2]
+
+        for i in range(len(sigma_vals)):
+            v_A = mean_A + (sigma_vals[i] * sigma_A)
+            vf_A = v_A / n_A
+
+            v_B = mean_B + (sigma_vals[i] * sigma_B)
+            vf_B = v_B / n_B
+
+            # Slightly wider tolerance here.... not sure if this should be required
+            assert mf.by_group_ci[i][1]["A"] == pytest.approx(
+                vf_A, rel=2 / math.sqrt(n_A)
+            )
+            assert mf.by_group_ci[i][1]["B"] == pytest.approx(
+                vf_B, rel=2 / math.sqrt(n_B)
+            )
+
+    def test_difference_between_groups(self, mf):
+        # When adding or subtracting, absolute errors
+        # add in quadrature
+        # Only check the one sigma values here
+
+        # Start by checking the nominal value
+        assert mf.difference(method="between_groups") == pytest.approx(
+            mf.difference_group_ci[2][1], rel=1 / math.sqrt(n_samples)
+        )
+
+        # Do the error calculation
+        nominal_acc_AB = abs(p_A - p_B)
+
+        sigma_A = math.sqrt(n_A * p_A * (1 - p_A))
+        sigma_B = math.sqrt(n_B * p_B * (1 - p_B))
+        acc_sigma_A = sigma_A / n_A
+        acc_sigma_B = sigma_B / n_B
+
+        # The actual quadrature
+        acc_sigma_AB = math.sqrt(acc_sigma_A**2 + acc_sigma_B**2)
+
+        # Sanity check
+        assert nominal_acc_AB == pytest.approx(mf.difference(method="between_groups"))
+
+        # Check the one sigma values in the output
+        assert nominal_acc_AB - acc_sigma_AB == pytest.approx(
+            mf.difference_group_ci[1][1], rel=1 / math.sqrt(n_samples)
+        )
+        assert nominal_acc_AB + acc_sigma_AB == pytest.approx(
+            mf.difference_group_ci[3][1], rel=1 / math.sqrt(n_samples)
+        )

--- a/test/unit/metrics/test_metricframe_bootstrap_values.py
+++ b/test/unit/metrics/test_metricframe_bootstrap_values.py
@@ -150,10 +150,10 @@ class TestBootstrapValues:
             vf_B = v_B / n_B
 
             # Slightly wider tolerance here.... not sure if this should be required
-            assert mf.by_group_ci[i][1]["A"] == pytest.approx(
+            assert mf.by_group_ci[i]["A"] == pytest.approx(
                 vf_A, rel=2 / math.sqrt(n_A)
             )
-            assert mf.by_group_ci[i][1]["B"] == pytest.approx(
+            assert mf.by_group_ci[i]["B"] == pytest.approx(
                 vf_B, rel=2 / math.sqrt(n_B)
             )
 

--- a/test/unit/metrics/test_metricframe_missing.py
+++ b/test/unit/metrics/test_metricframe_missing.py
@@ -24,7 +24,6 @@ g_B = np.asarray([group_gen(x, 1 + int(n / 3), ["x", "y", "z"]) for x in range(n
 
 @pytest.mark.parametrize("metric_fn", metric)
 def test_missing_sensitive_feature_combinations(metric_fn):
-
     target = metrics.MetricFrame(
         metrics=metric_fn,
         y_true=y_t,

--- a/test/unit/metrics/test_metricframe_smoke.py
+++ b/test/unit/metrics/test_metricframe_smoke.py
@@ -30,6 +30,7 @@ def test_basic(transform_y_t, transform_y_p):
     assert target.control_levels is None
     assert isinstance(target.sensitive_levels, list)
     assert target.sensitive_levels == ["My feature"]
+    assert target.quantiles_ is None
 
     # Check we have correct return types
     assert isinstance(target.overall, float)
@@ -74,6 +75,7 @@ def test_basic_metric_dict(transform_y_t, transform_y_p):
     assert target.control_levels is None
     assert isinstance(target.sensitive_levels, list)
     assert target.sensitive_levels == ["My feature"]
+    assert target.quantiles_ is None
 
     # Check we have correct return types
     assert isinstance(target.overall, pd.Series)
@@ -122,6 +124,7 @@ def test_1m_1sf_1cf(transform_y_t, transform_y_p):
     assert target.control_levels == ["control_feature_0"]
     assert isinstance(target.sensitive_levels, list)
     assert target.sensitive_levels == ["sensitive_feature_0"]
+    assert target.quantiles_ is None
 
     # Check we have correct return types
     assert isinstance(target.overall, pd.Series)
@@ -187,6 +190,7 @@ def test_1m_1sf_1cf_metric_dict(transform_y_t, transform_y_p):
     assert target.control_levels == ["control_feature_0"]
     assert isinstance(target.sensitive_levels, list)
     assert target.sensitive_levels == ["sensitive_feature_0"]
+    assert target.quantiles_ is None
 
     # Check we have correct return types
     assert isinstance(target.overall, pd.DataFrame)


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description

This is an update of #1038 to sort out some git confusion. It will address #999 . The following description is taken from the original PR:

- Use of [bootstrap](https://en.wikipedia.org/wiki/Bootstrapping_(statistics)) to estimate the empirical distribution of any scalar metric passed to MetricFrame. Bootstrap settings are controlled by two new init parameters: `n_boot`, which determines how many replications of the dataset to generate with replacement, and `n_jobs`, which controls how many parallel processes to use in the bootstrap operation.

- Confidence interval estimation as a summary of the empirical bootstrap distribution. This is controlled by the `ci` and `ci_method` parameters, which offer options of which quantiles to sample and whether or not estimates should be bias-corrected. Many users can use simple parameter settings like `ci=0.95` for a 95% confidence interval on each MetricFrame statistic, while advanced users can query specific quantiles (e.g. `ci=[0.25, 0.5, 0.75]`) for further study. These results are calculated during initialization and are stored in new attributes on MetricFrame suffixed in `.*_ci`. 

Some significant changes have been made to MetricFrame internals in order to support this set of operations. Firstly, because we build the bootstrap distribution during initialization and chose not to pin it on the object, some operations like `.difference` are calculated during init. Secondly, because bootstrapping involves calculating the same operation on different (resampled) inputs, I've changed some internal functions like `def __group()` to work on any set of inputs, and not be hard-coded to use pinned attributes like `self.overall` and `self.by_group`. I've also refactored some general code into new private functions to make repeated calls easier. These should have no breaking changes to an end user. 

The new `.*_ci` attributes are all lists of tuples, with each tuple representing the quantile of the distribution in the first element, and the corresponding values for each metric in the second. For example, if a user requests a 90% confidence interval with `ci=0.9`, the output of `.overall_ci` will look like:

```python
.overall_ci = [
   (0.05, pd.DataFrame({...})),
   (0.95, pd.DataFrame({...}))
]
```

where each of the inner frames exactly parallel the structure of `.overall`. This API design hopefully makes it easy for users to adopt confidence intervals into their workflow -- any code that runs on the "main" MetricFrame objects will also work on the .ci versions.



## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [x] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [ ] user guide added or updated
- [x] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
