### PR TITLE
FIX Zero Divide fix for MetricFrame

### DIFF
--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -705,6 +705,7 @@ class MetricFrame:
         typing.Any or pandas.Series or pandas.DataFrame
             The exact type follows the table in :attr:`.MetricFrame.overall`.
         """
+
         def ratio_sub_one(x):
             if x > 1:
                 return 1 / x
@@ -752,7 +753,8 @@ class MetricFrame:
     def _process_functions(
         self, metric, sample_params, all_data: pd.DataFrame
     ) -> Dict[str, AnnotatedMetricFunction]:
-        """Get the underlying metrics into :class:`fairlearn.metrics.AnnotatedMetricFunction` objects."""  # noqa: E501
+        """Get the underlying metrics into :class:`fairlearn.metrics.AnnotatedMetricFunction` objects.
+        """  # noqa: E501
         self._user_supplied_callable = True
         func_dict = dict()
 

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -705,6 +705,12 @@ class MetricFrame:
         typing.Any or pandas.Series or pandas.DataFrame
             The exact type follows the table in :attr:`.MetricFrame.overall`.
         """
+        def ratio_sub_one(x):
+            if x > 1:
+                return 1 / x
+            else:
+                return x
+
         if errors not in _VALID_ERROR_STRING:
             raise ValueError(_INVALID_ERRORS_VALUE_ERROR_MESSAGE)
 
@@ -716,12 +722,12 @@ class MetricFrame:
                 tmp = self.by_group / self.overall
                 if self.control_levels:
                     result = (
-                        tmp.transform(lambda x: min(x, 1 / x))
+                        tmp.transform(ratio_sub_one)
                         .groupby(level=self.control_levels)
                         .min()
                     )
                 else:
-                    result = tmp.transform(lambda x: min(x, 1 / x)).min()
+                    result = tmp.transform(ratio_sub_one).min()
             else:
                 ratios = None
 
@@ -732,12 +738,6 @@ class MetricFrame:
                     ) / self.overall.unstack(level=self.control_levels)
                 else:
                     ratios = self.by_group / self.overall
-
-                def ratio_sub_one(x):
-                    if x > 1:
-                        return 1 / x
-                    else:
-                        return x
 
                 ratios = ratios.apply(lambda x: x.transform(ratio_sub_one))
                 if not self.control_levels:

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -753,8 +753,7 @@ class MetricFrame:
     def _process_functions(
         self, metric, sample_params, all_data: pd.DataFrame
     ) -> Dict[str, AnnotatedMetricFunction]:
-        """Get the underlying metrics into :class:`fairlearn.metrics.AnnotatedMetricFunction` objects.
-        """  # noqa: E501
+        """Get the underlying metrics into :class:`fairlearn.metrics.AnnotatedMetricFunction`."""
         self._user_supplied_callable = True
         func_dict = dict()
 

--- a/test/unit/metrics/test_metricframe_aggregates.py
+++ b/test/unit/metrics/test_metricframe_aggregates.py
@@ -125,6 +125,17 @@ class Test1m1sf0cf:
             expected_ratio_overall, rel=1e-10, abs=1e-16
         )
 
+    def test_ratio_zero_divide(self):
+        # Simple test to check on zero division
+        my_prec = functools.partial(skm.precision_score, zero_division=0)
+        my_prec.__name__ = "precision_score_zero_div"
+
+        mf = metrics.MetricFrame(
+            metrics=my_prec, y_true=[1, 0], y_pred=[1, 0], sensitive_features=["a", "b"]
+        )
+
+        assert mf.ratio(method="to_overall") == 0
+
 
 class Test1m1sf0cfFnDict:
     # Key difference is that the function is supplied as a dict


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

Work related to #999 uncovered a zero-divide bug when `MetricFrame` was computing ratios. Annoyingly, the required fix was present in half the routine, but not the other.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [x] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
