### PR TITLE
[BugFix] Small metric fixes

### DIFF
--- a/docs/user_guide/assessment.rst
+++ b/docs/user_guide/assessment.rst
@@ -143,6 +143,9 @@ We can use :class:`MetricFrame` to evaluate these metrics on our data:
 .. doctest:: assessment_metrics
     :options:  +NORMALIZE_WHITESPACE
 
+    >>> import pandas as pd
+    >>> pd.set_option('display.max_columns', 20)
+    >>> pd.set_option('display.width', 80)
     >>> from fairlearn.metrics import MetricFrame
     >>> from fairlearn.metrics import count, \
     ...                               false_positive_rate, \

--- a/fairlearn/metrics/_annotated_metric_function.py
+++ b/fairlearn/metrics/_annotated_metric_function.py
@@ -48,7 +48,7 @@ class AnnotatedMetricFunction:
         *,
         func: Callable,
         name: Optional[str],
-        postional_argument_names: List[str] = None,
+        positional_argument_names: List[str] = None,
         kw_argument_mapping: Dict[str, str] = None,
     ):
         if func is None:
@@ -68,8 +68,8 @@ class AnnotatedMetricFunction:
 
         self.func = func
         self.postional_argument_names = ["y_true", "y_pred"]
-        if postional_argument_names is not None:
-            self.postional_argument_names = postional_argument_names
+        if positional_argument_names is not None:
+            self.postional_argument_names = positional_argument_names
         self.kw_argument_mapping = dict()
         if kw_argument_mapping is not None:
             self.kw_argument_mapping = kw_argument_mapping

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -751,7 +751,7 @@ class MetricFrame:
         return result
 
     def _process_functions(
-        self, metric, sample_params, all_data: pd.DataFrame
+        self, metric: Union[Callable, Dict[str, Callable]], sample_params, all_data: pd.DataFrame
     ) -> Dict[str, AnnotatedMetricFunction]:
         """Get the underlying metrics into :class:`fairlearn.metrics.AnnotatedMetricFunction`."""
         self._user_supplied_callable = True
@@ -791,8 +791,8 @@ class MetricFrame:
     def _process_one_function(
         self,
         func: Callable,
-        name: str,
-        sample_parameters: Dict[str, Any],
+        name: Optional[str],
+        sample_parameters: Optional[Dict[str, Any]],
         all_data: pd.DataFrame,
     ) -> AnnotatedMetricFunction:
         # Deal with the sample parameters

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -756,8 +756,7 @@ class MetricFrame:
         sample_params,
         all_data: pd.DataFrame,
     ) -> Dict[str, AnnotatedMetricFunction]:
-        """Get the underlying metrics into :class:`fairlearn.metrics.AnnotatedMetricFunction`.
-        """
+        """Get the metrics into :class:`fairlearn.metrics.AnnotatedMetricFunction`."""
         self._user_supplied_callable = True
         func_dict = dict()
 

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -751,9 +751,13 @@ class MetricFrame:
         return result
 
     def _process_functions(
-        self, metric: Union[Callable, Dict[str, Callable]], sample_params, all_data: pd.DataFrame
+        self,
+        metric: Union[Callable, Dict[str, Callable]],
+        sample_params,
+        all_data: pd.DataFrame,
     ) -> Dict[str, AnnotatedMetricFunction]:
-        """Get the underlying metrics into :class:`fairlearn.metrics.AnnotatedMetricFunction`."""
+        """Get the underlying metrics into :class:`fairlearn.metrics.AnnotatedMetricFunction`.
+        """
         self._user_supplied_callable = True
         func_dict = dict()
 

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -816,7 +816,7 @@ class MetricFrame:
         amf = AnnotatedMetricFunction(
             func=func,
             name=name,
-            postional_argument_names=["y_true", "y_pred"],
+            positional_argument_names=["y_true", "y_pred"],
             kw_argument_mapping=kwarg_dict,
         )
 

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -438,7 +438,7 @@ class MetricFrame:
             return self._by_group
 
     @property
-    def control_levels(self) -> List[str]:
+    def control_levels(self) -> Optional[List[str]]:
         """Return a list of feature names which are produced by control features.
 
         If control features are present, then the rows of the :attr:`.by_group`


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description

The `AnnotatedMetricFunction` constructor argument `positional_argument_names` was misspelled. Since this is not used directly by users, there are no documentation or test changes.

However, while fixing this issue, discovered that the doc build was failing due to pandas 'print' output changing. So fix that as well in `assessment.rst`.

At this point I decided to install `mypy` as well, and fix some of the warnings generated for `MetricFrame`.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
