### PR TITLE
Tweaks to Assessment Documentation

### DIFF
--- a/docs/user_guide/assessment/advanced_metricframe.rst
+++ b/docs/user_guide/assessment/advanced_metricframe.rst
@@ -7,7 +7,7 @@ Advanced Usage of MetricFrame
 
 In this section, we will discuss how :class:`MetricFrame` can
 be used in more sophisticated scenarios.
-All of these will use the following definitions:
+All of code examples will use the following definitions:
 
 
 .. doctest:: advanced_metricframe_code
@@ -129,6 +129,44 @@ Note that there is no concept of a 'global' sample parameter (e.g. a set
 of sample weights to be applied for all metric functions).
 In such a case, the sample parameter in question must be repeated in
 the nested dictionary for each metric function.
+
+
+No `y_true` or `y_pred`
+^^^^^^^^^^^^^^^^^^^^^^^
+
+In some cases, a metric may not have `y_true` or `y_pred` arguments, or even
+either of them.
+One example of this is the selection rate metric, which only considers
+the `y_pred` values (selection rate is used when computing
+:ref:`demographic parity <assessment_demographic_parity>`).
+However, :class:`MetricFrame` requires all supplied metric functions to
+conform to the SciKit-Learn metric paradigm, where the first two arguments
+to the metric function are the `y_true` and `y_pred` arrays.
+The workaround in this case is to supply a dummy argument.
+This is the approach we use in :meth:`selection_rate`, which simply ignores
+the supplied `y_true` argument.
+When invoking `MetricFrame`, a `y_true` array of the appropriate length
+must still be supplied.
+For example:
+
+.. doctest:: advanced_metricframe_code
+    :options:  +NORMALIZE_WHITESPACE
+
+    >>> from fairlearn.metrics import selection_rate
+    >>> dummy_y_true = [x for x in range(len(y_pred))]
+    >>> sel_rate_frame = MetricFrame(metrics=selection_rate,
+    ...                              y_true=dummy_y_true,
+    ...                              y_pred=y_pred,
+    ...                              sensitive_features=pd.Series(sf_data, name='SF 0'))
+    >>> sel_rate_frame.overall
+    0.55555...
+    >>> sel_rate_frame.by_group
+    SF 0
+    a    0.75
+    b    0.50
+    c    0.50
+    Name: selection_rate, dtype: float64
+
 
 .. _more_complex_metrics:
 

--- a/docs/user_guide/assessment/common_fairness_metrics.rst
+++ b/docs/user_guide/assessment/common_fairness_metrics.rst
@@ -53,7 +53,8 @@ Note that in the Fairlearn API, :func:`fairlearn.metrics.demographic_parity_diff
 is only defined for classification. 
 
 .. note::
-   Demographic parity is also sometimes referred to as *independence*, *group fairness*, *statistical parity*, and *disparate impact*.
+   Demographic parity is also sometimes referred to as *independence*,
+   *group fairness*, *statistical parity*, and *disparate impact*.
 
 Failing to achieve demographic parity could generate allocation harms. 
 Allocation harms occur when AI systems allocate 
@@ -149,14 +150,16 @@ help with this.
 However, more granular categories generally contain smaller sample sizes, and 
 it can be more difficult to establish that trends seen in very small 
 samples are not due to random chance. 
-We also recommend watching out for the `multiple comparisons problem <https://stats.libretexts.org/Bookshelves/Applied_Statistics/Book%3A_Biological_Statistics_(McDonald)/06%3A_Multiple_Tests/6.01%3A_Multiple_Comparisons>`_, 
+We also recommend watching out for the
+`multiple comparisons problem <https://stats.libretexts.org/Bookshelves/Applied_Statistics/Book%3A_Biological_Statistics_(McDonald)/06%3A_Multiple_Tests/6.01%3A_Multiple_Comparisons>`_, 
 which states that the more statistical inferences are made, the 
 more erroneous those inferences will become. For example, in the case 
 of evaluating fairness metrics on multiple groups, as we break the 
 groups down into more granular categories and evaluate those smaller 
 groups, it will become more likely that these subgroups will 
 differ enough to fail one of the metrics. For dealing with the multiple 
-comparisons problem, we recommend investigating `statistical techniques <https://www.statology.org/bonferroni-correction/>`_ 
+comparisons problem, we recommend investigating
+`statistical techniques <https://www.statology.org/bonferroni-correction/>`_ 
 meant to correct the errors produced by individual statistical tests. 
 
 Fairlearn provides the :func:`demographic_parity_difference` and

--- a/docs/user_guide/assessment/intersecting_groups.rst
+++ b/docs/user_guide/assessment/intersecting_groups.rst
@@ -12,6 +12,8 @@ One important point to bear in mind when performing an intersectional analysis
 is that some of the intersections may have very few members (or even be empty).
 This will affect the confidence interval associated with the computed metrics;
 random noise has a greater effect on smaller groups.
+For this reason, we strongly suggest that :meth:`count` be included as a metric
+whenever using intersecting groups.
 All of these will use the following definitions:
 
 

--- a/docs/user_guide/assessment/perform_fairness_assessment.rst
+++ b/docs/user_guide/assessment/perform_fairness_assessment.rst
@@ -63,9 +63,17 @@ Quantify harms
 
 Define metrics that quantify harms or benefits:
 
-* In a job screening scenario, we need to quantify the number of candidates that are classified as "negative" (not recommended for the job), but whose true label is "positive" (they are "qualified"). One possible metric is the false negative rate: fraction of qualified candidates that are screened out. Note that before we attempt to classify candidates, we need to determine the construct validity of the "qualified" status; more information on construct validity can be found in :ref:`construct_validity`
+* In a job screening scenario, we need to quantify the number of candidates
+  that are classified as "negative" (not recommended for the job), but whose
+  true label is "positive" (they are "qualified"). One possible metric is
+  the false negative rate: fraction of qualified candidates that are
+  screened out. Note that before we attempt to classify candidates, we need
+  to determine the construct validity of the "qualified" status; more
+  information on construct validity can be found in :ref:`construct_validity`
 
-* For a speech-to-text application, the harm could be measured by disparities in the word error rate for different group, measured by the number of mistakes in a transcript divided by the overall number of words.
+* For a speech-to-text application, the harm could be measured by disparities
+  in the word error rate for different group, measured by the number of
+  mistakes in a transcript divided by the overall number of words.
 
 Note that in some cases, the outcome we seek to measure is not 
 directly available. 

--- a/docs/user_guide/assessment/perform_fairness_assessment.rst
+++ b/docs/user_guide/assessment/perform_fairness_assessment.rst
@@ -44,6 +44,8 @@ to considering groups according to gender and groups according to race, it is
 also important to consider their intersections (e.g., Black women, Latinx 
 nonbinary people, etc.). :footcite:cts:`crenshaw1991intersectionality`
 offers a thorough background on the topic of intersectionality.
+See the :ref:`appropriate section later in this guide <intersecting_groups>` for
+details of how Fairlearn can compute metrics for intersections.
 
 
 .. note::

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -536,7 +536,7 @@ class MetricFrame:
         features, then :attr:`.overall` is multivalued for each metric).
         The result is the absolute maximum of these values.
 
-        Read more in the :ref:`User Guide <control_features_metrics>`.
+        Read more in the :ref:`User Guide <assessment>`.
 
         Parameters
         ----------


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description

Make some small changes to the Assessment section of the user guide:

- Fix some links
- Reflow some very long ReST lines
- Add a short section about cases where `y_true` and/or `y_pred` are not present

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [x] user guide added or updated
- [x] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
