### PR TITLE
[DOC] Fix README link to assessment docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ Fairlearn metrics
 ~~~~~~~~~~~~~~~~~
 
 Check out our in-depth `guide on the Fairlearn
-metrics <https://fairlearn.org/main/user_guide/assessment.html>`__.
+metrics <https://fairlearn.org/main/user_guide/assessment>`__.
 
 Fairlearn algorithms
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Description
README link broke after PR #1123 for splitting assessment docs.
@riedgar-ms 

## Tests
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
N/A