### PR TITLE
DOC Add explanation for BibTeX citations

### DIFF
--- a/docs/contributor_guide/contributing_documentation.rst
+++ b/docs/contributor_guide/contributing_documentation.rst
@@ -74,6 +74,27 @@ ensure that they all render properly.
     pull request) and need help, simply @mention
     :code:`@fairlearn/fairlearn-maintainers` to get help.
 
+Citations
+^^^^^^^^^
+
+Citations are built using the `sphinxcontrib-bibtex <https://pypi.org/project/sphinxcontrib-bibtex/>`_ 
+extension. This allows us to use the `refs.bib <https://github.com/fairlearn/fairlearn/blob/main/docs/refs.bib>`_ BibTeX file to generate our citations.
+
+To add a citation:
+
+1. Check if your required BibTex entry already exists in the 
+   `docs/refs.bib <https://github.com/fairlearn/fairlearn/blob/main/docs/refs.bib>`_ file. If not, simply paste your entry at the end.
+2. Change your bibtex id to the format ``<author-last-name><4digit-year><keyword>``.
+3. Use the :code:`:footcite:`bibtex-id`` role to create an inline citation rendered as :code:`[CitationNumber]`.
+   For example, :code:`:footcite:`agarwal2018reductions`` will be rendered as :footcite:`agarwal2018reductions`.
+4. You can also use :code:`:footcite:t:`bibtex-id`` to create a textual citation. The role :code:`:footcite:t:`agarwal2018reductions`` will be rendered as :footcite:t:`agarwal2018reductions`.
+5. To add the bibliography use :code:`.. footbibliography::` directive at the bottom of your file if not already present.
+   This will list all the citations for the current document.
+
+   For example :code:`.. footbibliography::` will be rendered as shown below:
+
+   .. footbibliography::
+
 Building the website for all versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## Description
Fixes #1056. Adds explanation for BibTeX citations to the [Contributor Guide](https://fairlearn.org/main/contributor_guide/contributing_documentation.html).

## Tests
Built documentation locally and verified.

## Documentation
- [x] Citations explanation added.

## Screenshots
![image](https://user-images.githubusercontent.com/50991099/196814534-475f139a-2767-497e-b2e8-8185620d969c.png)

