### PR TITLE
handle TypeError during metrics.selection_rate

### DIFF
--- a/fairlearn/metrics/_selection_rate.py
+++ b/fairlearn/metrics/_selection_rate.py
@@ -34,10 +34,10 @@ def selection_rate(y_true, y_pred, *, pos_label: Any = 1, sample_weight=None) ->
     sample_weight : array_like
         Optional array of sample weights
     """
-    if len(y_pred) == 0:
+    selected = _convert_to_ndarray_and_squeeze(y_pred) == pos_label
+    if len(selected) == 0:
         raise ValueError(_EMPTY_INPUT_PREDICTIONS_ERROR_MESSAGE)
 
-    selected = _convert_to_ndarray_and_squeeze(y_pred) == pos_label
     s_w = np.ones(len(selected))
     if sample_weight is not None:
         s_w = np.squeeze(np.asarray(sample_weight))

--- a/test/unit/metrics/test_selection_rate.py
+++ b/test/unit/metrics/test_selection_rate.py
@@ -13,11 +13,22 @@ def test_selection_rate_empty():
     assert _EMPTY_INPUT_PREDICTIONS_ERROR_MESSAGE == exc.value.args[0]
 
 
-def test_selection_rate_single_element():
-    assert 1 == metrics.selection_rate([1], [1])
-    assert 1 == metrics.selection_rate([0], [1])
-    assert 0 == metrics.selection_rate([1], [0])
-    assert 0 == metrics.selection_rate([0], [0])
+@pytest.mark.parametrize(("y_true", "y_pred", "expected"), (
+        ([1], [1], 1),
+        ([0], [1], 1),
+        ([1], [0], 0),
+        ([0], [0], 0),
+        (1, 1, 1),
+        (0, 0, 0),
+        (0, 1, 1),
+        (1, 0, 0),
+        ([False], [False], 0),
+        ([True], [True], 1),
+        (False, False, 0),
+        (True, True, 1)
+))
+def test_selection_rate_single_element(y_true, y_pred, expected):
+    assert expected == metrics.selection_rate(y_true, y_pred)
 
 
 def test_selection_rate_unweighted():


### PR DESCRIPTION

## Description
I encountered a TypeError during
https://github.com/pycaret/pycaret/blob/master/tests/test_check_fairness.py
I traced it to fairlearn.metrics.selection_rate()

During Cross-Validation, y_true and y_pred could be scalar
len(y_pred) raises a TypeError

_convert_to_ndarray_and_squeeze() already handles this case, 
so call it before checking for len(y_pred) == 0

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [x] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
