### PR TITLE
[DOC] fix bad source links

### DIFF
--- a/docs/_static/versions.json
+++ b/docs/_static/versions.json
@@ -26,7 +26,7 @@
     },
     {
         "name": "v0.9.0 (dev)",
-        "version": "v0.9.0",
+        "version": "0.9.0",
         "url": "https://fairlearn.org/main/"
     }
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -228,7 +228,10 @@ def linkcode_resolve(domain, info):
     fn = os.path.relpath(fn, start=os.path.dirname(fairlearn.__file__)).replace(
         os.sep, "/"
     )
-    return f"http://github.com/fairlearn/fairlearn/blob/{tag_or_branch}/fairlearn/{fn}{linespec}"
+    if tag_or_branch == 'main':
+        return f"http://github.com/fairlearn/fairlearn/blob/{tag_or_branch}/fairlearn/{fn}{linespec}"
+    else:
+        return f"http://github.com/fairlearn/fairlearn/blob/v{tag_or_branch}/fairlearn/{fn}{linespec}"
 
 
 # -- LaTeX macros ------------------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -78,8 +78,10 @@ intersphinx_mapping = {
     ),
     "tensorflow": (
         "https://www.tensorflow.org/api_docs/python",
-        "https://raw.githubusercontent.com/GPflow/"
-        "tensorflow-intersphinx/master/tf2_py_objects.inv",
+        (
+            "https://raw.githubusercontent.com/GPflow/"
+            "tensorflow-intersphinx/master/tf2_py_objects.inv"
+        ),
     ),
 }
 
@@ -228,10 +230,17 @@ def linkcode_resolve(domain, info):
     fn = os.path.relpath(fn, start=os.path.dirname(fairlearn.__file__)).replace(
         os.sep, "/"
     )
-    if tag_or_branch == 'main':
-        return f"http://github.com/fairlearn/fairlearn/blob/{tag_or_branch}/fairlearn/{fn}{linespec}"
+    if tag_or_branch == "main":
+        return (
+            "http://github.com/fairlearn/fairlearn/blob"
+            f"/{tag_or_branch}/fairlearn/{fn}{linespec}"
+        )
+
     else:
-        return f"http://github.com/fairlearn/fairlearn/blob/v{tag_or_branch}/fairlearn/{fn}{linespec}"
+        return (
+            "http://github.com/fairlearn/fairlearn/blob/"
+            f"v{tag_or_branch}/fairlearn/{fn}{linespec}"
+        )
 
 
 # -- LaTeX macros ------------------------------------------------------------


### PR DESCRIPTION
## Description

this should resolve #1150 

@adrinjalali: I wasn't sure why 0.9.0 in `versions.json` was called `"v0.9.0"` instead of `"0.9.0"` like the others so I assumed this was a typo - let me know if I'm missing something here :)

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
