### PR TITLE
CI set matplotlib backend to agg

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,6 +16,8 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python: ["3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.os }}
+    env:
+      MPLBACKEND: Agg
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3


### PR DESCRIPTION
Resolves #1156 

## Description
Sets matplotlib backend to Agg so our windows builds (hopefully) don't fail anymore.

@riedgar-ms @adrinjalali 

## Tests
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated
