### PR TITLE
BUG fix bugs in tests that surfaced with sklearn 1.2 and autopep8 2.0.1

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -78,8 +78,8 @@ than $50,000 a year.
     >>> import numpy as np 
     >>> import pandas as pd
     >>> import matplotlib.pyplot as plt 
-    >>> from sklearn.datasets import fetch_openml
-    >>> data = fetch_openml(data_id=1590, as_frame=True)
+    >>> from fairlearn.datasets import fetch_adult
+    >>> data = fetch_adult(as_frame=True)
     >>> X = pd.get_dummies(data.data)
     >>> y_true = (data.target == '>50K') * 1
     >>> sex = data.data['sex']

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -78,8 +78,8 @@ than $50,000 a year.
     >>> import numpy as np 
     >>> import pandas as pd
     >>> import matplotlib.pyplot as plt 
-    >>> from fairlearn.datasets import fetch_adult
-    >>> data = fetch_adult(as_frame=True)
+    >>> from sklearn.datasets import fetch_openml
+    >>> data = fetch_openml(data_id=1590, as_frame=True)
     >>> X = pd.get_dummies(data.data)
     >>> y_true = (data.target == '>50K') * 1
     >>> sex = data.data['sex']

--- a/docs/user_guide/mitigation/adversarial.rst
+++ b/docs/user_guide/mitigation/adversarial.rst
@@ -215,9 +215,9 @@ Example 1: Basics & model specification
 First, we cover a most basic application of adversarial mitigation.
 We start by loading and preprocessing the dataset::
 
-    from sklearn.datasets import fetch_openml
+    from fairlearn.datasets import fetch_adult
 
-    X, y = fetch_openml(data_id=1590, as_frame=True, return_X_y=True)
+    X, y = fetch_adult(as_frame=True, return_X_y=True)
     pos_label = y[0]
 
     z = X["sex"] # In this example, we consider 'sex' the sensitive feature.

--- a/docs/user_guide/mitigation/adversarial.rst
+++ b/docs/user_guide/mitigation/adversarial.rst
@@ -215,9 +215,9 @@ Example 1: Basics & model specification
 First, we cover a most basic application of adversarial mitigation.
 We start by loading and preprocessing the dataset::
 
-    from fairlearn.datasets import fetch_adult
+    from sklearn.datasets import fetch_openml
 
-    X, y = fetch_adult(as_frame=True, return_X_y=True)
+    X, y = fetch_openml(data_id=1590, as_frame=True, return_X_y=True)
     pos_label = y[0]
 
     z = X["sex"] # In this example, we consider 'sex' the sensitive feature.

--- a/docs/user_guide/mitigation/preprocessing.rst
+++ b/docs/user_guide/mitigation/preprocessing.rst
@@ -58,7 +58,7 @@ The :code:`CorrelationRemover` will drop the sensitive features from the dataset
     >>> from fairlearn.preprocessing import CorrelationRemover
     >>> import pandas as pd
     >>> from fairlearn.datasets import fetch_diabetes_hospital
-    >>> data = fetch_diabetes_hospital(as_frame=True)
+    >>> data = fetch_diabetes_hospital()
     >>> X = data.data[["race", "time_in_hospital", "had_inpatient_days", "medicare"]]
     >>> X = pd.get_dummies(X)
     >>> X = X.drop(["race_Asian",

--- a/docs/user_guide/mitigation/preprocessing.rst
+++ b/docs/user_guide/mitigation/preprocessing.rst
@@ -57,8 +57,8 @@ The :code:`CorrelationRemover` will drop the sensitive features from the dataset
 
     >>> from fairlearn.preprocessing import CorrelationRemover
     >>> import pandas as pd
-    >>> from sklearn.datasets import fetch_openml
-    >>> data = fetch_openml(data_id=43874, as_frame=True)
+    >>> from fairlearn.datasets import fetch_diabetes_hospital
+    >>> data = fetch_diabetes_hospital()
     >>> X = data.data[["race", "time_in_hospital", "had_inpatient_days", "medicare"]]
     >>> X = pd.get_dummies(X)
     >>> X = X.drop(["race_Asian",

--- a/docs/user_guide/mitigation/preprocessing.rst
+++ b/docs/user_guide/mitigation/preprocessing.rst
@@ -57,8 +57,8 @@ The :code:`CorrelationRemover` will drop the sensitive features from the dataset
 
     >>> from fairlearn.preprocessing import CorrelationRemover
     >>> import pandas as pd
-    >>> from fairlearn.datasets import fetch_diabetes_hospital
-    >>> data = fetch_diabetes_hospital(as_frame=True)
+    >>> from sklearn.datasets import fetch_openml
+    >>> data = fetch_openml(data_id=43874, as_frame=True)
     >>> X = data.data[["race", "time_in_hospital", "had_inpatient_days", "medicare"]]
     >>> X = pd.get_dummies(X)
     >>> X = X.drop(["race_Asian",

--- a/docs/user_guide/mitigation/preprocessing.rst
+++ b/docs/user_guide/mitigation/preprocessing.rst
@@ -58,7 +58,7 @@ The :code:`CorrelationRemover` will drop the sensitive features from the dataset
     >>> from fairlearn.preprocessing import CorrelationRemover
     >>> import pandas as pd
     >>> from fairlearn.datasets import fetch_diabetes_hospital
-    >>> data = fetch_diabetes_hospital()
+    >>> data = fetch_diabetes_hospital(as_frame=True)
     >>> X = data.data[["race", "time_in_hospital", "had_inpatient_days", "medicare"]]
     >>> X = pd.get_dummies(X)
     >>> X = X.drop(["race_Asian",

--- a/docs/user_guide/mitigation/preprocessing.rst
+++ b/docs/user_guide/mitigation/preprocessing.rst
@@ -57,8 +57,8 @@ The :code:`CorrelationRemover` will drop the sensitive features from the dataset
 
     >>> from fairlearn.preprocessing import CorrelationRemover
     >>> import pandas as pd
-    >>> from sklearn.datasets import fetch_openml
-    >>> data = fetch_openml(data_id=43874, as_frame=True)
+    >>> from fairlearn.datasets import fetch_diabetes_hospital
+    >>> data = fetch_diabetes_hospital(as_frame=True)
     >>> X = data.data[["race", "time_in_hospital", "had_inpatient_days", "medicare"]]
     >>> X = pd.get_dummies(X)
     >>> X = X.drop(["race_Asian",

--- a/examples/plot_correlationremover_before_after.py
+++ b/examples/plot_correlationremover_before_after.py
@@ -27,7 +27,7 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 
-from sklearn.datasets import fetch_openml
+from fairlearn.datasets import fetch_diabetes_hospital
 from fairlearn.preprocessing import CorrelationRemover
 
 # %%
@@ -36,7 +36,7 @@ from fairlearn.preprocessing import CorrelationRemover
 # specifically at the African American race.
 # Finally, the columns are rearranged for consistency.
 
-data = fetch_openml(data_id=43874, as_frame=True)
+data = fetch_diabetes_hospital()
 X_raw = data.data[["race", "time_in_hospital", "had_inpatient_days", "medicare"]]
 X_raw = pd.get_dummies(X_raw)
 y = data.target

--- a/examples/plot_correlationremover_before_after.py
+++ b/examples/plot_correlationremover_before_after.py
@@ -36,7 +36,7 @@ from fairlearn.preprocessing import CorrelationRemover
 # specifically at the African American race.
 # Finally, the columns are rearranged for consistency.
 
-data = fetch_diabetes_hospital(as_frame=True)
+data = fetch_diabetes_hospital()
 X_raw = data.data[["race", "time_in_hospital", "had_inpatient_days", "medicare"]]
 X_raw = pd.get_dummies(X_raw)
 y = data.target

--- a/examples/plot_correlationremover_before_after.py
+++ b/examples/plot_correlationremover_before_after.py
@@ -36,7 +36,7 @@ from fairlearn.preprocessing import CorrelationRemover
 # specifically at the African American race.
 # Finally, the columns are rearranged for consistency.
 
-data = fetch_diabetes_hospital()
+data = fetch_diabetes_hospital(as_frame=True)
 X_raw = data.data[["race", "time_in_hospital", "had_inpatient_days", "medicare"]]
 X_raw = pd.get_dummies(X_raw)
 y = data.target

--- a/examples/plot_correlationremover_before_after.py
+++ b/examples/plot_correlationremover_before_after.py
@@ -27,7 +27,7 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 
-from sklearn.datasets import fetch_openml
+from fairlearn.datasets import fetch_diabetes_hospital
 from fairlearn.preprocessing import CorrelationRemover
 
 # %%
@@ -36,7 +36,7 @@ from fairlearn.preprocessing import CorrelationRemover
 # specifically at the African American race.
 # Finally, the columns are rearranged for consistency.
 
-data = fetch_openml(data_id=43874, as_frame=True)
+data = fetch_diabetes_hospital(as_frame=True)
 X_raw = data.data[["race", "time_in_hospital", "had_inpatient_days", "medicare"]]
 X_raw = pd.get_dummies(X_raw)
 y = data.target

--- a/examples/plot_correlationremover_before_after.py
+++ b/examples/plot_correlationremover_before_after.py
@@ -27,7 +27,7 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 
-from fairlearn.datasets import fetch_diabetes_hospital
+from sklearn.datasets import fetch_openml
 from fairlearn.preprocessing import CorrelationRemover
 
 # %%
@@ -36,7 +36,7 @@ from fairlearn.preprocessing import CorrelationRemover
 # specifically at the African American race.
 # Finally, the columns are rearranged for consistency.
 
-data = fetch_diabetes_hospital(as_frame=True)
+data = fetch_openml(data_id=43874, as_frame=True)
 X_raw = data.data[["race", "time_in_hospital", "had_inpatient_days", "medicare"]]
 X_raw = pd.get_dummies(X_raw)
 y = data.target

--- a/examples/plot_grid_search_census.py
+++ b/examples/plot_grid_search_census.py
@@ -34,11 +34,11 @@ GridSearch with Census Data
 
 import pandas as pd
 from sklearn import metrics as skm
-from sklearn.datasets import fetch_openml
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelEncoder, StandardScaler
 
+from fairlearn.datasets import fetch_adult
 from fairlearn.reductions import DemographicParity, ErrorRate, GridSearch
 from fairlearn.metrics import (
     MetricFrame, selection_rate, count, plot_model_comparison, selection_rate_difference
@@ -47,7 +47,7 @@ from fairlearn.metrics import (
 # %%
 # We can now load and inspect the data by using the `fairlearn.datasets` module:
 
-data = fetch_openml(data_id=1590, as_frame=True)
+data = fetch_adult(as_frame=True)
 X_raw = data.data
 Y = (data.target == ">50K") * 1
 X_raw

--- a/examples/plot_grid_search_census.py
+++ b/examples/plot_grid_search_census.py
@@ -34,11 +34,11 @@ GridSearch with Census Data
 
 import pandas as pd
 from sklearn import metrics as skm
+from sklearn.datasets import fetch_openml
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelEncoder, StandardScaler
 
-from fairlearn.datasets import fetch_adult
 from fairlearn.reductions import DemographicParity, ErrorRate, GridSearch
 from fairlearn.metrics import (
     MetricFrame, selection_rate, count, plot_model_comparison, selection_rate_difference
@@ -47,7 +47,7 @@ from fairlearn.metrics import (
 # %%
 # We can now load and inspect the data by using the `fairlearn.datasets` module:
 
-data = fetch_adult(as_frame=True)
+data = fetch_openml(data_id=1590, as_frame=True)
 X_raw = data.data
 Y = (data.target == ">50K") * 1
 X_raw

--- a/examples/plot_make_derived_metric.py
+++ b/examples/plot_make_derived_metric.py
@@ -35,19 +35,19 @@ import numpy as np
 import sklearn.metrics as skm
 from sklearn.compose import ColumnTransformer
 from sklearn.compose import make_column_selector as selector
-from sklearn.datasets import fetch_openml
 from sklearn.impute import SimpleImputer
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import OneHotEncoder, StandardScaler
 
+from fairlearn.datasets import fetch_adult
 from fairlearn.metrics import MetricFrame, accuracy_score_group_min, make_derived_metric
 
 # %%
 # Next, we import the data, dropping any rows which are missing data:
 
-data = fetch_openml(data_id=1590, as_frame=True)
+data = fetch_adult(as_frame=True)
 X_raw = data.data
 y = (data.target == ">50K") * 1
 A = X_raw[["race", "sex"]]

--- a/examples/plot_make_derived_metric.py
+++ b/examples/plot_make_derived_metric.py
@@ -35,19 +35,19 @@ import numpy as np
 import sklearn.metrics as skm
 from sklearn.compose import ColumnTransformer
 from sklearn.compose import make_column_selector as selector
+from sklearn.datasets import fetch_openml
 from sklearn.impute import SimpleImputer
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import OneHotEncoder, StandardScaler
 
-from fairlearn.datasets import fetch_adult
 from fairlearn.metrics import MetricFrame, accuracy_score_group_min, make_derived_metric
 
 # %%
 # Next, we import the data, dropping any rows which are missing data:
 
-data = fetch_adult(as_frame=True)
+data = fetch_openml(data_id=1590, as_frame=True)
 X_raw = data.data
 y = (data.target == ">50K") * 1
 A = X_raw[["race", "sex"]]

--- a/examples/plot_new_metrics.py
+++ b/examples/plot_new_metrics.py
@@ -57,19 +57,19 @@ import numpy as np
 import sklearn.metrics as skm
 from sklearn.compose import ColumnTransformer
 from sklearn.compose import make_column_selector as selector
-from sklearn.datasets import fetch_openml
 from sklearn.impute import SimpleImputer
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import OneHotEncoder, StandardScaler
 
+from fairlearn.datasets import fetch_adult
 from fairlearn.metrics import MetricFrame, count, selection_rate
 
 # %%
 # Next, we import the data:
 
-data = fetch_openml(data_id=1590, as_frame=True)
+data = fetch_adult(as_frame=True)
 X_raw = data.data
 y = (data.target == ">50K") * 1
 

--- a/examples/plot_new_metrics.py
+++ b/examples/plot_new_metrics.py
@@ -57,19 +57,19 @@ import numpy as np
 import sklearn.metrics as skm
 from sklearn.compose import ColumnTransformer
 from sklearn.compose import make_column_selector as selector
+from sklearn.datasets import fetch_openml
 from sklearn.impute import SimpleImputer
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import OneHotEncoder, StandardScaler
 
-from fairlearn.datasets import fetch_adult
 from fairlearn.metrics import MetricFrame, count, selection_rate
 
 # %%
 # Next, we import the data:
 
-data = fetch_adult(as_frame=True)
+data = fetch_openml(data_id=1590, as_frame=True)
 X_raw = data.data
 y = (data.target == ">50K") * 1
 

--- a/examples/plot_plotting_metrics_with_error.py
+++ b/examples/plot_plotting_metrics_with_error.py
@@ -26,7 +26,7 @@ from fairlearn.experimental.enable_metric_frame_plotting import plot_metric_fram
 from fairlearn.metrics import MetricFrame
 
 # %%
-# We download the data set using :func:`fetch_adult` function in :mod:`fairlearn.datasets`.
+# We download the data set using the function :func:`fetch_adult` in :mod:`fairlearn.datasets`.
 # The original Adult data set can be found at https://archive.ics.uci.edu/ml/datasets/Adult
 # There are some caveats to using this dataset, but we will use it solely as an example
 # to demonstrate the functionality of plotting metrics with error bars.

--- a/examples/plot_plotting_metrics_with_error.py
+++ b/examples/plot_plotting_metrics_with_error.py
@@ -9,7 +9,7 @@ Plotting Metrics with Errors
 import numpy as np
 from sklearn.compose import ColumnTransformer
 from sklearn.compose import make_column_selector as selector
-from sklearn.datasets import fetch_openml
+from fairlearn.datasets import fetch_adult
 from sklearn.impute import SimpleImputer
 from sklearn.metrics import accuracy_score, confusion_matrix, recall_score
 from sklearn.model_selection import train_test_split
@@ -26,14 +26,14 @@ from fairlearn.experimental.enable_metric_frame_plotting import plot_metric_fram
 from fairlearn.metrics import MetricFrame
 
 # %%
-# We download the data set using :meth:`fetch_openml` function in :class:`sklearn.datasets`.
+# We download the data set using :func:`fetch_adult` function in :mod:`fairlearn.datasets`.
 # The original Adult data set can be found at https://archive.ics.uci.edu/ml/datasets/Adult
 # There are some caveats to using this dataset, but we will use it solely as an example
 # to demonstrate the functionality of plotting metrics with error bars.
 # We use a pipeline to preprocess the data then use a
 # :py:class:`sklearn.tree.DecisionTreeClassifier` to make predictions
 
-data = fetch_openml(data_id=1590, as_frame=True)
+data = fetch_adult(as_frame=True)
 X = data.data
 y = (data.target == ">50K").astype(int)
 X_train, X_test, y_train_true, y_test_true = train_test_split(

--- a/examples/plot_plotting_metrics_with_error.py
+++ b/examples/plot_plotting_metrics_with_error.py
@@ -9,7 +9,7 @@ Plotting Metrics with Errors
 import numpy as np
 from sklearn.compose import ColumnTransformer
 from sklearn.compose import make_column_selector as selector
-from fairlearn.datasets import fetch_adult
+from sklearn.datasets import fetch_openml
 from sklearn.impute import SimpleImputer
 from sklearn.metrics import accuracy_score, confusion_matrix, recall_score
 from sklearn.model_selection import train_test_split
@@ -26,14 +26,14 @@ from fairlearn.experimental.enable_metric_frame_plotting import plot_metric_fram
 from fairlearn.metrics import MetricFrame
 
 # %%
-# We download the data set using :func:`fetch_adult` function in :mod:`fairlearn.datasets`.
+# We download the data set using :meth:`fetch_openml` function in :class:`sklearn.datasets`.
 # The original Adult data set can be found at https://archive.ics.uci.edu/ml/datasets/Adult
 # There are some caveats to using this dataset, but we will use it solely as an example
 # to demonstrate the functionality of plotting metrics with error bars.
 # We use a pipeline to preprocess the data then use a
 # :py:class:`sklearn.tree.DecisionTreeClassifier` to make predictions
 
-data = fetch_adult(as_frame=True)
+data = fetch_openml(data_id=1590, as_frame=True)
 X = data.data
 y = (data.target == ">50K").astype(int)
 X_train, X_test, y_train_true, y_test_true = train_test_split(

--- a/examples/plot_quickstart.py
+++ b/examples/plot_quickstart.py
@@ -8,7 +8,7 @@ MetricFrame visualizations
 """
 
 import pandas as pd
-from sklearn.datasets import fetch_openml
+from fairlearn.datasets import fetch_adult
 from sklearn.metrics import accuracy_score, precision_score
 from sklearn.tree import DecisionTreeClassifier
 
@@ -21,7 +21,7 @@ from fairlearn.metrics import (
     selection_rate,
 )
 
-data = fetch_openml(data_id=1590, as_frame=True)
+data = fetch_adult(as_frame=True)
 X = pd.get_dummies(data.data)
 y_true = (data.target == ">50K") * 1
 sex = data.data["sex"]

--- a/examples/plot_quickstart.py
+++ b/examples/plot_quickstart.py
@@ -8,7 +8,7 @@ MetricFrame visualizations
 """
 
 import pandas as pd
-from fairlearn.datasets import fetch_adult
+from sklearn.datasets import fetch_openml
 from sklearn.metrics import accuracy_score, precision_score
 from sklearn.tree import DecisionTreeClassifier
 
@@ -21,7 +21,7 @@ from fairlearn.metrics import (
     selection_rate,
 )
 
-data = fetch_adult(as_frame=True)
+data = fetch_openml(data_id=1590, as_frame=True)
 X = pd.get_dummies(data.data)
 y_true = (data.target == ">50K") * 1
 sex = data.data["sex"]

--- a/fairlearn/datasets/_fetch_acs_income.py
+++ b/fairlearn/datasets/_fetch_acs_income.py
@@ -181,6 +181,7 @@ def fetch_acs_income(
         cache=cache,
         as_frame=True,
         return_X_y=False,
+        parser="auto",
     )
 
     # filter by state

--- a/fairlearn/datasets/_fetch_acs_income.py
+++ b/fairlearn/datasets/_fetch_acs_income.py
@@ -181,7 +181,6 @@ def fetch_acs_income(
         cache=cache,
         as_frame=True,
         return_X_y=False,
-        parser="auto",
     )
 
     # filter by state

--- a/fairlearn/datasets/_fetch_acs_income.py
+++ b/fairlearn/datasets/_fetch_acs_income.py
@@ -181,6 +181,7 @@ def fetch_acs_income(
         cache=cache,
         as_frame=True,
         return_X_y=False,
+        parser="liac-arff",
     )
 
     # filter by state

--- a/fairlearn/datasets/_fetch_adult.py
+++ b/fairlearn/datasets/_fetch_adult.py
@@ -97,4 +97,5 @@ def fetch_adult(*, cache=True, data_home=None, as_frame=False, return_X_y=False)
         cache=cache,
         as_frame=as_frame,
         return_X_y=return_X_y,
+        parser="auto",
     )

--- a/fairlearn/datasets/_fetch_adult.py
+++ b/fairlearn/datasets/_fetch_adult.py
@@ -97,5 +97,4 @@ def fetch_adult(*, cache=True, data_home=None, as_frame=False, return_X_y=False)
         cache=cache,
         as_frame=as_frame,
         return_X_y=return_X_y,
-        parser="auto",
     )

--- a/fairlearn/datasets/_fetch_adult.py
+++ b/fairlearn/datasets/_fetch_adult.py
@@ -97,4 +97,5 @@ def fetch_adult(*, cache=True, data_home=None, as_frame=False, return_X_y=False)
         cache=cache,
         as_frame=as_frame,
         return_X_y=return_X_y,
+        parser="liac-arff",
     )

--- a/fairlearn/datasets/_fetch_bank_marketing.py
+++ b/fairlearn/datasets/_fetch_bank_marketing.py
@@ -100,4 +100,5 @@ def fetch_bank_marketing(
         cache=cache,
         as_frame=as_frame,
         return_X_y=return_X_y,
+        parser="liac-arff",
     )

--- a/fairlearn/datasets/_fetch_bank_marketing.py
+++ b/fairlearn/datasets/_fetch_bank_marketing.py
@@ -100,5 +100,4 @@ def fetch_bank_marketing(
         cache=cache,
         as_frame=as_frame,
         return_X_y=return_X_y,
-        parser="auto",
     )

--- a/fairlearn/datasets/_fetch_bank_marketing.py
+++ b/fairlearn/datasets/_fetch_bank_marketing.py
@@ -100,4 +100,5 @@ def fetch_bank_marketing(
         cache=cache,
         as_frame=as_frame,
         return_X_y=return_X_y,
+        parser="auto",
     )

--- a/fairlearn/datasets/_fetch_boston.py
+++ b/fairlearn/datasets/_fetch_boston.py
@@ -150,4 +150,5 @@ def fetch_boston(
         cache=cache,
         as_frame=as_frame,
         return_X_y=return_X_y,
+        parser="liac-arff",
     )

--- a/fairlearn/datasets/_fetch_boston.py
+++ b/fairlearn/datasets/_fetch_boston.py
@@ -150,4 +150,5 @@ def fetch_boston(
         cache=cache,
         as_frame=as_frame,
         return_X_y=return_X_y,
+        parser="auto",
     )

--- a/fairlearn/datasets/_fetch_boston.py
+++ b/fairlearn/datasets/_fetch_boston.py
@@ -150,5 +150,4 @@ def fetch_boston(
         cache=cache,
         as_frame=as_frame,
         return_X_y=return_X_y,
-        parser="auto",
     )

--- a/fairlearn/datasets/_fetch_diabetes_hospital.py
+++ b/fairlearn/datasets/_fetch_diabetes_hospital.py
@@ -96,4 +96,5 @@ def fetch_diabetes_hospital(
         cache=cache,
         as_frame=True,
         return_X_y=return_X_y,
+        parser="liac-arff",
     )

--- a/fairlearn/datasets/_fetch_diabetes_hospital.py
+++ b/fairlearn/datasets/_fetch_diabetes_hospital.py
@@ -96,5 +96,4 @@ def fetch_diabetes_hospital(
         cache=cache,
         as_frame=True,
         return_X_y=return_X_y,
-        parser="auto",
     )

--- a/fairlearn/datasets/_fetch_diabetes_hospital.py
+++ b/fairlearn/datasets/_fetch_diabetes_hospital.py
@@ -96,4 +96,5 @@ def fetch_diabetes_hospital(
         cache=cache,
         as_frame=True,
         return_X_y=return_X_y,
+        parser="auto",
     )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
 # Requirements for Fairlearn development
 
 # Required for environment
-autopep8
 flake8<6  # Having strange issue with latest release
+autopep8<2.0.1 # To ensure compatibility with flake8<6
 flake8-blind-except
 flake8-builtins
 flake8-copyright

--- a/test/unit/adversarial/test_preprocessing.py
+++ b/test/unit/adversarial/test_preprocessing.py
@@ -5,7 +5,7 @@ from fairlearn.adversarial._preprocessor import FloatTransformer
 import pytest
 from pandas import DataFrame, Series
 from numpy import ndarray, asarray, issubdtype
-from sklearn.datasets import fetch_openml
+from fairlearn.datasets import fetch_adult
 
 
 def data_generator():
@@ -39,7 +39,7 @@ def data_generator():
     yield [[0, 1], [1, 0], [0.1, 2]], "continuous", [Series]
 
     # Larger examples.
-    X, y = fetch_openml(data_id=1590, as_frame=True, return_X_y=True)
+    X, y = fetch_adult(as_frame=True, return_X_y=True)
     yield y.tolist(), "binary"
     non_NaN_rows = ~X.isna().any(axis=1)
     X = X[non_NaN_rows]

--- a/test/unit/adversarial/test_preprocessing.py
+++ b/test/unit/adversarial/test_preprocessing.py
@@ -5,7 +5,7 @@ from fairlearn.adversarial._preprocessor import FloatTransformer
 import pytest
 from pandas import DataFrame, Series
 from numpy import ndarray, asarray, issubdtype
-from fairlearn.datasets import fetch_adult
+from sklearn.datasets import fetch_openml
 
 
 def data_generator():
@@ -39,7 +39,7 @@ def data_generator():
     yield [[0, 1], [1, 0], [0.1, 2]], "continuous", [Series]
 
     # Larger examples.
-    X, y = fetch_adult(as_frame=True, return_X_y=True)
+    X, y = fetch_openml(data_id=1590, as_frame=True, return_X_y=True)
     yield y.tolist(), "binary"
     non_NaN_rows = ~X.isna().any(axis=1)
     X = X[non_NaN_rows]

--- a/test/unit/metrics/test_generated_metrics.py
+++ b/test/unit/metrics/test_generated_metrics.py
@@ -7,6 +7,13 @@ import fairlearn.metrics as metrics
 
 # ======================================================
 
+# Evaluation of log loss with y_true=1 and y_pred=0 (or vice versa)
+# gives mathematically an infinite value. Scikit-learn in this case
+# returns a finite value based on the setting of the keyword parameter
+# eps of log_loss function. In our tests with log loss, we replace 0 with
+# apx0 and 1 with apx1 in y_pred when it disagrees with y_true. This
+# avoids the issue of an infinite log loss.
+
 apx0 = 1e-15
 apx1 = 1 - apx0
 

--- a/test/unit/metrics/test_generated_metrics.py
+++ b/test/unit/metrics/test_generated_metrics.py
@@ -7,8 +7,12 @@ import fairlearn.metrics as metrics
 
 # ======================================================
 
+apx0 = 1e-15
+apx1 = 1 - apx0
+
 y_true = [0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1]
 y_pred = [1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1]
+y_pred_log_loss = [apx1, 0, apx1, apx0, 1, apx0, 0, apx1, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1]
 sf_binary = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
 
 derived_metric_results = {
@@ -57,9 +61,13 @@ def test_dict_sizes():
 def test_generated_metrics_smoke(func_name):
     func = getattr(metrics, func_name)
     assert callable(func)
+    if func_name.startswith("log_loss"):
+        y_pred_test = y_pred_log_loss
+    else:
+        y_pred_test = y_pred
     result = func(
         y_true,
-        y_pred,
+        y_pred_test,
         sensitive_features=sf_binary,
         method=derived_metric_results[func_name]["method"],
     )

--- a/test/unit/reductions/grid_search/test_grid_search_demographicparity.py
+++ b/test/unit/reductions/grid_search/test_grid_search_demographicparity.py
@@ -40,7 +40,7 @@ def _simple_threshold_data(
     X = pd.DataFrame(
         {
             "actual_feature": score_feature,
-            "sensitive_feature1": A,
+            "sensitive_features": A,
             "constant_ones_feature": np.ones(len(Y)),
         }
     )

--- a/test/unit/test_random_state.py
+++ b/test/unit/test_random_state.py
@@ -70,7 +70,7 @@ def test_random_state_exponentiated_gradient():
 
 def _get_test_data():
     # fetch data from OpenML
-    data = fetch_openml(data_id=42193, parser="auto")
+    data = fetch_openml(data_id=42193)
     X = (
         pd.DataFrame(data["data"], columns=data["feature_names"])
         .drop(columns=["race_Caucasian", "c_charge_degree_F"])

--- a/test/unit/test_random_state.py
+++ b/test/unit/test_random_state.py
@@ -70,7 +70,7 @@ def test_random_state_exponentiated_gradient():
 
 def _get_test_data():
     # fetch data from OpenML
-    data = fetch_openml(data_id=42193)
+    data = fetch_openml(data_id=42193, parser="auto")
     X = (
         pd.DataFrame(data["data"], columns=data["feature_names"])
         .drop(columns=["race_Caucasian", "c_charge_degree_F"])

--- a/test/unit/test_random_state.py
+++ b/test/unit/test_random_state.py
@@ -70,7 +70,7 @@ def test_random_state_exponentiated_gradient():
 
 def _get_test_data():
     # fetch data from OpenML
-    data = fetch_openml(data_id=42193)
+    data = fetch_openml(data_id=42193, parser="liac-arff")
     X = (
         pd.DataFrame(data["data"], columns=data["feature_names"])
         .drop(columns=["race_Caucasian", "c_charge_degree_F"])

--- a/test_othermlpackages/adversarial_fairness.py
+++ b/test_othermlpackages/adversarial_fairness.py
@@ -9,8 +9,8 @@ from sklearn.impute import SimpleImputer
 from sklearn.pipeline import Pipeline
 import torch
 from numpy import mean, number
-from sklearn.datasets import fetch_openml
 
+from fairlearn.datasets import fetch_adult
 from fairlearn.metrics import (
     MetricFrame,
     selection_rate,
@@ -28,7 +28,7 @@ step = 1
 
 def test_examples():
     # EXAMPLE 1
-    X, y = fetch_openml(data_id=1590, as_frame=True, return_X_y=True)
+    X, y = fetch_adult(as_frame=True, return_X_y=True)
     pos_label = y[0]
 
     z = X["sex"]  # In this example, we consider 'sex' the sensitive feature.

--- a/test_othermlpackages/adversarial_fairness.py
+++ b/test_othermlpackages/adversarial_fairness.py
@@ -9,8 +9,8 @@ from sklearn.impute import SimpleImputer
 from sklearn.pipeline import Pipeline
 import torch
 from numpy import mean, number
+from sklearn.datasets import fetch_openml
 
-from fairlearn.datasets import fetch_adult
 from fairlearn.metrics import (
     MetricFrame,
     selection_rate,
@@ -28,7 +28,7 @@ step = 1
 
 def test_examples():
     # EXAMPLE 1
-    X, y = fetch_adult(as_frame=True, return_X_y=True)
+    X, y = fetch_openml(data_id=1590, as_frame=True, return_X_y=True)
     pos_label = y[0]
 
     z = X["sex"]  # In this example, we consider 'sex' the sensitive feature.

--- a/test_othermlpackages/package_test_common.py
+++ b/test_othermlpackages/package_test_common.py
@@ -8,11 +8,11 @@ import copy
 import pandas as pd
 from numpy import mean, random, number
 
+from sklearn.datasets import fetch_openml
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelEncoder, StandardScaler, OneHotEncoder
 from sklearn.compose import make_column_selector, make_column_transformer
 
-import fairlearn.datasets as fld
 from fairlearn.metrics import demographic_parity_difference
 from fairlearn.postprocessing import ThresholdOptimizer
 from fairlearn.reductions import ExponentiatedGradient, GridSearch
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 def fetch_adult():
     """Grab dataset for testing."""
-    data = fld.fetch_adult(as_frame=True)
+    data = fetch_openml(data_id=1590, as_frame=True)
     X = data.data.drop(labels=["sex"], axis=1)
     X = pd.get_dummies(X)
     Y = (data.target == ">50K") * 1
@@ -127,7 +127,7 @@ def run_AdversarialFairness_classification(estimator):
     """Run classification test with AdversarialFairness."""
     random.seed(123)
 
-    X, y = fld.fetch_adult(as_frame=True, return_X_y=True)
+    X, y = fetch_openml(data_id=1590, as_frame=True, return_X_y=True)
 
     non_NaN_rows = ~X.isna().any(axis=1)
 

--- a/test_othermlpackages/package_test_common.py
+++ b/test_othermlpackages/package_test_common.py
@@ -8,11 +8,11 @@ import copy
 import pandas as pd
 from numpy import mean, random, number
 
-from sklearn.datasets import fetch_openml
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelEncoder, StandardScaler, OneHotEncoder
 from sklearn.compose import make_column_selector, make_column_transformer
 
+import fairlearn.datasets as fld
 from fairlearn.metrics import demographic_parity_difference
 from fairlearn.postprocessing import ThresholdOptimizer
 from fairlearn.reductions import ExponentiatedGradient, GridSearch
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 def fetch_adult():
     """Grab dataset for testing."""
-    data = fetch_openml(data_id=1590, as_frame=True)
+    data = fld.fetch_adult(as_frame=True)
     X = data.data.drop(labels=["sex"], axis=1)
     X = pd.get_dummies(X)
     Y = (data.target == ">50K") * 1
@@ -127,7 +127,7 @@ def run_AdversarialFairness_classification(estimator):
     """Run classification test with AdversarialFairness."""
     random.seed(123)
 
-    X, y = fetch_openml(data_id=1590, as_frame=True, return_X_y=True)
+    X, y = fld.fetch_adult(as_frame=True, return_X_y=True)
 
     non_NaN_rows = ~X.isna().any(axis=1)
 


### PR DESCRIPTION
Signed-off-by: Miro Dudik <mdudik@gmail.com>

<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

Three sklearn 1.2 related issues are being fixed:

* A typo in our test scripts: mismatched feature names between fit and predict. This was previously FutureWarning in sklearn, but with sklearn 1.2 it is now an error.
* Default behavior of log loss in sklearn 1.2 changes, affecting the evaluation of log loss in derived metrics. The default only kicks in when prediction=0 and truth=1 or vice versa, so the tests are adjusted to avoid this case (and give the log loss value equal to the previous default behavior).
* Warnings issued by fetch_openml when `parser` keyword argument is not present.

Additionally:

* autopep8 version is being kept lower to keep our linting scripts working

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
