### PR TITLE
add sklearn-version-dependent parser kwarg

### DIFF
--- a/fairlearn/datasets/_constants.py
+++ b/fairlearn/datasets/_constants.py
@@ -2,4 +2,17 @@
 # Licensed under the MIT License.
 
 
+from sklearn.datasets import fetch_openml
+import inspect
+
 _DOWNLOAD_DIRECTORY_NAME = ".fairlearn-data"
+
+# In sklearn 1.2, the function fetch_openml added a new keyword
+# argument 'parser', and also changed the default behavior. To
+# maintain compatibility, we therefore set the 'parser' argument
+# to 'liac-arff', which matches the behavior before version 1.2.
+
+if 'parser' in inspect.getfullargspec(fetch_openml).kwonlyargs:
+    _PARSER_KWARG_COMPATIBILITY = {'parser': 'liac-arff'}
+else:
+    _PARSER_KWARG_COMPATIBILITY = {}

--- a/fairlearn/datasets/_fetch_acs_income.py
+++ b/fairlearn/datasets/_fetch_acs_income.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 from sklearn.datasets import fetch_openml
 
-from ._constants import _DOWNLOAD_DIRECTORY_NAME
+from ._constants import _DOWNLOAD_DIRECTORY_NAME, _PARSER_KWARG_COMPATIBILITY
 
 
 def fetch_acs_income(
@@ -181,7 +181,7 @@ def fetch_acs_income(
         cache=cache,
         as_frame=True,
         return_X_y=False,
-        parser="liac-arff",
+        **_PARSER_KWARG_COMPATIBILITY,
     )
 
     # filter by state

--- a/fairlearn/datasets/_fetch_adult.py
+++ b/fairlearn/datasets/_fetch_adult.py
@@ -5,7 +5,7 @@ import pathlib
 
 from sklearn.datasets import fetch_openml
 
-from ._constants import _DOWNLOAD_DIRECTORY_NAME
+from ._constants import _DOWNLOAD_DIRECTORY_NAME, _PARSER_KWARG_COMPATIBILITY
 
 
 def fetch_adult(*, cache=True, data_home=None, as_frame=False, return_X_y=False):
@@ -97,5 +97,5 @@ def fetch_adult(*, cache=True, data_home=None, as_frame=False, return_X_y=False)
         cache=cache,
         as_frame=as_frame,
         return_X_y=return_X_y,
-        parser="liac-arff",
+        **_PARSER_KWARG_COMPATIBILITY,
     )

--- a/fairlearn/datasets/_fetch_bank_marketing.py
+++ b/fairlearn/datasets/_fetch_bank_marketing.py
@@ -5,7 +5,7 @@ import pathlib
 
 from sklearn.datasets import fetch_openml
 
-from ._constants import _DOWNLOAD_DIRECTORY_NAME
+from ._constants import _DOWNLOAD_DIRECTORY_NAME, _PARSER_KWARG_COMPATIBILITY
 
 
 def fetch_bank_marketing(
@@ -100,5 +100,5 @@ def fetch_bank_marketing(
         cache=cache,
         as_frame=as_frame,
         return_X_y=return_X_y,
-        parser="liac-arff",
+        **_PARSER_KWARG_COMPATIBILITY,
     )

--- a/fairlearn/datasets/_fetch_boston.py
+++ b/fairlearn/datasets/_fetch_boston.py
@@ -8,7 +8,7 @@ from sklearn.datasets import fetch_openml
 
 from fairlearn.exceptions import DataFairnessWarning
 
-from ._constants import _DOWNLOAD_DIRECTORY_NAME
+from ._constants import _DOWNLOAD_DIRECTORY_NAME, _PARSER_KWARG_COMPATIBILITY
 
 
 def fetch_boston(
@@ -150,5 +150,5 @@ def fetch_boston(
         cache=cache,
         as_frame=as_frame,
         return_X_y=return_X_y,
-        parser="liac-arff",
+        **_PARSER_KWARG_COMPATIBILITY,
     )

--- a/fairlearn/datasets/_fetch_diabetes_hospital.py
+++ b/fairlearn/datasets/_fetch_diabetes_hospital.py
@@ -4,7 +4,7 @@
 import pathlib
 
 from sklearn.datasets import fetch_openml
-from ._constants import _DOWNLOAD_DIRECTORY_NAME
+from ._constants import _DOWNLOAD_DIRECTORY_NAME, _PARSER_KWARG_COMPATIBILITY
 
 
 def fetch_diabetes_hospital(
@@ -96,5 +96,5 @@ def fetch_diabetes_hospital(
         cache=cache,
         as_frame=True,
         return_X_y=return_X_y,
-        parser="liac-arff",
+        **_PARSER_KWARG_COMPATIBILITY,
     )


### PR DESCRIPTION
Signed-off-by: Miro Dudik <mdudik@gmail.com>

<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description

In sklearn 1.2, the function fetch_openml added a new keyword argument 'parser', and also changed the default behavior. To
maintain compatibility, we therefore set the 'parser' argument to 'liac-arff', which matches the behavior before version 1.2.

I haven't added any tests, but the compatibility behavior is partly tested by the 'other-ml' jobs which require older sklearn versions.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
