### PR TITLE
DOC remove misleading link to error rate parity user guide

### DIFF
--- a/fairlearn/reductions/_moments/error_rate.py
+++ b/fairlearn/reductions/_moments/error_rate.py
@@ -32,8 +32,6 @@ class ErrorRate(ClassificationMoment):
     and false negative errors respectively. The standard misclassification
     error corresponds to :math:`c_{FP}=c_{FN}=1.0`.
 
-    Read more in the :ref:`User Guide <error_rate_parity>`.
-
     Parameters
     ----------
     costs : dict


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description

`ErrorRate` is not the same as `ErrorRateParity`, but the link kind of indicates that it is so it's best to remove it. We don't currently have a user guide for `ErrorRate`, but we should add one.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [ ] user guide added or updated
- [x] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
