### PR TITLE
Amendment to Equal Opportunity Definition

### DIFF
--- a/docs/user_guide/assessment/common_fairness_metrics.rst
+++ b/docs/user_guide/assessment/common_fairness_metrics.rst
@@ -298,8 +298,8 @@ conditional expectations with respect to positive labels, i.e., :math:`Y=1`.
 Another way of thinking about this metric is 
 requiring equal outcomes only within the subset of records belonging to the 
 positive class. In the hiring example, equal opportunity requires that the 
-individuals in group A who are qualified to be hired are just as likely to 
-be chosen as individuals in group B who are qualified to be hired. 
+individuals in *group A* who are qualified to be hired are just as likely to 
+be chosen as individuals in *group B* who are qualified to be hired. 
 However, by not considering whether false 
 positive rates are equivalent across groups, equal opportunity does not 
 capture the costs of missclassification disparities.

--- a/docs/user_guide/assessment/common_fairness_metrics.rst
+++ b/docs/user_guide/assessment/common_fairness_metrics.rst
@@ -297,9 +297,10 @@ conditional expectations with respect to positive labels, i.e., :math:`Y=1`.
 :footcite:p:`hardt2016equality`
 Another way of thinking about this metric is 
 requiring equal outcomes only within the subset of records belonging to the 
-positive class. For example, in the hiring example, equal opportunity 
-requires that the individuals who are actually hired have an equal opportunity 
-of being hired in the first place. However, by not considering whether false 
+positive class. In the hiring example, equal opportunity requires that the 
+individuals in group A who are qualified to be hired are just as likely to 
+be chosen as individuals in group B who are qualified to be hired. 
+However, by not considering whether false 
 positive rates are equivalent across groups, equal opportunity does not 
 capture the costs of missclassification disparities.
 


### PR DESCRIPTION


Addresses Issue #1154 
https://github.com/fairlearn/fairlearn/issues/1154


The old line used "equal opportunity" in the definition of equal opportunity which was a bit confusing.
It also drops the concepts of groups, which the previous section on Equalised Odds was using throughout.

I've made a suggested change that addresses this issue.

@hildeweerts @romanlutz 


## Tests
- [x ] no new tests required

## Documentation
- [x ] user guide added or updated

## Screenshot
![image](https://user-images.githubusercontent.com/1736281/214184759-a2c5c0c8-6130-4e39-aae2-cad54fd5ae35.png)


