### PR TITLE
DOC: Don't generate filename.png for doc build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,3 @@ docbuild/
 
 # Generated API stub files
 docs/api_reference/generated/
-
-# plot_quickstart.py
-**/filename.png

--- a/examples/plot_quickstart.py
+++ b/examples/plot_quickstart.py
@@ -91,4 +91,7 @@ fig = metric_frame.by_group[["count"]].plot(
     figsize=[12, 8],
     title="Show count metric in pie chart",
 )
-fig[0][0].figure.savefig("filename.png")
+
+# Don't save file during doc build
+if "__file__" in locals():
+    fig[0][0].figure.savefig("filename.png")


### PR DESCRIPTION
Fixes #1192 

## Description
Don't generate `filename.png` for doc build

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
