### PR TITLE
[MNT] Fix failing xgboost tests in the otherml test pipeline

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   all-deps:
     strategy:
+      # Keep running remaining matrix jobs even if one fails
+      # to see all issues rather than just the first failure.
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python: ["3.8", "3.9", "3.10"]
@@ -20,6 +23,9 @@ jobs:
   
   minimal-deps:
     strategy:
+      # Keep running remaining matrix jobs even if one fails
+      # to see all issues rather than just the first failure.
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python: ["3.8", "3.9", "3.10"]
@@ -28,9 +34,11 @@ jobs:
       os: ${{ matrix.os }}
       python: ${{ matrix.python }}
 
-  
   other-ml:
     strategy:
+      # Keep running remaining matrix jobs even if one fails
+      # to see all issues rather than just the first failure.
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         python: ["3.8", "3.9", "3.10"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.17.2
-pandas>=0.25.1
+numpy>=1.18.0
+pandas>=0.25.2
 scikit-learn>=0.22.1
-scipy>=1.4.1
+scipy>=1.5.0

--- a/scripts/install_requirements.py
+++ b/scripts/install_requirements.py
@@ -94,7 +94,7 @@ def _install_requirements_file(file_stem, fix_requirements):
     if fix_requirements:
         source_file = f"{file_stem}.{_REQUIREMENTS_EXTENSION}"
         requirements_file = \
-            f"{file_stem}{_INSERTION_FIXED}.{_REQUIREMENTS_EXTENSION}")
+            f"{file_stem}{_INSERTION_FIXED}.{_REQUIREMENTS_EXTENSION}"
         _pin_requirements(source_file, requirements_file)
     else:
         requirements_file = f"{file_stem}.{_REQUIREMENTS_EXTENSION}"

--- a/scripts/install_requirements.py
+++ b/scripts/install_requirements.py
@@ -27,11 +27,6 @@ _REQUIREMENTS_EXTENSION = "txt"
 # names that require an override. The values are the lowest possible override
 # versions that should be used in the pinned requirements files.
 _REQUIREMENTS_FIXED_EXCEPTIONS = {
-    "3.8": {
-        "scipy": "1.5.0",
-        "numpy": "1.18.0",
-        "pandas": "0.25.2"
-    },
     "3.9": {
         "scipy": "1.6.0",
         "numpy": "1.20.0",

--- a/scripts/install_requirements.py
+++ b/scripts/install_requirements.py
@@ -27,8 +27,22 @@ _REQUIREMENTS_EXTENSION = "txt"
 # names that require an override. The values are the lowest possible override
 # versions that should be used in the pinned requirements files.
 _REQUIREMENTS_FIXED_EXCEPTIONS = {
+    "3.8": {
+        "scipy": "1.5.0",
+        "numpy": "1.18.0",
+        "pandas": "0.25.2"
+    },
+    "3.9": {
+        "scipy": "1.6.0",
+        "numpy": "1.20.0",
+        "scikit-learn": "0.24.0",
+        "pandas": "1.1.3"
+    }
     "3.10": {
-        "scipy": "1.7.2"
+        "scipy": "1.7.2",
+        "numpy": "1.22.0",
+        "scikit-learn": "1.1.0",
+        "pandas": "1.3.4"
     }
 }
 

--- a/scripts/install_requirements.py
+++ b/scripts/install_requirements.py
@@ -66,16 +66,16 @@ def _process_line(src_line):
         .get(python_version, {}).get(package_name, None)
     if replacement_version is not None:
         current_version = processed_line.split("==")[1]
-        _logger.debug(f"Replacing {package_name} version {current_version} "
-                      f"with {replacement_version}")
+        _logger.debug("Replacing {0} version {1} with {2}"
+                      .format(package_name, current_version, replacement_version))
         return processed_line.replace(current_version, replacement_version)
     return processed_line
 
 
 def _pin_requirements(src_file, dst_file):
-    with _LogWrapper(f"Pinning {src_file} into {dst_file}"):
+    with _LogWrapper("Pinning {0} into {1}".format(src_file, dst_file)):
 
-        _logger.debug(f"Reading file {src_file}")
+        _logger.debug("Reading file %s", src_file)
         text_lines = []
         with open(src_file, "r") as f:
             text_lines = f.readlines()
@@ -83,13 +83,13 @@ def _pin_requirements(src_file, dst_file):
         result_lines = [
             _process_line(current_line) for current_line in text_lines]
 
-        _logger.debug(f"Writing file {dst_file}")
+        _logger.debug("Writing file %s", dst_file)
         with open(dst_file, "w") as f:
             f.writelines(result_lines)
 
 
 def _install_requirements_file(file_stem, fix_requirements):
-    _logger.info(f"Processing {file_stem}")
+    _logger.info("Processing %s", file_stem)
 
     if fix_requirements:
         source_file = f"{file_stem}.{_REQUIREMENTS_EXTENSION}"
@@ -99,12 +99,12 @@ def _install_requirements_file(file_stem, fix_requirements):
     else:
         requirements_file = f"{file_stem}.{_REQUIREMENTS_EXTENSION}"
 
-    with _LogWrapper(f"Running pip on {requirements_file}"):
+    with _LogWrapper("Running pip on {0}".format(requirements_file)):
         command_args = ["pip", "install", "-r", requirements_file]
         subprocess.check_call(command_args)
 
     if fix_requirements:
-        _logger.info(f"Removing temporary file {requirements_file}")
+        _logger.info("Removing temporary file %s", requirements_file)
         os.remove(requirements_file)
 
 
@@ -115,7 +115,7 @@ def main(argv):
     if args.loglevel:
         logging.basicConfig(level=getattr(logging, args.loglevel))
 
-    _logger.info(f"Pinned set to: {args.pinned}")
+    _logger.info("Pinned set to: %s", args.pinned)
 
     for rs in _REQUIREMENTS_STEMS:
         _install_requirements_file(rs, args.pinned)

--- a/test_othermlpackages/conda-xgboost.yaml
+++ b/test_othermlpackages/conda-xgboost.yaml
@@ -8,7 +8,7 @@ dependencies:
 - pytest
 - pytest-cov
 - xgboost>=1.7.0
-- pandas<1.4 # Capped for xgboost only
+- pandas
 
 # Note xgboost not available for Windows on conda-forge
 # See

--- a/test_othermlpackages/conda-xgboost.yaml
+++ b/test_othermlpackages/conda-xgboost.yaml
@@ -7,7 +7,7 @@ dependencies:
 - pip>=19.1.1
 - pytest
 - pytest-cov
-- xgboost
+- xgboost>=1.7.0
 - pandas<1.4 # Capped for xgboost only
 
 # Note xgboost not available for Windows on conda-forge

--- a/test_othermlpackages/test_xgboost.py
+++ b/test_othermlpackages/test_xgboost.py
@@ -11,20 +11,20 @@ xgb = pytest.importorskip("xgboost")
 
 
 def test_expgrad_classification():
-    estimator = xgb.XGBClassifier(use_label_encoder=False)
+    estimator = xgb.XGBClassifier()
     disparity_moment = DemographicParity()
 
     ptc.run_expgrad_classification(estimator, disparity_moment)
 
 
 def test_gridsearch_classification():
-    estimator = xgb.XGBClassifier(use_label_encoder=False)
+    estimator = xgb.XGBClassifier()
     disparity_moment = DemographicParity()
 
     ptc.run_gridsearch_classification(estimator, disparity_moment)
 
 
 def test_thresholdoptimizer_classification():
-    estimator = xgb.XGBClassifier(use_label_encoder=False)
+    estimator = xgb.XGBClassifier()
 
     ptc.run_thresholdoptimizer_classification(estimator)


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

The xgboost tests are currently failing because `use_label_encoder` is deprecated. From v1.7.0 onwards it should be omitted.

While I check the requirements I also found that we had several packages with minimum versions that are apparently not supported by Python 3.8, so I bumped them.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [x] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
