### PR TITLE
DOC remove multiversion remnants

### DIFF
--- a/docs/contributor_guide/contributing_documentation.rst
+++ b/docs/contributor_guide/contributing_documentation.rst
@@ -94,19 +94,3 @@ To add a citation:
    For example :code:`.. footbibliography::` will be rendered as shown below:
 
    .. footbibliography::
-
-Building the website for all versions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Our documentation build runs for each pull request and upon merging pull
-requests. There should not be a need to run this locally except for very rare
-cases.
-
-To fully build the website for all versions use the following script:
-
-.. code-block::
-
-    make doc
-
-The comprehensive set of commands to build the website is in our CircleCI
-configuration file in the `.circleci` directory of the repository.

--- a/docs/contributor_guide/release.rst
+++ b/docs/contributor_guide/release.rst
@@ -12,7 +12,7 @@ done on a clone of `fairlearn/fairlearn` and not on a fork).
    are up to date. Run `python scripts/generate_maintainers_table.py` from the
    repository root directory. If the generated file
    `docs/about/maintainers.rst` does not change you can proceed with the next
-   step. Otherwise, create PR to update the generated maintainers file on
+   step. Otherwise, create a PR to update the generated maintainers file on
    the `main` branch. Proceed only when the PR is merged.
 
 #. Check the `docs/user_guide/installation_and_version_guide` for a file
@@ -30,7 +30,8 @@ done on a clone of `fairlearn/fairlearn` and not on a fork).
 
         :code:`git push -u origin release/v<x.y>.X`
 
-#. On the release branch, create a PR to update the version in `__init__.py` to `x.y.z` (where `z=0` for the first release from a branch)
+#. On the release branch, create a PR to update the version in `__init__.py`
+   to `x.y.z` (where `z=0` for the first release from a branch)
 
 #. Merge that PR.
 
@@ -49,7 +50,9 @@ done on a clone of `fairlearn/fairlearn` and not on a fork).
 
 #. On `GitHub's release page <https://github.com/fairlearn/fairlearn/releases>`_
    there should be a new release named `v<x.y.z>`.
-   Open it and post the changes from CHANGES.md into the description, then hit "publish".
+   Open it and post the changes from the release file within
+   `docs/user_guide/installation_and_version_guide` into the description, then
+   hit "publish".
 
 #. On the `main` branch, create a PR to:
 


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

closes #1098 
We moved away from sphinx multiversion some time ago. This PR removes the last remnants of sphinx multiversion from our docs. I don't think the release process needs to be adjusted, though. From what I can tell, it is smart enough to update the older versions based on release branches.


## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

contrib guide adjusted

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
