### PR TITLE
MNT add codecov token

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,3 +5,4 @@ codecov:
   notify:
     after_n_builds: 12
     wait_for_ci: true
+  token: 363a2bcc-6585-4bdf-ac2d-3d9cb1bfdecf


### PR DESCRIPTION
As suggested (https://github.com/codecov/codecov-action/issues/837#issuecomment-1453877750), this PR adds the codecov token to our config so that the codecov uploads become more reliable (they're very annoying).

Note that we can't put the token as a secret since secrets are not exposed to PRs from forks.

This does not add a security issue since people can upload coverage to the codecov anyway.