### PR TITLE
DOC update citation

### DIFF
--- a/docs/about/index.rst
+++ b/docs/about/index.rst
@@ -193,14 +193,13 @@ If you wish to cite Fairlearn in your work, please use the following:
 
 .. code ::
 
-    @techreport{bird2020fairlearn,
-        author = {Bird, Sarah and Dud{\'i}k, Miro and Edgar, Richard and Horn, Brandon and Lutz, Roman and Milan, Vanessa and Sameki, Mehrnoosh and Wallach, Hanna and Walker, Kathleen},
-        title = {Fairlearn: A toolkit for assessing and improving fairness in {AI}},
-        institution = {Microsoft},
-        year = {2020},
-        month = {May},
-        url = "https://www.microsoft.com/en-us/research/publication/fairlearn-a-toolkit-for-assessing-and-improving-fairness-in-ai/",
-        number = {MSR-TR-2020-32},
+    @misc{weerts2023fairlearn,
+          title={Fairlearn: Assessing and Improving Fairness of AI Systems}, 
+          author={Hilde Weerts and Miroslav Dudík and Richard Edgar and Adrin Jalali and Roman Lutz and Michael Madaio},
+          year={2023},
+          eprint={2303.16626},
+          archivePrefix={arXiv},
+          primaryClass={cs.LG}
     }
 
 Frequently asked questions


### PR DESCRIPTION

## Description
Adds citation of the preprint of the new Fairlearn paper, standard arXiv style.

Closes #1251

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->

Standard ACM reference would render like this, which looks perfectly fine to me:
<img width="731" alt="image" src="https://github.com/fairlearn/fairlearn/assets/24417440/6b59ad5d-6b86-466d-ac7c-10e1ab8ba25c">
