### PR TITLE
fix show_versions and remove pkg_resources

### DIFF
--- a/fairlearn/show_versions.py
+++ b/fairlearn/show_versions.py
@@ -57,9 +57,6 @@ def _get_deps_info():
         ]
     )
 
-    def get_version(module):
-        return module.__version__
-
     from fairlearn import __version__
     deps_info = {
         "fairlearn": __version__

--- a/fairlearn/show_versions.py
+++ b/fairlearn/show_versions.py
@@ -14,8 +14,10 @@ import sys
 def _get_sys_info():
     """System information.
 
-    :returns: system and Python version information
-    :rtype: dict
+    Returns
+    -------
+    sys_info : dict
+        system and Python version information
     """
     python = sys.version.replace("\n", " ")
 
@@ -31,39 +33,45 @@ def _get_sys_info():
 def _get_deps_info():
     """Overview of the installed version of main dependencies.
 
-    :return: version information on relevant Python libraries
-    :rtype: dict
+    This function does not import the modules to collect the version numbers
+    but instead relies on standard Python package metadata.
+
+    Returns
+    -------
+    deps_info: dict
+        version information on relevant Python libraries
     """
     deps = sorted(
         [
             "pip",
             "setuptools",
-            "sklearn",
             "numpy",
             "scipy",
             "Cython",
             "pandas",
             "matplotlib",
-            "tempeh",
+            "sklearn",
+            "lightgbm",
+            "pytorch",
+            "tensorflow"
         ]
     )
 
     def get_version(module):
         return module.__version__
 
-    deps_info = {}
+    from fairlearn import __version__
+    deps_info = {
+        "fairlearn": __version__
+    }
+
+    from importlib.metadata import PackageNotFoundError, version
 
     for modname in deps:
         try:
-            if modname in sys.modules:
-                mod = sys.modules[modname]
-            else:
-                mod = importlib.import_module(modname)
-            ver = get_version(mod)
-            deps_info[modname] = ver
-        except ImportError:
+            deps_info[modname] = version(modname)
+        except PackageNotFoundError:
             deps_info[modname] = None
-
     return deps_info
 
 
@@ -78,4 +86,4 @@ def show_versions():
 
     print("\nPython dependencies:")
     for k, stat in deps_info.items():
-        print("{k:>10}: {stat}".format(k=k, stat=stat))
+        print("{k:>13}: {stat}".format(k=k, stat=stat))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ filterwarnings = [
     "default:You are about to use a dataset with known fairness issues:Warning",
     "default:Auto-removal of overlapping axes is deprecated:Warning",
     "default:DataFrame is highly fragmented:Warning",
-    "default:Setuptools is replacing distutils:UserWarning",
 
     # Warnings in other-ml (tensorflow)
     "default:The initializer GlorotNormal is unseeded:UserWarning",

--- a/test/unit/postprocessing/test_plots.py
+++ b/test/unit/postprocessing/test_plots.py
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
-import pkg_resources
 import pytest
 
 from fairlearn.postprocessing import ThresholdOptimizer, plot_threshold_optimizer
@@ -43,8 +42,8 @@ def _fit_and_plot(constraints, plotting_data):
 
 def is_mpl_installed():
     try:
-        pkg_resources.get_distribution("pytest-mpl")
-        pkg_resources.get_distribution("matplotlib")
+        import pytest_mpl
+        import matplotlib.pyplot as plt
         return True
     except pkg_resources.DistributionNotFound:
         return False


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description

Addressing #1254 although the tensorflow issue still needs investigating...

- removing usage of `pkg_resources` since it's deprecated.
- updating `show_versions` to be in sync with scikit-learn's function of the same name to resolve failures.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [x] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
