### PR TITLE
MNT Fix lightgbm test

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,7 +22,7 @@ pytest-cov
 pytest-mock
 pytest-mpl>=0.11
 wheel
-lightgbm
+lightgbm<4.0.0  # 4.0.0 is incompatible with latest numpy https://github.com/microsoft/LightGBM/issues/5990
 xlrd
 
 # Required for documentation

--- a/test_othermlpackages/conda-lightgbm.yaml
+++ b/test_othermlpackages/conda-lightgbm.yaml
@@ -10,4 +10,4 @@ dependencies:
 - pytest
 - pytest-cov
 - scikit-learn
-- lightgbm
+- lightgbm<4.0.0  # 4.0.0 is incompatible with latest numpy https://github.com/microsoft/LightGBM/issues/5990


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description

Related to #1254 
This PR fixes an incompatibility between lightgbm and numpy in the latest versions (4.0.0 and 1.25.1, respectively) by prohibiting lightgbm to upgrade to 4.0.0

I validated locally that it fixes the problem. Here's the bug on lightgbm for reference https://github.com/microsoft/LightGBM/issues/5990

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
