### PR TITLE
MNT use older numpy version in tensorflow tests to allow tensorflow to run without deprecation errors

### DIFF
--- a/test_othermlpackages/conda-tensorflow.yaml
+++ b/test_othermlpackages/conda-tensorflow.yaml
@@ -9,4 +9,5 @@ dependencies:
 - pytest-cov
 - tensorflow
 - pip:
+   - numpy==1.21  # latest numpy is incompatible with TF, see https://stackoverflow.com/questions/74852225/attributeerror-module-numpy-has-no-attribute-typedict
    - scikeras[tensorflow-cpu]


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
Related to #1254 
Numpy added errors for using `typeDict` and TF has not updated their code, so our TF tests need to pin numpy at a working version. According to https://stackoverflow.com/questions/74852225/attributeerror-module-numpy-has-no-attribute-typedict 1.21 is such a working version, but the gates will show...

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
