### PR TITLE
MNT fix flake8 issues due to string comparison by using isinstance

### DIFF
--- a/fairlearn/postprocessing/_threshold_optimizer.py
+++ b/fairlearn/postprocessing/_threshold_optimizer.py
@@ -538,7 +538,7 @@ class ThresholdOptimizer(BaseEstimator, MetaEstimatorMixin):
 
         n = len(labels)
 
-        if type(labels) == pd.DataFrame:
+        if isinstance(labels, pd.DataFrame):
             n_positive = labels.sum().loc[0]
         else:
             n_positive = sum(labels)
@@ -712,7 +712,7 @@ def _reformat_data_into_dict(key, data_dict, additional_data):
     dict
         The updated `data_dict` with reformatted data at the `key` slot
     """
-    if type(additional_data) == np.ndarray:
+    if isinstance(additional_data, np.ndarray):
         if len(additional_data.shape) > 2 or (
             len(additional_data.shape) == 2 and additional_data.shape[1] > 1
         ):
@@ -722,14 +722,14 @@ def _reformat_data_into_dict(key, data_dict, additional_data):
             )
         else:
             data_dict[key] = additional_data.squeeze()
-    elif type(additional_data) == pd.DataFrame:
+    elif isinstance(additional_data, pd.DataFrame):
         # TODO: extend to multiple columns for additional_data by using column names
         for attribute_column in additional_data.columns:
             data_dict[key] = additional_data[attribute_column].values
-    elif type(additional_data) == pd.Series:
+    elif isinstance(additional_data, pd.Series):
         data_dict[key] = additional_data.values
-    elif type(additional_data) == list:
-        if type(additional_data[0]) == list:
+    elif isinstance(additional_data, list):
+        if isinstance(additional_data[0], list):
             if len(additional_data[0]) > 1:
                 # TODO: extend to multiple columns for additional_data
                 raise ValueError(


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description

In postprocessing code, we're using `type(object) == Type` instead of `isinstance(object, Type)` which now causes flake8 issues.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
