### PR TITLE
Adding documentation addressing issue 1231

### DIFF
--- a/docs/user_guide/assessment/index.rst
+++ b/docs/user_guide/assessment/index.rst
@@ -11,6 +11,13 @@ fairness metrics, such as demographic parity and equalized odds.
 We will show how :class:`MetricFrame` can be used to evaluate the metrics
 identified during the course of a fairness assessment.
 
+Fairlean provides two primary ways of assessing fairness: :class:`MetricFrame`,
+which can be used to perform disaggregated analysis of a particular performance 
+metric (such as accuracy, false positive rate, etc.) across sensitive 
+groups, and a set of predefined fairness metrics that output a single 
+number. In the :ref:`perform_fairness_assessment`, we will dive further into
+each of these types of fairness assessments. 
+
 In the mathematical definitions below, :math:`X` denotes a feature vector 
 used for predictions, :math:`A` will be a single sensitive feature (such as age 
 or race), and :math:`Y` will be the true label.

--- a/docs/user_guide/assessment/perform_fairness_assessment.rst
+++ b/docs/user_guide/assessment/perform_fairness_assessment.rst
@@ -199,6 +199,11 @@ These are accessed through the :attr:`MetricFrame.by_group` property:
 
 All of these values can be checked against the original arrays above.
 
+Note that :class:`MetricFrame` is intended for analyzing the differences 
+between groups with regard to a base metric, and consequently cannot take 
+predefined fairness metrics, such as :func:`demographic_parity_difference`, 
+as input to the `metrics` parameter.
+
 .. _assessment_compare_harms:
 
 Compare quantified harms across the groups
@@ -277,3 +282,46 @@ overall values for the data:
     dtype: float64
 
 In every case, the *largest* difference and *smallest* ratio are returned.
+
+
+.. _assessment_predefined_fairness_metrics:
+
+Predefined fairness metrics
+---------------------------
+
+In addition to the disaggregated analysis of base metrics enabled by
+:class:`MetricFrame`, Fairlearn also provides a set of predefined fairness 
+metrics that output a single score. These metrics take as input 
+`sensitive_features` to compute the maximum difference or ratio between 
+subgroups of a sensitive variable. The predefined fairness metrics offered 
+by Fairlearn are **demographic parity** ratio/difference and **equalized odds** 
+ratio/difference. Note that because these metrics are calculated using 
+aggregations between groups (unlike, say, accuracy, the demographic parity 
+for one subgroup versus another does not make sense), they are meant to be 
+called directly, rather than used within the instantiation of a MetricFrame.
+
+Below, we show an example of calculating demographic parity ratio using the 
+sample data defined above.
+
+.. doctest:: assessment_metrics
+    :options:  +NORMALIZE_WHITESPACE
+
+    >>> from fairlearn.metrics import demographic_parity_ratio
+    >>> print(demographic_parity_ratio(y_true,
+    ...                                y_pred,
+    ...                                sensitive_features=sf_data))
+    0.66666...
+
+Note that to achieve a one-number score for a standard performance metric,
+like false positive rate or selection rate, the user must use the MetricFrame 
+data structure. Under the hood, the fairness assessment metrics also use 
+:class:`MetricFrame` to compute a particular base rate across sensitive 
+groups and subsequently perform an aggregation (the difference or ratio) 
+on the base metric values across groups. For example, 
+:func:`equalized_odds_ratio` uses both the :func:`false_positive_rate` and
+:func:`false_negative_rate` within a MetricFrame on the backend to generate 
+an output.
+
+:ref:`common_fairness_metrics` provides an overview of common metrics used 
+in fairness analyses. For a deep dive into how to extend the capabilities of 
+fairness metrics provided by Fairlearn, review :ref:`custom_fairness_metrics`.


### PR DESCRIPTION
## Description
This PR adds information about the distinction between MetricFrame and the predefined fairness metrics to the User Guide. It references open issue #1231 and closed issue #1222. I welcome all recommendations on feedback to the wording. I also added a code snippet that is duplicative of the code in "Common Fairness Metrics" to clarify the documentation, but we can remove it if it does not add anything. Tagging @hildeweerts and @romanlutz (@riedgar-ms I accidentally tagged you as a reviewer but please disregard)

## Tests
- [X] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
- [ ] no documentation changes needed
- [X] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
![image](https://github.com/fairlearn/fairlearn/assets/15962391/e69640f4-6b49-4a6e-9109-4bf5badf4f30)
![image](https://github.com/fairlearn/fairlearn/assets/15962391/77c5718a-af49-4e87-be4b-9829cf3aee9b)
