### PR TITLE
Fix fetch_openml

### DIFF
--- a/fairlearn/datasets/_fetch_adult.py
+++ b/fairlearn/datasets/_fetch_adult.py
@@ -5,8 +5,6 @@ import pathlib
 
 from sklearn.datasets import fetch_openml
 
-import fairlearn.utils._compatibility as compat
-
 from ._constants import _DOWNLOAD_DIRECTORY_NAME
 
 
@@ -103,9 +101,9 @@ def fetch_adult(*, cache=True, data_home=None, as_frame=True, return_X_y=False):
 
     return fetch_openml(
         data_id=1590,
-        data_home=data_home,
+        data_home=str(data_home),
         cache=cache,
         as_frame=as_frame,
         return_X_y=return_X_y,
-        **compat._PARSER_KWARG,
+        parser="auto",
     )


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description

It appears that `fetch_openml()` no longer likes `pathlib.Path` objects. I have filed [an issue on SciKit-Learn](https://github.com/scikit-learn/scikit-learn/issues/27447) about this, but in the meantime.....

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
