### PR TITLE
MNT update linter versions

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -28,4 +28,4 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: psf/black@23.3.0
+      - uses: psf/black@23.9.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,15 +13,15 @@ repos:
 # requirements-dev.txt
 # linting.yml
 # .pre-commit-config.yaml
-    rev: 23.3.0
+    rev: 23.9.1
     hooks:
     -   id: black
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+-   repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
     hooks:
     -   id: flake8
         types: [file, python]
 -   repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     -   id: isort

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -14,9 +14,9 @@ from fairlearn.utils._input_manipulations import _convert_to_ndarray_and_squeeze
 
 from ._annotated_metric_function import AnnotatedMetricFunction
 from ._disaggregated_result import (
-    DisaggregatedResult,
-    _VALID_ERROR_STRING,
     _INVALID_ERRORS_VALUE_ERROR_MESSAGE,
+    _VALID_ERROR_STRING,
+    DisaggregatedResult,
 )
 from ._group_feature import GroupFeature
 
@@ -75,12 +75,10 @@ def _deprecate_metric_frame_init(new_metric_frame_init):
         if len(args) > 0:
             args_msg = ", ".join([f"'{name}'" for name in positional_dict.keys()])
             warnings.warn(
-                (
-                    f"You have provided {args_msg} as positional arguments. "
-                    "Please pass them as keyword arguments. From version "
-                    f"{version} passing them as positional arguments "
-                    "will result in an error."
-                ),
+                f"You have provided {args_msg} as positional arguments. "
+                "Please pass them as keyword arguments. From version "
+                f"{version} passing them as positional arguments "
+                "will result in an error.",
                 FutureWarning,
             )
 
@@ -89,12 +87,10 @@ def _deprecate_metric_frame_init(new_metric_frame_init):
         if metric is not None:
             metric_arg_dict = {"metrics": metric}
             warnings.warn(
-                (
-                    "The positional argument 'metric' has been replaced "
-                    "by a keyword argument 'metrics'. "
-                    f"From version {version} passing it as a positional argument "
-                    "or as a keyword argument 'metric' will result in an error"
-                ),
+                "The positional argument 'metric' has been replaced "
+                "by a keyword argument 'metrics'. "
+                f"From version {version} passing it as a positional argument "
+                "or as a keyword argument 'metric' will result in an error",
                 FutureWarning,
             )
 

--- a/fairlearn/postprocessing/_interpolated_thresholder.py
+++ b/fairlearn/postprocessing/_interpolated_thresholder.py
@@ -101,12 +101,10 @@ class InterpolatedThresholder(BaseEstimator, MetaEstimatorMixin):
 
         if self.predict_method == "deprecated":
             warn(
-                (
-                    "'predict_method' default value is changed from 'predict' to "
-                    "'auto'. Explicitly pass `predict_method='predict' to "
-                    "replicate the old behavior, or pass `predict_method='auto' "
-                    "or other valid values to silence this warning."
-                ),
+                "'predict_method' default value is changed from 'predict' to "
+                "'auto'. Explicitly pass `predict_method='predict' to "
+                "replicate the old behavior, or pass `predict_method='auto' "
+                "or other valid values to silence this warning.",
                 FutureWarning,
             )
             self._predict_method = "predict"

--- a/fairlearn/postprocessing/_threshold_optimizer.py
+++ b/fairlearn/postprocessing/_threshold_optimizer.py
@@ -178,21 +178,21 @@ class ThresholdOptimizer(BaseEstimator, MetaEstimatorMixin):
         values.
 
             'auto'
-                use one of :code:`predict_proba`, :code:`decision_function`, or 
+                use one of :code:`predict_proba`, :code:`decision_function`, or
                 :code:`predict`, in that order.
-            
+
             'predict_proba'
-                use the second column from the output of :code:`predict_proba`. 
-                It is assumed that the second column represents the positive 
+                use the second column from the output of :code:`predict_proba`.
+                It is assumed that the second column represents the positive
                 outcome.
-            
+
             'decision_function'
                 use the raw values given by the :code:`decision_function`.
-            
+
             'predict'
-                use the hard values reported by the :code:`predict` method if 
-                estimator is a classifier, and the regression values if 
-                estimator is a regressor. This is equivalent to what 
+                use the hard values reported by the :code:`predict` method if
+                estimator is a classifier, and the regression values if
+                estimator is a regressor. This is equivalent to what
                 is done in [1]_.
 
         .. versionadded:: 0.7
@@ -290,12 +290,10 @@ class ThresholdOptimizer(BaseEstimator, MetaEstimatorMixin):
 
         if self.predict_method == "deprecated":
             warn(
-                (
-                    "'predict_method' default value is changed from 'predict' to "
-                    "'auto'. Explicitly pass `predict_method='predict' to "
-                    "replicate the old behavior, or pass `predict_method='auto' "
-                    "or other valid values to silence this warning."
-                ),
+                "'predict_method' default value is changed from 'predict' to "
+                "'auto'. Explicitly pass `predict_method='predict' to "
+                "replicate the old behavior, or pass `predict_method='auto' "
+                "or other valid values to silence this warning.",
                 FutureWarning,
             )
             self._predict_method = "predict"

--- a/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
+++ b/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
@@ -211,10 +211,8 @@ class ExponentiatedGradient(BaseEstimator, MetaEstimatorMixin):
                 gaps.append(gap_LP)
 
             logger.debug(
-                (
-                    "%seta=%.6f, L_low=%.3f, L=%.3f, L_high=%.3f, gap=%.6f, disp=%.3f, "
-                    "err=%.3f, gap_LP=%.6f"
-                ),
+                "%seta=%.6f, L_low=%.3f, L=%.3f, L_high=%.3f, gap=%.6f, disp=%.3f, "
+                "err=%.3f, gap_LP=%.6f",
                 _INDENTATION,
                 eta,
                 result_EG.L_low,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ requirements-parser
 # requirements-dev.txt
 # linting.yml
 # .pre-commit-config.yaml
-black==23.3.0
+black==23.9.1
 
 # Required for test
 pytest==7.2.0


### PR DESCRIPTION
Updating linter versions, and flake8 has moved to github. Will do another PR to move to `ruff` instead for `isort` and `flake8`.