### PR TITLE
Bump Python for OtherML packages

### DIFF
--- a/test_othermlpackages/conda-lightgbm.yaml
+++ b/test_othermlpackages/conda-lightgbm.yaml
@@ -3,11 +3,11 @@ channels:
 - defaults
 - conda-forge
 dependencies:
-- python==3.8
+- python==3.11
 - pip>=19.1.1
 - numpy
 - pandas
 - pytest
 - pytest-cov
 - scikit-learn
-- lightgbm<4.0.0  # 4.0.0 is incompatible with latest numpy https://github.com/microsoft/LightGBM/issues/5990
+- lightgbm

--- a/test_othermlpackages/conda-pytorch.yaml
+++ b/test_othermlpackages/conda-pytorch.yaml
@@ -4,7 +4,7 @@ channels:
 - conda-forge
 - pytorch
 dependencies:
-- python==3.8
+- python==3.11
 - pip>=19.1.1
 - pytest
 - pytest-cov

--- a/test_othermlpackages/conda-tensorflow.yaml
+++ b/test_othermlpackages/conda-tensorflow.yaml
@@ -3,11 +3,10 @@ channels:
 - defaults
 - conda-forge
 dependencies:
-- python==3.8
+- python>=3.10
 - pip>=19.1.1
 - pytest
 - pytest-cov
 - tensorflow
 - pip:
-   - numpy==1.21  # latest numpy is incompatible with TF, see https://stackoverflow.com/questions/74852225/attributeerror-module-numpy-has-no-attribute-typedict
    - scikeras[tensorflow-cpu]

--- a/test_othermlpackages/conda-xgboost.yaml
+++ b/test_othermlpackages/conda-xgboost.yaml
@@ -3,7 +3,7 @@ channels:
 - defaults
 - conda-forge
 dependencies:
-- python==3.8
+- python==3.11
 - pip>=19.1.1
 - pytest
 - pytest-cov


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

Bump the version of Python used by the Conda files in `test_othermlpackages`. For all except TensorFlow, this involves going to Python 3.11; Tensorflow only seems to work with Python 3.10.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
