### PR TITLE
MNT Fixing pandas

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
         requirementsPinned: ["false"]
     uses: ./.github/workflows/test-all-deps.yml
     with:
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
     uses: ./.github/workflows/test-minimal-deps.yml
     with:
       os: ${{ matrix.os }}
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ["3.8"]
+        python: ["3.11"]
         mlpackage: [lightgbm, xgboost, tensorflow, pytorch]
     uses: ./.github/workflows/test-other-ml.yml
     with:
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ["3.9"]
+        python: ["3.11"]
     uses: ./.github/workflows/linting.yml
     with:
       os: ${{ matrix.os }}

--- a/fairlearn/metrics/_disaggregated_result.py
+++ b/fairlearn/metrics/_disaggregated_result.py
@@ -172,7 +172,9 @@ class DisaggregatedResult:
             elif errors == "coerce":
                 # Fill all impossible columns with NaN before grouping metric frame
                 mf = self.by_group.copy()
-                mf = mf.apply(lambda x: x.apply(lambda y: y if np.isscalar(y) else np.nan))
+                mf = mf.apply(
+                    lambda x: x.apply(lambda y: y if np.isscalar(y) else np.nan)
+                )
                 if grouping_function == "min":
                     result = mf.groupby(level=control_feature_names).min()
                 else:
@@ -233,7 +235,7 @@ class DisaggregatedResult:
         # Can assume errors='coerce', else error would already have been raised in .group_min
         # Fill all non-scalar values with NaN
         mf = mf.apply(lambda x: x.apply(lambda y: y if np.isscalar(y) else np.nan))
-        
+
         if control_feature_names is None:
             result = (mf - subtrahend).abs().max()
         else:

--- a/fairlearn/metrics/_disaggregated_result.py
+++ b/fairlearn/metrics/_disaggregated_result.py
@@ -172,7 +172,7 @@ class DisaggregatedResult:
             elif errors == "coerce":
                 # Fill all impossible columns with NaN before grouping metric frame
                 mf = self.by_group.copy()
-                mf = mf.map(lambda x: x if np.isscalar(x) else np.nan)
+                mf = mf.apply(lambda x: x.apply(lambda y: y if np.isscalar(y) else np.nan))
                 if grouping_function == "min":
                     result = mf.groupby(level=control_feature_names).min()
                 else:
@@ -232,8 +232,8 @@ class DisaggregatedResult:
         mf = self.by_group.copy()
         # Can assume errors='coerce', else error would already have been raised in .group_min
         # Fill all non-scalar values with NaN
-        mf = mf.map(lambda x: x if np.isscalar(x) else np.nan)
-
+        mf = mf.apply(lambda x: x.apply(lambda y: y if np.isscalar(y) else np.nan))
+        
         if control_feature_names is None:
             result = (mf - subtrahend).abs().max()
         else:

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -362,7 +362,13 @@ class MetricFrame:
         self, target: Union[pd.Series, pd.DataFrame]
     ) -> Union[pd.Series, pd.DataFrame]:
         """Convert Nones to NaNs."""
-        result = target.map(lambda x: x if x is not None else np.nan)
+        # Ideally, we wouldn't care about Series vs DataFrame
+        # However, DataFrame.map() didn't appear until Pandas 2.1
+        # Before, it was DataFrame.applymap() which then got deprecated
+        if isinstance(target, pd.Series):
+            result = target.map(lambda x: x if x is not None else np.nan)
+        else:
+            result = target.apply(lambda x: x.apply(lambda y: y if np.isscalar(y) else np.nan))
         return result
 
     def _populate_results(self, raw_result: DisaggregatedResult):

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -368,7 +368,9 @@ class MetricFrame:
         if isinstance(target, pd.Series):
             result = target.map(lambda x: x if x is not None else np.nan)
         else:
-            result = target.apply(lambda x: x.apply(lambda y: y if np.isscalar(y) else np.nan))
+            result = target.apply(
+                lambda x: x.apply(lambda y: y if np.isscalar(y) else np.nan)
+            )
         return result
 
     def _populate_results(self, raw_result: DisaggregatedResult):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 88
-target_version = ['py37', 'py38', 'py39', 'py310', 'py311']
+target_version = ['py38', 'py39', 'py310', 'py311']
 preview = true
 extend-exclude = '''
 (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.18.0
-pandas>=0.25.2
+pandas>=2
 scikit-learn>=1.2.1
 scipy>=1.5.0

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

The recent `pandas` 2.1 release has simultaneously introduced a new `DataFrame.map()` API, and deprecated the `DataFrame.applymap()` API which we use in `MetricFrame`. Since our builds fail on warnings, this left us with a conundrum. This PR (temporarily) solves this by changing the `DataFrame.applymap()` calls to a nested `DataFrame.apply()` pattern. This is not particularly great, but this should not be being used in performance-critical portions of `MetricFrame` and can suffice until we decide to require `pandas` be at least version 2.1.

Also make sure that Python 3.7 is fully excised and add 3.11 to the regular builds and setup.

Issue #1299 exists to track the need to tidy all of this up once we drop `pandas` v2.0 support.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [ ] new tests added
- [x] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
