### PR TITLE
MNT Further build fixes

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,6 +29,7 @@ jobs:
       os: ${{ matrix.os }}
       python: ${{ matrix.python }}
       requirementsPinned: ${{ matrix.requirementsPinned }}
+      codeCovPython: "3.11"
   
   minimal-deps:
     strategy:

--- a/.github/workflows/test-all-deps.yml
+++ b/.github/workflows/test-all-deps.yml
@@ -34,8 +34,8 @@ jobs:
       - run: pip install matplotlib
       - run: pytest --ignore=test/install --cov=fairlearn --cov-report=xml test/
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
         if: ${{ inputs.codeCovPython == inputs.python }}
+        uses: codecov/codecov-action@v3
         with:
           env_vars: OS,PYTHON
           fail_ci_if_error: true

--- a/.github/workflows/test-all-deps.yml
+++ b/.github/workflows/test-all-deps.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
         default: "false"
+      codeCovPython:
+        required: true
+        type: string
+        default: "3.11"
 
 jobs:
   all-deps:
@@ -31,6 +35,7 @@ jobs:
       - run: pytest --ignore=test/install --cov=fairlearn --cov-report=xml test/
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+        if: ${{ inputs.codeCovPython == inputs.python }}
         with:
           env_vars: OS,PYTHON
           fail_ci_if_error: true

--- a/.github/workflows/test-other-ml.yml
+++ b/.github/workflows/test-other-ml.yml
@@ -42,7 +42,8 @@ jobs:
           source /usr/share/miniconda/etc/profile.d/conda.sh
           conda activate $condaEnv
           conda list
-          python -m pytest --cov=fairlearn --cov-report=xml $baseDir/test_${{inputs.mlpackage}}.py 
+          # Override the filterwarnings set in the TOML file
+          python -m pytest -o filterwarnings=default --cov=fairlearn --cov-report=xml $baseDir/test_${{inputs.mlpackage}}.py 
         name: Run ${{matrix.mlpackage}} tests
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/test_othermlpackages/conda-lightgbm.yaml
+++ b/test_othermlpackages/conda-lightgbm.yaml
@@ -6,7 +6,7 @@ dependencies:
 - python==3.11
 - pip>=19.1.1
 - numpy
-- pandas<2.1
+- pandas
 - pytest
 - pytest-cov
 - scikit-learn

--- a/test_othermlpackages/conda-lightgbm.yaml
+++ b/test_othermlpackages/conda-lightgbm.yaml
@@ -6,7 +6,7 @@ dependencies:
 - python==3.11
 - pip>=19.1.1
 - numpy
-- pandas
+- pandas<2.1
 - pytest
 - pytest-cov
 - scikit-learn


### PR DESCRIPTION
## Description

Taking another swing at getting our builds to Green. There are two changes:

- I saw errors from CodeCov about 'too many uploads for commit.' Since we don't have different code paths based on Python version, I've tweaked the CodeCov step so that it only runs for Python 3.11
- The `test_otherml` directory was still getting warnings. Since those dependencies are not entirely under our control, my solution is to override the `pyproject.toml` and "Treat Warnings as Warnings." I know that this is not ideal, but short of unpicking the exact combination of packages which get installed, it's probably the most robust solution

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
