### PR TITLE
MNT Release pytest-mpl bound

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,7 +25,7 @@ black==23.9.1
 pytest==7.2.0
 pytest-cov
 pytest-mock
-pytest-mpl>=0.16.1
+pytest-mpl
 wheel
 lightgbm<4.0.0  # 4.0.0 is incompatible with latest numpy https://github.com/microsoft/LightGBM/issues/5990  Needs to sync with .github/workflows/release-wheel.yml
 xlrd

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,7 +25,7 @@ black==23.9.1
 pytest==7.2.0
 pytest-cov
 pytest-mock
-pytest-mpl>=0.11
+pytest-mpl>=0.16.1
 wheel
 lightgbm<4.0.0  # 4.0.0 is incompatible with latest numpy https://github.com/microsoft/LightGBM/issues/5990  Needs to sync with .github/workflows/release-wheel.yml
 xlrd


### PR DESCRIPTION
## Description

Yet another hack at our Nightly build. I'm not sure why `pytest-mpl` had a lower bound, but it was quite old. Remove it entirely, in the hopes of killing off another warning-as-error (which was actually coming from what appears to be the expected `pytest-mpl` workflow).

The errors being generated were of the form:
```
FAILED test/unit/postprocessing/test_plots.py::TestPlots::test_plot_equalized_odds_ex1 - pytest.PytestReturnNotNoneWarning: Expected None, but test/unit/postprocessing/test_plots.py::TestPlots::test_plot_equalized_odds_ex1 returned <Figure size 640x480 with 1 Axes>, which will be an error in a future version of pytest.  Did you mean to use assert instead of return?
```
I suspect that a later version of `pytest-mpl` 'knows' how to suppress this (since the return-from-test-function looks like the required workflow), but our 'pinned' build was getting the older version.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
