### PR TITLE
Bump documentation and test dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ docbuild/
 
 # Generated API stub files
 docs/api_reference/generated/
+
+# Doc build generated files
+*.pkl

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,6 @@ else:
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "bokeh.sphinxext.bokeh_plot",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.doctest",
@@ -99,10 +98,6 @@ autosummary_generate = True
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "README.rst"]
 
 master_doc = "index"
-
-if fairlearn.__version__ == "0.4.6":
-    print("Current version is v0.4.6, will apply overrides")
-    master_doc = "index"
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -204,5 +204,5 @@ What's next?
 Please refer to our :ref:`user_guide` for a comprehensive view on Fairness in
 Machine Learning and how Fairlearn fits in, as well as an exhaustive guide on
 all parts of the toolkit. For concrete examples check out the
-:ref:`sphx_glr_auto_examples` section. Finally, we also have a collection
+:ref:`examples` section. Finally, we also have a collection
 of :ref:`faq`.

--- a/docs/user_guide/datasets/acs_income.rst
+++ b/docs/user_guide/datasets/acs_income.rst
@@ -1,4 +1,5 @@
 .. _acsincome_data:
+
 ACSIncome
 ---------
 

--- a/docs/user_guide/datasets/adult_data.rst
+++ b/docs/user_guide/datasets/adult_data.rst
@@ -1,4 +1,5 @@
 .. _adult_data:
+
 Adult Census Dataset
 --------------------
 

--- a/docs/user_guide/datasets/diabetes_hospital_data.rst
+++ b/docs/user_guide/datasets/diabetes_hospital_data.rst
@@ -118,8 +118,7 @@ contains 25 features, which we describe below:
          - None
 
    *  - A1Cresult
-      - Indicates the range of the result in percentages or if the A1c test was
-        not taken:
+      - Indicates the range of the result in percentages or if the A1c test was not taken:
          - >7 (greater than 7%, but less than 8%)
          - >8 (greater than 8%)
          - Norm (indicating normal, which is less than 7%)

--- a/docs/user_guide/installation_and_version_guide/v0.5.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.5.0.rst
@@ -154,7 +154,7 @@ remain.
 
 For an introduction to all the new features, see the 
 :ref:`sphx_glr_auto_examples_plot_new_metrics.py` example in
-:ref:`sphx_glr_auto_examples`.
+:ref:`examples`.
 
 
 Renamed object attributes

--- a/docs/user_guide/installation_and_version_guide/v0.7.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.7.0.rst
@@ -16,6 +16,6 @@ v0.7.0
 * Removed :code:`fairlearn.widgets` module including the
   :code:`FairlearnDashboard`.
   Instead, the :class:`fairlearn.metrics.MetricFrame` supports plotting as
-  explained in :ref:`plot`.
+  explained in :ref:`plot_metricframe`.
 * Added return value (:code:`self`) to
   :class:`fairlearn.reductions.ExponentiatedGradient`'s :code:`fit` method.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,10 +19,10 @@ requirements-parser
 # requirements-dev.txt
 # linting.yml
 # .pre-commit-config.yaml
-black==23.9.1
+black==23.10.0
 
 # Required for test
-pytest==7.2.0
+pytest==7.4.2
 pytest-cov
 pytest-mock
 pytest-mpl
@@ -31,12 +31,11 @@ lightgbm<4.0.0  # 4.0.0 is incompatible with latest numpy https://github.com/mic
 xlrd
 
 # Required for documentation
-bokeh
 pypandoc
-sphinx==4.5.0
+sphinx==7.2.6
 sphinx-gallery
 numpydoc
-pydata-sphinx-theme==0.13.3
+pydata-sphinx-theme==0.14.1
 sphinx-autodoc-typehints
 sphinxcontrib-bibtex
 packaging


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
This is our periodic update of pytest, black, sphinx, and pydata-sphinx-theme to latest versions.

While I was at it, I cleaned up unnecessary things like v0.4.6-specific code in the doc build, indentation warnings in the doc build, empty line warnings in the doc build, and broken refs.

For validation, I ran the doc build, pytest, and doctest locally. I checked several pages locally to make sure everything is as expected. The theme update changes some things visually but it all seems in order. The only thing that perhaps seems a little off is the positioning of the version picker: 
![image](https://github.com/fairlearn/fairlearn/assets/10245648/b4f68113-18e5-4979-a674-97fd1c2de688)
compared with the currently deployed version:
![image](https://github.com/fairlearn/fairlearn/assets/10245648/cac19347-7e58-4c2f-96fc-c0b5915f7b93)



## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
 see above