### PR TITLE
MNT CodeCov Fixes

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -40,6 +40,7 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python: ${{ matrix.python }}
+      codeCovPython: "3.11"
 
   
   other-ml:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,6 +34,7 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python: ${{ matrix.python }}
+      codeCovPython: "3.11"
 
   other-ml:
     strategy:

--- a/.github/workflows/test-minimal-deps.yml
+++ b/.github/workflows/test-minimal-deps.yml
@@ -9,6 +9,10 @@ on:
       python:
         required: true
         type: string
+      codeCovPython:
+        required: true
+        type: string
+        default: "3.11"
 
 jobs:
   minimal-deps:

--- a/.github/workflows/test-minimal-deps.yml
+++ b/.github/workflows/test-minimal-deps.yml
@@ -26,6 +26,7 @@ jobs:
       - run: pytest --cov=fairlearn --cov-report=xml test/install
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+        if: ${{ inputs.codeCovPython == inputs.python }}
         with:
           env_vars: OS,PYTHON
           fail_ci_if_error: true


### PR DESCRIPTION
## Description

I'm seeing more whining from CodeCov about too many results for a single commit. Extend the 'single version of Python' filter to the `minimal-deps` portion of the build.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
