### PR TITLE
MNT Fix Nightly Builds

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -30,6 +30,7 @@ jobs:
       python: ${{ matrix.python }}
       requirementsPinned: ${{ matrix.requirementsPinned }}
       codeCovPython: "3.11"
+      codeCovOS: "ubuntu-latest"
   
   minimal-deps:
     strategy:
@@ -41,6 +42,7 @@ jobs:
       os: ${{ matrix.os }}
       python: ${{ matrix.python }}
       codeCovPython: "3.11"
+      codeCovOS: "ubuntu-latest"
 
   
   other-ml:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,6 +21,7 @@ jobs:
       python: ${{ matrix.python }}
       requirementsPinned: ${{ matrix.requirementsPinned }}
       codeCovPython: "3.11"
+      codeCovOS: "ubuntu-latest"
   
   minimal-deps:
     strategy:
@@ -35,6 +36,7 @@ jobs:
       os: ${{ matrix.os }}
       python: ${{ matrix.python }}
       codeCovPython: "3.11"
+      codeCovOS: "ubuntu-latest"
 
   other-ml:
     strategy:

--- a/.github/workflows/test-all-deps.yml
+++ b/.github/workflows/test-all-deps.yml
@@ -17,6 +17,10 @@ on:
         required: true
         type: string
         default: "3.11"
+      codeCovOS:
+        required: true
+        type: string
+        default: "ubuntu-latest"
 
 jobs:
   all-deps:
@@ -34,7 +38,7 @@ jobs:
       - run: pip install matplotlib
       - run: pytest --ignore=test/install --cov=fairlearn --cov-report=xml test/
       - name: Upload coverage to Codecov
-        if: ${{ inputs.codeCovPython == inputs.python }}
+        if: ${{ (inputs.codeCovPython == inputs.python) && (inputs.codeCovOS == inputs.os) }}
         uses: codecov/codecov-action@v3
         with:
           env_vars: OS,PYTHON

--- a/.github/workflows/test-minimal-deps.yml
+++ b/.github/workflows/test-minimal-deps.yml
@@ -13,6 +13,10 @@ on:
         required: true
         type: string
         default: "3.11"
+      codeCovOS:
+        required: true
+        type: string
+        default: "ubuntu-latest"
 
 jobs:
   minimal-deps:
@@ -30,7 +34,7 @@ jobs:
       - run: pytest --cov=fairlearn --cov-report=xml test/install
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
-        if: ${{ inputs.codeCovPython == inputs.python }}
+        if: ${{ (inputs.codeCovPython == inputs.python) && (inputs.codeCovOS == inputs.os) }}
         with:
           env_vars: OS,PYTHON
           fail_ci_if_error: true


### PR DESCRIPTION
## Description

Nightly builds are failing again due to CodeCov not liking how many different results we upload. Scale back again, to only upload the Ubuntu results.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
