### PR TITLE
Setting up the landing page for version release and prep for v0.11.0

### DIFF
--- a/docs/_static/versions.json
+++ b/docs/_static/versions.json
@@ -2,7 +2,7 @@
     {
         "name": "v0.10.0 (stable)",
         "version": "0.10.0",
-        "url": "https://fairlearn.org/v0.10.0/"
+        "url": "https://fairlearn.org/v0.10/"
     },
     {
         "name": "v0.9.0",

--- a/docs/_static/versions.json
+++ b/docs/_static/versions.json
@@ -1,6 +1,11 @@
 [
     {
-        "name": "v0.9.0 (stable)",
+        "name": "v0.10.0 (stable)",
+        "version": "0.10.0",
+        "url": "https://fairlearn.org/v0.10.0/"
+    },
+    {
+        "name": "v0.9.0",
         "version": "0.9.0",
         "url": "https://fairlearn.org/v0.9/"
     },
@@ -30,8 +35,8 @@
         "url": "https://fairlearn.org/v0.4.6/"
     },
     {
-        "name": "v0.10.0 (dev)",
-        "version": "0.10.0",
+        "name": "v0.11.0 (dev)",
+        "version": "0.11.0",
         "url": "https://fairlearn.org/main/"
     }
 ]

--- a/docs/static_landing_page/js/landing_page.js
+++ b/docs/static_landing_page/js/landing_page.js
@@ -148,7 +148,7 @@ $(document).ready(function () {
 
 async function setLinks() {
   // update this version with every release
-  const latestVersion = 'v0.10';
+  const latestVersion = 'v0.10'; // Do not include the patch
   const prefix = "./" + latestVersion;
 
   const contribGuideLink = prefix + "/contributor_guide/index.html";

--- a/docs/static_landing_page/js/landing_page.js
+++ b/docs/static_landing_page/js/landing_page.js
@@ -148,7 +148,7 @@ $(document).ready(function () {
 
 async function setLinks() {
   // update this version with every release
-  const latestVersion = 'v0.10.0'; // Do not include the patch
+  const latestVersion = 'v0.10';
   const prefix = "./" + latestVersion;
 
   const contribGuideLink = prefix + "/contributor_guide/index.html";

--- a/docs/static_landing_page/js/landing_page.js
+++ b/docs/static_landing_page/js/landing_page.js
@@ -148,7 +148,7 @@ $(document).ready(function () {
 
 async function setLinks() {
   // update this version with every release
-  const latestVersion = 'v0.9'; // Do not include the patch
+  const latestVersion = 'v0.10.0'; // Do not include the patch
   const prefix = "./" + latestVersion;
 
   const contribGuideLink = prefix + "/contributor_guide/index.html";

--- a/docs/user_guide/installation_and_version_guide/v0.10.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.10.0.rst
@@ -3,9 +3,6 @@ v0.10.0
 
 .. note::
 
-   v0.10.0 is not yet released. This page reflects changes on the current
-   :code:`main` branch that will eventually be a part of v0.10.0.
-
 * Added bootstrapping to :class:`MetricFrame`, along with a new section
   in the user guide
 * Added intersectionality in mental health care example notebook.

--- a/docs/user_guide/installation_and_version_guide/v0.11.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.11.0.rst
@@ -1,0 +1,7 @@
+v0.11.0
+=======
+
+.. note::
+
+   v0.11.0 is not yet released. This page reflects changes on the current
+   :code:`main` branch that will eventually be a part of v0.11.0.

--- a/fairlearn/__init__.py
+++ b/fairlearn/__init__.py
@@ -10,7 +10,7 @@ import os
 from .show_versions import show_versions  # noqa: F401
 
 __name__ = "fairlearn"
-__version__ = "0.10.0.dev0"
+__version__ = "0.11.0.dev0"
 _base_version = __version__  # To enable the v0.4.6 docs
 
 # Setup logging infrastructure


### PR DESCRIPTION
I pushed through the v11 release and am at the last step. I followed the steps in the release guide:
1. Update the version in __init__.py to 0.11.0.dev0
2. Update the version in docs/static_landing_page/js/landing_page.js so that all the links point to the new release
4. Update the docs/_static/versions.json file
6. Create a new file 0.11.0.rst in docs/user_guide/installation_and_version_guide

@riedgar-ms, please take a look and let me know if everything looks correct!

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [X] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [X] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated
