### PR TITLE
MetricFrame: docstring update for usage with selection_metric

### DIFF
--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -154,7 +154,7 @@ class MetricFrame:
     >>> from fairlearn.metrics import MetricFrame, selection_rate
     >>> from sklearn.metrics import accuracy_score
     >>> import pandas as pd
-    >>> y_true = [1,1,1,1,1,0,0,1,1,0]
+    >>> y_true = [1,1,1,1,1,0,0,0,0,0]
     >>> y_pred = [0,1,1,1,1,0,0,0,1,1]
     >>> sex = ['Female']*5 + ['Male']*5
     >>> metrics = {"selection_rate": selection_rate}


### PR DESCRIPTION
## Description

I am aware that the value itself of `y_true` doesn't matter for `selection_rate`. However, as a beginner it confused me when I was going through the examples for `MetricFrame` and the value of `y_true` not matching with the sample data in `sex`.

Hope the change makes sense, worst case my (mis)understanding will be clarified, thanks.

## Tests
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [ ] user guide added or updated
- [x] API docs added or updated
- [ ] example notebook added or updated

## Screenshots