### PR TITLE
Fixed missing parenthesis in the Equalized odds formula

### DIFF
--- a/docs/user_guide/assessment/common_fairness_metrics.rst
+++ b/docs/user_guide/assessment/common_fairness_metrics.rst
@@ -225,8 +225,8 @@ conditionally independent of the sensitive feature :math:`A` given the label
 :footcite:cts:`agarwal2018reductions` show that this is equivalent to
 :math:`\E[h(X) \given A=a, Y=y] = \E[h(X) \given Y=y] \quad \forall a, y`.
 Equalized odds requires that the true 
-positive rate, :math:`\P(h(X)=1 | Y=1`, and the false positive rate, 
-:math:`\P(h(X)=1 | Y=0`, be equal across groups. 
+positive rate, :math:`\P(h(X)=1 | Y=1)`, and the false positive rate, 
+:math:`\P(h(X)=1 | Y=0)`, be equal across groups. 
 
 The inclusion of false positive rates acknowledges that different groups 
 experience different costs from misclassification. For example, in the case of 


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description

I added a missing parenthesis in the Equalized odds latex formula.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x ] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
