### PR TITLE
MNT update sparse to sparse_output

### DIFF
--- a/examples/plot_plotting_metrics_with_error.py
+++ b/examples/plot_plotting_metrics_with_error.py
@@ -50,7 +50,7 @@ numeric_transformer = Pipeline(
 categorical_transformer = Pipeline(
     [
         ("impute", SimpleImputer(strategy="most_frequent")),
-        ("ohe", OneHotEncoder(handle_unknown="ignore", sparse=False)),
+        ("ohe", OneHotEncoder(handle_unknown="ignore", sparse_output=False)),
     ]
 )
 
@@ -110,12 +110,8 @@ def general_wilson(p, n, digits=4, z=1.959964):
     denominator = 1 + z**2 / n
     centre_adjusted_probability = p + z * z / (2 * n)
     adjusted_standard_deviation = np.sqrt((p * (1 - p) + z * z / (4 * n))) / np.sqrt(n)
-    lower_bound = (
-        centre_adjusted_probability - z * adjusted_standard_deviation
-    ) / denominator
-    upper_bound = (
-        centre_adjusted_probability + z * adjusted_standard_deviation
-    ) / denominator
+    lower_bound = (centre_adjusted_probability - z * adjusted_standard_deviation) / denominator
+    upper_bound = (centre_adjusted_probability + z * adjusted_standard_deviation) / denominator
     return np.array([round(lower_bound, digits), round(upper_bound, digits)])
 
 

--- a/examples/plot_plotting_metrics_with_error.py
+++ b/examples/plot_plotting_metrics_with_error.py
@@ -110,8 +110,12 @@ def general_wilson(p, n, digits=4, z=1.959964):
     denominator = 1 + z**2 / n
     centre_adjusted_probability = p + z * z / (2 * n)
     adjusted_standard_deviation = np.sqrt((p * (1 - p) + z * z / (4 * n))) / np.sqrt(n)
-    lower_bound = (centre_adjusted_probability - z * adjusted_standard_deviation) / denominator
-    upper_bound = (centre_adjusted_probability + z * adjusted_standard_deviation) / denominator
+    lower_bound = (
+        centre_adjusted_probability - z * adjusted_standard_deviation
+    ) / denominator
+    upper_bound = (
+        centre_adjusted_probability + z * adjusted_standard_deviation
+    ) / denominator
     return np.array([round(lower_bound, digits), round(upper_bound, digits)])
 
 


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

From version >1.2 of scikit-learn `sparse` was changed to `sparse_output`

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [x] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
