### PR TITLE
MNT delete trailing note in version guide

### DIFF
--- a/docs/user_guide/installation_and_version_guide/v0.10.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.10.0.rst
@@ -1,8 +1,6 @@
 v0.10.0
 =======
 
-.. note::
-
 * Added bootstrapping to :class:`MetricFrame`, along with a new section
   in the user guide
 * Added intersectionality in mental health care example notebook.


### PR DESCRIPTION
Deletes the empty note block in the version guide of v0.10.0 that gives an [error](https://app.circleci.com/pipelines/github/fairlearn/fairlearn/3962/workflows/4b5df195-d6a3-4132-bdfb-9f0ae746556f/jobs/7888/parallel-runs/0/steps/0-108?invite=true#step-108-64504_158) in the doc build.

<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [x] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
