### PR TITLE
MNT set requirements pandas>=2.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.24.4
-pandas>=2.0.3
+pandas>=2.2.0
 # pyarrow is going to be a mandatory dependency to pandas
 # this explicit dependency is only for the sake removing the DeprecationWarning
 # from pandas in this regard while that happens.


### PR DESCRIPTION
In #1336 we introduced `include_groups=False` to silence a deprecation warning in pandas, but this argument did not exist before pandas 2.2.0, resulting in a bunch of test failures. It seems the easiest solution is to change our min dependency of pandas to 2.2.0.

<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
