### PR TITLE
MNT Build fixes

### DIFF
--- a/fairlearn/metrics/_disaggregated_result.py
+++ b/fairlearn/metrics/_disaggregated_result.py
@@ -39,14 +39,22 @@ def extract_unique_classes(
 
 
 def apply_to_dataframe(
-    data: pd.DataFrame, metric_functions: Dict[str, AnnotatedMetricFunction]
+    data: pd.DataFrame,
+    metric_functions: Dict[str, AnnotatedMetricFunction],
+    include_groups: bool = False,
 ) -> pd.Series:
     """Apply metric functions to a DataFrame.
 
     The incoming DataFrame may have been sliced via `groupby()`.
     This function applies each annotated function in turn to the
     supplied DataFrame.
+
+    The include_groups argument is weird. It appears that pandas
+    introduced it as an argument in v2.2, and immediately deprecated
+    it (dependent on when this is being read, may need to adjust):
+    https://pandas.pydata.org/docs/reference/api/pandas.core.groupby.DataFrameGroupBy.apply.html
     """
+    assert not include_groups, "Unexpected change to include_groups"
     values = dict()
     for function_name, metric_function in metric_functions.items():
         values[function_name] = metric_function(data)

--- a/fairlearn/metrics/_disaggregated_result.py
+++ b/fairlearn/metrics/_disaggregated_result.py
@@ -53,8 +53,9 @@ def apply_to_dataframe(
     introduced it as an argument in v2.2, and immediately deprecated
     it (dependent on when this is being read, may need to adjust):
     https://pandas.pydata.org/docs/reference/api/pandas.core.groupby.DataFrameGroupBy.apply.html
+    We don't use this argument, and only include it so that we can be
+    compatible with pandas<2.2
     """
-    assert not include_groups, "Unexpected change to include_groups"
     values = dict()
     for function_name, metric_function in metric_functions.items():
         values[function_name] = metric_function(data)
@@ -373,6 +374,7 @@ class DisaggregatedResult:
             temp = data.groupby(by=control_feature_names).apply(
                 apply_to_dataframe,
                 metric_functions=annotated_functions,
+                # See note in apply_to_dataframe about include_groups
                 include_groups=False,
             )
             # If there are multiple control features, might have missing combinations
@@ -395,6 +397,7 @@ class DisaggregatedResult:
         temp = data.groupby(all_grouping_names).apply(
             apply_to_dataframe,
             metric_functions=annotated_functions,
+            # See note in apply_to_dataframe about include_groups
             include_groups=False,
         )
         if len(all_grouping_names) > 1:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.24.4
-pandas>=2.0.3,<2.1
+pandas>=2.0.3
 # pyarrow is going to be a mandatory dependency to pandas
 # this explicit dependency is only for the sake removing the DeprecationWarning
 # from pandas in this regard while that happens.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ pandas>=2.0.3
 # this explicit dependency is only for the sake removing the DeprecationWarning
 # from pandas in this regard while that happens.
 pyarrow>=15
-scikit-learn>=1.2.1
+# Upper bound on scikit-learn pending investigation
+scikit-learn>=1.2.1,<1.4
 scipy>=1.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ pandas>=2.0.3
 # from pandas in this regard while that happens.
 pyarrow>=15
 # Upper bound on scikit-learn pending investigation
+# MetricFrame failing in CI
 scikit-learn>=1.2.1,<1.4
 scipy>=1.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.24.4
-pandas>=2.0.3
+pandas>=2.0.3,<2.2
 # pyarrow is going to be a mandatory dependency to pandas
 # this explicit dependency is only for the sake removing the DeprecationWarning
 # from pandas in this regard while that happens.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.24.4
-pandas>=2.0.3,<2.2
+pandas>=2.0.3,<2.1
 # pyarrow is going to be a mandatory dependency to pandas
 # this explicit dependency is only for the sake removing the DeprecationWarning
 # from pandas in this regard while that happens.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.24.4
-pandas>=2.0.3,<2.2
+pandas>=2.0.3
 # pyarrow is going to be a mandatory dependency to pandas
 # this explicit dependency is only for the sake removing the DeprecationWarning
 # from pandas in this regard while that happens.

--- a/test/unit/reductions/grid_search/test_grid_generator.py
+++ b/test/unit/reductions/grid_search/test_grid_generator.py
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
-import warnings
-
 from test.unit.reductions.grid_search.utilities import _quick_data
 
 import numpy as np

--- a/test/unit/reductions/grid_search/test_grid_generator.py
+++ b/test/unit/reductions/grid_search/test_grid_generator.py
@@ -64,15 +64,12 @@ def test_grid_generator_demographic_parity_with_center(
     step_size = 2 * grid_limit / grid_size_or_next_smaller_even_number
     for i in range(grid_size):
         expected_grid[i] = pd.Series(0.0, index=expected_index)
-        with warnings.catch_warnings(record=True) as caught_warnings:
-            warnings.simplefilter("default", category=FutureWarning)
-            expected_grid[i]["-", _ALL, 1] = (
-                max(grid_limit - step_size * i, 0) + grid_offset["-", _ALL, 1]
-            )
-            expected_grid[i]["+", _ALL, 1] = (
-                max(-grid_limit + step_size * i, 0) + grid_offset["+", _ALL, 1]
-            )
-            assert len(caught_warnings) == 2
+        expected_grid.loc[("-", _ALL, 1), i] = (
+            max(grid_limit - step_size * i, 0) + grid_offset["-", _ALL, 1]
+        )
+        expected_grid.loc[("+", _ALL, 1), i] = (
+            max(-grid_limit + step_size * i, 0) + grid_offset["+", _ALL, 1]
+        )
     assert np.isclose(expected_grid.values, grid.values).all()
 
 
@@ -97,13 +94,10 @@ def test_grid_generator_equalized_odds_basic(grid_limit):
     for i in range(grid_size):
         expected_grid[i] = pd.Series(0.0, index=expected_index)
 
-    with warnings.catch_warnings(record=True) as caught_warnings:
-        warnings.simplefilter("default", category=FutureWarning)
-        expected_grid[0]["-", label0, 1] = grid_limit
-        expected_grid[1]["-", label1, 1] = grid_limit
-        expected_grid[3]["+", label1, 1] = grid_limit
-        expected_grid[4]["+", label0, 1] = grid_limit
-        assert len(caught_warnings) == 4
+    expected_grid.loc[("-", label0, 1), 0] = grid_limit
+    expected_grid.loc[("-", label1, 1), 1] = grid_limit
+    expected_grid.loc[("+", label1, 1), 3] = grid_limit
+    expected_grid.loc[("+", label0, 1), 4] = grid_limit
 
     assert np.isclose(expected_grid.values, grid.values).all()
 

--- a/test/unit/reductions/grid_search/test_grid_generator.py
+++ b/test/unit/reductions/grid_search/test_grid_generator.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
+import warnings
+
 from test.unit.reductions.grid_search.utilities import _quick_data
 
 import numpy as np
@@ -62,12 +64,15 @@ def test_grid_generator_demographic_parity_with_center(
     step_size = 2 * grid_limit / grid_size_or_next_smaller_even_number
     for i in range(grid_size):
         expected_grid[i] = pd.Series(0.0, index=expected_index)
-        expected_grid[i]["-", _ALL, 1] = (
-            max(grid_limit - step_size * i, 0) + grid_offset["-", _ALL, 1]
-        )
-        expected_grid[i]["+", _ALL, 1] = (
-            max(-grid_limit + step_size * i, 0) + grid_offset["+", _ALL, 1]
-        )
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            warnings.simplefilter("default", category=FutureWarning)
+            expected_grid[i]["-", _ALL, 1] = (
+                max(grid_limit - step_size * i, 0) + grid_offset["-", _ALL, 1]
+            )
+            expected_grid[i]["+", _ALL, 1] = (
+                max(-grid_limit + step_size * i, 0) + grid_offset["+", _ALL, 1]
+            )
+            assert len(caught_warnings) == 2
     assert np.isclose(expected_grid.values, grid.values).all()
 
 
@@ -92,10 +97,13 @@ def test_grid_generator_equalized_odds_basic(grid_limit):
     for i in range(grid_size):
         expected_grid[i] = pd.Series(0.0, index=expected_index)
 
-    expected_grid[0]["-", label0, 1] = grid_limit
-    expected_grid[1]["-", label1, 1] = grid_limit
-    expected_grid[3]["+", label1, 1] = grid_limit
-    expected_grid[4]["+", label0, 1] = grid_limit
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("default", category=FutureWarning)
+        expected_grid[0]["-", label0, 1] = grid_limit
+        expected_grid[1]["-", label1, 1] = grid_limit
+        expected_grid[3]["+", label1, 1] = grid_limit
+        expected_grid[4]["+", label0, 1] = grid_limit
+        assert len(caught_warnings) == 4
 
     assert np.isclose(expected_grid.values, grid.values).all()
 

--- a/test_othermlpackages/conda-lightgbm.yaml
+++ b/test_othermlpackages/conda-lightgbm.yaml
@@ -9,5 +9,5 @@ dependencies:
 - pandas
 - pytest
 - pytest-cov
-- scikit-learn
+- scikit-learn<1.4
 - lightgbm

--- a/test_othermlpackages/conda-lightgbm.yaml
+++ b/test_othermlpackages/conda-lightgbm.yaml
@@ -6,7 +6,7 @@ dependencies:
 - python==3.11
 - pip>=19.1.1
 - numpy
-- pandas
+- pandas<2.2
 - pytest
 - pytest-cov
 - scikit-learn<1.4

--- a/test_othermlpackages/conda-lightgbm.yaml
+++ b/test_othermlpackages/conda-lightgbm.yaml
@@ -10,4 +10,4 @@ dependencies:
 - pytest
 - pytest-cov
 - scikit-learn<1.4
-- lightgbm
+- lightgbm<4.3

--- a/test_othermlpackages/conda-lightgbm.yaml
+++ b/test_othermlpackages/conda-lightgbm.yaml
@@ -6,8 +6,8 @@ dependencies:
 - python==3.11
 - pip>=19.1.1
 - numpy
-- pandas<2.2
+- pandas
 - pytest
 - pytest-cov
 - scikit-learn<1.4
-- lightgbm<4.3
+- lightgbm


### PR DESCRIPTION
## Description

Various tweaks to fix the builds:

- Temporary upper bound on `scikit-learn`. Issue #1350 for tracking. A full fix will be required in due course
- Tweaks a couple of the grid generator tests to avoid warnings from `pandas`
- Adjust `_disaggregated_result.py` to cope with recently introduced (and deprecated) argument from `pandas`

Both of the `pandas` changes should fall under #1299 

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [ ] new tests added
- [x] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated