### PR TITLE
Release upper bound on scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,5 @@ pandas>=2.0.3
 # this explicit dependency is only for the sake removing the DeprecationWarning
 # from pandas in this regard while that happens.
 pyarrow>=15
-# Upper bound on scikit-learn pending investigation
-# MetricFrame failing in CI
-scikit-learn>=1.2.1,<1.4
+scikit-learn>=1.2.1
 scipy>=1.9.3

--- a/test/unit/metrics/test_metricframe_missing.py
+++ b/test/unit/metrics/test_metricframe_missing.py
@@ -22,6 +22,9 @@ g_A = np.asarray([group_gen(x, int(n / 2), ["aa", "bb"]) for x in range(n)])
 g_B = np.asarray([group_gen(x, 1 + int(n / 3), ["x", "y", "z"]) for x in range(n)])
 
 
+@pytest.mark.filterwarnings(
+    "default:A single label was found in 'y_true' and 'y_pred'.:UserWarning"
+)
 @pytest.mark.parametrize("metric_fn", metric)
 def test_missing_sensitive_feature_combinations(metric_fn):
     target = metrics.MetricFrame(
@@ -62,6 +65,9 @@ def test_missing_sensitive_feature_combinations(metric_fn):
     )
 
 
+@pytest.mark.filterwarnings(
+    "default:A single label was found in 'y_true' and 'y_pred'.:UserWarning"
+)
 @pytest.mark.parametrize("metric_fn", metric)
 def test_missing_conditional_feature_combinations(metric_fn):
     target = metrics.MetricFrame(

--- a/test/unit/metrics/test_metricframe_smoke.py
+++ b/test/unit/metrics/test_metricframe_smoke.py
@@ -415,7 +415,7 @@ def test_duplicate_cf_sf_names():
 
 def test_single_element_lists():
     mf = metrics.MetricFrame(
-        metrics=skm.balanced_accuracy_score,
+        metrics=skm.recall_score,
         y_true=[1],
         y_pred=[1],
         sensitive_features=[0],


### PR DESCRIPTION
## Description

We had temporarily added an upper bound on SciKit-Learn since there were issues with some of our tests. Remove the bound and address the test failures.

Closes #1350 

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [ ] new tests added
- [x] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
