### PR TITLE
DOC Fix typos in the documentation

### DIFF
--- a/docs/contributor_guide/contributing_documentation.rst
+++ b/docs/contributor_guide/contributing_documentation.rst
@@ -56,9 +56,11 @@ the following commands:
     ...
     start docs/_build/html/auto_examples/plot_*.html
 
-The above code block works for Windows users.
-For MacOS users, use :code: `open docs/_build/html/index.html`
-For Linux users, use :code: `xdg-open docs/_build/html/index.html`
+.. line-block::
+
+| The above code block works for Windows users.
+| For MacOS users, use :code:`open docs/_build/html/index.html`.
+| For Linux users, use :code:`xdg-open docs/_build/html/index.html`.
 
 .. note::
 

--- a/docs/user_guide/assessment/common_fairness_metrics.rst
+++ b/docs/user_guide/assessment/common_fairness_metrics.rst
@@ -79,7 +79,7 @@ phenomena itself is unjust (e.g., consider the case of predictive policing,
 where a system created to predict crime rates may correctly predict higher crime 
 rates for certain areas, but simultaneously fail to consider that those higher 
 rates may be caused by disproportionate policing and overcriminimalization of those areas). 
-In reality, these assumptions may not be the true. The
+In reality, these assumptions may not be true. The
 dataset might be an accurate representation of the phenomena itself, 
 or the phenomena being modeled may not be unjust. 
 If either assumption is not true, then demographic parity may not provide 


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
This PR fixes three typos in the documentation. 
The first two remove an extra space after the :`code:` markup that failed to render a code snippet block in the documentation contribution guide (59ba2ed1a0d48dc9648a076f104b0c73a0c707a5). The third is a text typo in the common metrics user guide (e06df00a16a3ef368adcbf1fef0aba36233227bd). 

@adrinjalali 
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
