### PR TITLE
MNT unpin pytest

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,7 @@ requirements-parser
 black==24.4.2
 
 # Required for test
-pytest==7.4.2
+pytest
 pytest-cov
 pytest-mock
 pytest-mpl


### PR DESCRIPTION
I don't see any errors with the latest pytest release. So removing the pin.

cc @riedgar-ms @romanlutz 