### PR TITLE
DOC change OneHotEncoder.sparse to sparse_output

### DIFF
--- a/docs/user_guide/mitigation/adversarial.rst
+++ b/docs/user_guide/mitigation/adversarial.rst
@@ -250,7 +250,7 @@ to get rid of NaN's::
             Pipeline(
                 [
                     ("imputer", SimpleImputer(strategy="most_frequent")),
-                    ("encoder", OneHotEncoder(drop="if_binary", sparse=False)),
+                    ("encoder", OneHotEncoder(drop="if_binary", sparse_output=False)),
                 ]
             ),
             make_column_selector(dtype_include="category"),


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
This (tiniest) PR changes the remaining `OneHotEncoder.sparse` to `sparse_output`. In all the other places it has been updated already. 

@adrinjalali this came up while we were working on https://github.com/fairlearn/fairlearn/issues/1373. 

<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [x] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
