### PR TITLE
MNT Address (not always reproducible) docs build warnings

### DIFF
--- a/fairlearn/datasets/_fetch_diabetes_hospital.py
+++ b/fairlearn/datasets/_fetch_diabetes_hospital.py
@@ -91,7 +91,7 @@ def fetch_diabetes_hospital(*, as_frame=True, cache=True, data_home=None, return
     (data, target) : tuple if ``return_X_y`` is True
 
     Notes
-    ----------
+    -----
     Our API largely follows the API of :func:`sklearn.datasets.fetch_openml`.
 
     References

--- a/fairlearn/reductions/_moments/error_rate.py
+++ b/fairlearn/reductions/_moments/error_rate.py
@@ -85,7 +85,7 @@ class ErrorRate(ClassificationMoment):
         total_fn_cost = np.sum(signed_errors[signed_errors > 0] * self.fn_cost)
         total_fp_cost = np.sum(-signed_errors[signed_errors < 0] * self.fp_cost)
         error_value = (total_fn_cost + total_fp_cost) / self.total_samples
-        error = pd.Series(data=error_value, index=self.index)
+        error = pd.Series(data=error_value, index=self.index).copy()
         self._gamma_descr = str(error)
         return error
 


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
PR #1378 addressed all visible warnings after a clean build, but it seems that sometimes a partial build yields more warnings, addressing two small ones here. I will make a subsequent PR that will remove an [older deprecation warning](https://github.com/TamaraAtanasoska/fairlearn/blob/main/fairlearn/postprocessing/_threshold_optimizer.py#L281) that isn't necessary any more. 

I am not able to consistently reproduce the warnings with the same steps, but I saved one of the console outputs and they are pointing to real issues, despite not consistently appearing. If anyone understands why this is so I would love to know 🙏 . After this PR the `FutureWarning` should still appear as it is not addressed, but it doesn't consistently show. I am also surprised how the Notes underline in 821d8dd0f4e3036058d40d781c27a3ce2685f516 was not showing up with all the rest addressed in the previous PR.

@adrinjalali 

<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [ ] user guide added or updated
- [x] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
