### PR TITLE
FIX Add classes_ attribute to AdversarialFairnessClassifier

### DIFF
--- a/examples/plot_credit_loan_decisions.py
+++ b/examples/plot_credit_loan_decisions.py
@@ -314,6 +314,7 @@ lgb_params = {
     "max_depth": 3,
     "random_state": rand_seed,
     "n_jobs": 1,
+    "verbose": -1,
 }
 
 estimator = Pipeline(

--- a/fairlearn/adversarial/_adversarial_mitigation.py
+++ b/fairlearn/adversarial/_adversarial_mitigation.py
@@ -556,6 +556,9 @@ class _AdversarialFairness(BaseEstimator):
         sensitive_features : array
             Array-like containing the sensitive feature of the
             training data.
+
+        classes : array
+            An array containing the labels of classes.
         """
         X, Y, A = self._validate_input(X, y, sensitive_features, reinitialize=False)
         self.backendEngine_.train_step(X, Y, A)

--- a/fairlearn/adversarial/_adversarial_mitigation.py
+++ b/fairlearn/adversarial/_adversarial_mitigation.py
@@ -541,7 +541,7 @@ class _AdversarialFairness(BaseEstimator):
 
         return self
 
-    def partial_fit(self, X, y, *, sensitive_features=None, classes=None):
+    def partial_fit(self, X, y, *, sensitive_features=None):
         """
         Perform one epoch on given samples and update model.
 
@@ -556,9 +556,6 @@ class _AdversarialFairness(BaseEstimator):
         sensitive_features : array
             Array-like containing the sensitive feature of the
             training data.
-
-        classes : array
-            An array containing the labels of classes.
         """
         X, Y, A = self._validate_input(X, y, sensitive_features, reinitialize=False)
         self.backendEngine_.train_step(X, Y, A)

--- a/fairlearn/adversarial/_adversarial_mitigation.py
+++ b/fairlearn/adversarial/_adversarial_mitigation.py
@@ -541,7 +541,7 @@ class _AdversarialFairness(BaseEstimator):
 
         return self
 
-    def partial_fit(self, X, y, *, sensitive_features=None):
+    def partial_fit(self, X, y, *, sensitive_features=None, classes=None):
         """
         Perform one epoch on given samples and update model.
 
@@ -987,6 +987,36 @@ class AdversarialFairnessClassifier(_AdversarialFairness, ClassifierMixin):
             random_state=random_state,
         )
 
+    def _more_tags(self):
+        return {
+            "_xfail_checks": {
+                "check_parameters_default_constructible": (
+                    "cannot have an empty default parameter of a mutable type."
+                ),
+                "check_estimators_pickle": "pickling is not possible.",
+                "check_classifiers_train(readonly_memmap=True)": (
+                    "the output must be of type numpy.array."
+                ),
+                "check_classifiers_train": ("the output must be of type numpy.array."),
+                "check_estimators_overwrite_params": "pickling is not possible.",
+                "check_classifier_data_not_an_array": ("data must be transformed into an array."),
+                "check_supervised_y_no_nan": ("cannot fit an array with inf values."),
+                "check_non_transformer_estimators_n_iter": (
+                    "estimator is missing the _n_iter attribute."
+                ),
+                "check_classifiers_regression_target": ("the data cannot look continuous."),
+                "check_estimators_partial_fit_n_features": ("number of features cannot change."),
+                "check_classifiers_classes": (
+                    "decision function output must match classifier output."
+                ),
+                "check_fit_non_negative": (
+                    "a ValueError should be raised if output is negative. "
+                ),
+                "check_supervised_y_2d": "DataConversionWarning not caught.",
+            },
+            "requires_positive_X": True,
+        }
+
 
 class AdversarialFairnessRegressor(_AdversarialFairness, RegressorMixin):
     r"""Train PyTorch or TensorFlow regressors while mitigating unfairness.
@@ -1175,6 +1205,58 @@ class AdversarialFairnessRegressor(_AdversarialFairness, RegressorMixin):
             warm_start=warm_start,
             random_state=random_state,
         )
+
+    def _more_tags(self):
+        return {
+            "_xfail_checks": {
+                "check_parameters_default_constructible": (
+                    "cannot have an empty default parameter of a mutable type."
+                ),
+                "check_estimators_pickle": "pickling is not possible.",
+                "check_fit2d_predict1d": ("regressor estimator cannot look like multiclass."),
+                "check_dict_unchanged": ("regressor estimator cannot look like binary."),
+                "check_dont_overwrite_parameters": (
+                    "regressor estimator cannot look like multiclass."
+                ),
+                "check_methods_sample_order_invariance": (
+                    "regressor estimator cannot look like multiclass."
+                ),
+                "check_methods_subset_invariance": (
+                    "regressor estimator cannot look like multiclass."
+                ),
+                "check_non_transformer_estimators_n_iter": (
+                    "regressor estimator cannot look like multiclass."
+                ),
+                "check_regressors_int": ("regressor estimator cannot look like multiclass."),
+                "check_supervised_y_2d": ("regressor estimator cannot look like multiclass."),
+                "check_estimators_overwrite_params": (
+                    "regressor estimator cannot look like multiclass."
+                ),
+                "check_estimators_nan_inf": ("regressor estimator cannot look like binary."),
+                "check_estimators_partial_fit_n_features": (
+                    "regressor estimator cannot look like multiclass."
+                ),
+                "check_pipeline_consistency": ("regressor estimator cannot look like binary."),
+                "check_dtype_object": ("regressor estimator cannot look like multiclass."),
+                "check_estimators_fit_returns_self": (
+                    "regressor estimator cannot look like multiclass."
+                ),
+                "check_estimators_fit_returns_self(readonly_memmap=True)": (
+                    "regressor estimator cannot look like multiclass."
+                ),
+                "check_fit_score_takes_y": ("regressor estimator cannot look like multiclass."),
+                "check_estimators_dtypes": ("regressor estimator cannot look like multiclass."),
+                "check_fit2d_1feature": ("regressor estimator cannot look like binary."),
+                "check_fit2d_1sample": ("regressor estimator cannot look like binary."),
+                "check_supervised_y_no_nan": ("cannot fit an array with inf values."),
+                "check_regressor_data_not_an_array": ("data must be transformed into an array."),
+                "check_regressors_no_decision_function": (
+                    "regressors should not have a decision function."
+                ),
+                "check_regressors_train": ("predictions shape should match targets shape."),
+            },
+            "requires_positive_X": True,
+        }
 
 
 def check_X(X):

--- a/fairlearn/adversarial/_adversarial_mitigation.py
+++ b/fairlearn/adversarial/_adversarial_mitigation.py
@@ -5,7 +5,7 @@ import logging
 from math import ceil
 from time import time
 
-from numpy import arange, argmax, zeros
+from numpy import arange, argmax, unique, zeros
 from sklearn.base import (
     BaseEstimator,
     ClassifierMixin,
@@ -445,6 +445,7 @@ class _AdversarialFairness(BaseEstimator):
             training data.
         """
         X, Y, A = self._validate_input(X, y, sensitive_features, reinitialize=True)
+        self.classes_ = unique(y)
 
         # Not checked in __setup, because partial_fit may not require it.
         if self.epochs == -1 and self.max_iter == -1:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.24.4, <2.0.0
+numpy>=1.24.4
 pandas>=2.0.3
 # pyarrow is going to be a mandatory dependency to pandas
 # this explicit dependency is only for the sake removing the DeprecationWarning

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.24.4
+numpy>=1.24.4, <2.0.0
 pandas>=2.0.3
 # pyarrow is going to be a mandatory dependency to pandas
 # this explicit dependency is only for the sake removing the DeprecationWarning

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.24.4, <2.0.0
+numpy~=1.24.4
 pandas>=2.0.3
 # pyarrow is going to be a mandatory dependency to pandas
 # this explicit dependency is only for the sake removing the DeprecationWarning

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy~=1.24.4
+numpy>=1.24.4, <2.0.0
 pandas>=2.0.3
 # pyarrow is going to be a mandatory dependency to pandas
 # this explicit dependency is only for the sake removing the DeprecationWarning

--- a/test/unit/adversarial/test_adversarial_mitigation.py
+++ b/test/unit/adversarial/test_adversarial_mitigation.py
@@ -17,9 +17,6 @@ from fairlearn.adversarial._constants import _TYPE_COMPLIANCE_ERROR
 from fairlearn.adversarial._preprocessor import FloatTransformer
 
 from .helper import (
-    BCE,
-    CCE,
-    MSE,
     Bin1d,
     Bin2d,
     Cat,
@@ -264,43 +261,39 @@ def test_model_kw_error_torch():
             tensorflow=False,
             fake_mixin=True,
         ),
+        get_instance(
+            AdversarialFairnessClassifier,
+            fake_training=True,
+            torch=False,
+            tensorflow=True,
+            fake_mixin=True,
+        ),
+        get_instance(
+            AdversarialFairnessClassifier,
+            fake_training=True,
+            torch=True,
+            tensorflow=False,
+            fake_mixin=True,
+        ),
+        get_instance(
+            AdversarialFairnessRegressor,
+            fake_training=True,
+            torch=False,
+            tensorflow=True,
+            fake_mixin=True,
+        ),
+        get_instance(
+            AdversarialFairnessRegressor,
+            fake_training=True,
+            torch=True,
+            tensorflow=False,
+            fake_mixin=True,
+        ),
     ]
 )
 def test_estimators(estimator, check):
     """Check the compatibility with scikit-learn API."""
     check(estimator)
-
-
-@pytest.mark.parametrize("torch1", [True, False])
-def test_classifier(torch1):
-    """Test classifier subclass."""
-    mitigator = get_instance(
-        AdversarialFairnessClassifier,
-        fake_training=True,
-        torch=torch1,
-        tensorflow=not torch1,
-    )
-    assert isinstance(mitigator, _AdversarialFairness)
-
-    mitigator.fit(Cont2d, Bin1d, sensitive_features=Cat)
-    assert isinstance(mitigator.backendEngine_.predictor_loss, BCE)
-    assert isinstance(mitigator.backendEngine_.adversary_loss, CCE)
-
-
-@pytest.mark.parametrize("torch2", [True, False])
-def test_regressor(torch2):
-    """Test regressor subclass."""
-    mitigator = get_instance(
-        AdversarialFairnessRegressor,
-        fake_training=True,
-        torch=torch2,
-        tensorflow=not torch2,
-    )
-    assert isinstance(mitigator, _AdversarialFairness)
-
-    mitigator.fit(Cont2d, Cont2d, sensitive_features=Cat)
-    assert isinstance(mitigator.backendEngine_.predictor_loss, MSE)
-    assert isinstance(mitigator.backendEngine_.adversary_loss, CCE)
 
 
 @pytest.mark.parametrize("torch3", [True, False])

--- a/test_othermlpackages/test_lightgbm.py
+++ b/test_othermlpackages/test_lightgbm.py
@@ -15,6 +15,7 @@ def test_expgrad_classification():
         "learning_rate": 0.03,
         "num_leaves": 10,
         "max_depth": 3,
+        "verbose": -1,
     }
     estimator = lgb.LGBMClassifier(**lgb_params)
     disparity_moment = DemographicParity()
@@ -29,6 +30,7 @@ def test_gridsearch_classification():
         "learning_rate": 0.03,
         "num_leaves": 10,
         "max_depth": 3,
+        "verbose": -1,
     }
     estimator = lgb.LGBMClassifier(**lgb_params)
     disparity_moment = DemographicParity()
@@ -43,6 +45,7 @@ def test_thresholdoptimizer_classification():
         "learning_rate": 0.03,
         "num_leaves": 10,
         "max_depth": 3,
+        "verbose": -1,
     }
     estimator = lgb.LGBMClassifier(**lgb_params)
 


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
This PR addresses issue #1381.
Additionally, the new scikit-learn estimator checks are enabled for both `AdversarialFairnessClassifier` and `AdversarialFairnessRegressor`. As a result many checks are failing and they are added under the `xfail` flag. They would be addressed individually in the future.

@adrinjalali 
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [x] new tests added
- [x] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [ ] user guide added or updated
- [x] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
