### PR TITLE
MNT Update code to fit the new numpy2.0.0 API

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,29 +18,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-#  all-deps:
-#    strategy:
-#      matrix:
-#        os: [ubuntu-latest, windows-latest, macos-12]
-#        python: ["3.8", "3.9", "3.10", "3.11"]
-#        requirementsPinned: ["false"]
-#    uses: ./.github/workflows/test-all-deps.yml
-#    with:
-#      os: ${{ matrix.os }}
-#      python: ${{ matrix.python }}
-#      requirementsPinned: ${{ matrix.requirementsPinned }}
-#      codeCovPython: "3.11"
-#
-#  minimal-deps:
-#    strategy:
-#      matrix:
-#        os: [ubuntu-latest, windows-latest, macos-12]
-#        python: ["3.8", "3.9", "3.10", "3.11"]
-#    uses: ./.github/workflows/test-minimal-deps.yml
-#    with:
-#      os: ${{ matrix.os }}
-#      python: ${{ matrix.python }}
-#      codeCovPython: "3.11"
+  all-deps:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-12]
+        python: ["3.8", "3.9", "3.10", "3.11"]
+        requirementsPinned: ["false"]
+    uses: ./.github/workflows/test-all-deps.yml
+    with:
+      os: ${{ matrix.os }}
+      python: ${{ matrix.python }}
+      requirementsPinned: ${{ matrix.requirementsPinned }}
+      codeCovPython: "3.11"
+
+  minimal-deps:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-12]
+        python: ["3.8", "3.9", "3.10", "3.11"]
+    uses: ./.github/workflows/test-minimal-deps.yml
+    with:
+      os: ${{ matrix.os }}
+      python: ${{ matrix.python }}
+      codeCovPython: "3.11"
 
 
   other-ml:
@@ -48,8 +48,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python: ["3.11"]
-#        mlpackage: [lightgbm, xgboost, tensorflow, pytorch]
-        mlpackage: [tensorflow]
+        mlpackage: [lightgbm, xgboost, tensorflow, pytorch]
       fail-fast: false
     uses: ./.github/workflows/test-other-ml.yml
     with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,44 +11,45 @@ on:
   workflow_dispatch:
 
 
-concurrency: 
+concurrency:
   # this ensures after each commit the old jobs are cancelled and the new ones
   # run instead.
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
-  all-deps:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-12]
-        python: ["3.8", "3.9", "3.10", "3.11"]
-        requirementsPinned: ["false"]
-    uses: ./.github/workflows/test-all-deps.yml
-    with:
-      os: ${{ matrix.os }}
-      python: ${{ matrix.python }}
-      requirementsPinned: ${{ matrix.requirementsPinned }}
-      codeCovPython: "3.11"
-  
-  minimal-deps:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-12]
-        python: ["3.8", "3.9", "3.10", "3.11"]
-    uses: ./.github/workflows/test-minimal-deps.yml
-    with:
-      os: ${{ matrix.os }}
-      python: ${{ matrix.python }}
-      codeCovPython: "3.11"
+#  all-deps:
+#    strategy:
+#      matrix:
+#        os: [ubuntu-latest, windows-latest, macos-12]
+#        python: ["3.8", "3.9", "3.10", "3.11"]
+#        requirementsPinned: ["false"]
+#    uses: ./.github/workflows/test-all-deps.yml
+#    with:
+#      os: ${{ matrix.os }}
+#      python: ${{ matrix.python }}
+#      requirementsPinned: ${{ matrix.requirementsPinned }}
+#      codeCovPython: "3.11"
+#
+#  minimal-deps:
+#    strategy:
+#      matrix:
+#        os: [ubuntu-latest, windows-latest, macos-12]
+#        python: ["3.8", "3.9", "3.10", "3.11"]
+#    uses: ./.github/workflows/test-minimal-deps.yml
+#    with:
+#      os: ${{ matrix.os }}
+#      python: ${{ matrix.python }}
+#      codeCovPython: "3.11"
 
-  
+
   other-ml:
     strategy:
       matrix:
         os: [ubuntu-latest]
         python: ["3.11"]
-        mlpackage: [lightgbm, xgboost, tensorflow, pytorch]
+#        mlpackage: [lightgbm, xgboost, tensorflow, pytorch]
+        mlpackage: [tensorflow]
       fail-fast: false
     uses: ./.github/workflows/test-other-ml.yml
     with:

--- a/.github/workflows/test-other-ml.yml
+++ b/.github/workflows/test-other-ml.yml
@@ -12,10 +12,10 @@ on:
       mlpackage:
         required: true
         type: string
-      
+
 
 jobs:
-  other-ml:      
+  other-ml:
     runs-on: ${{ inputs.os }}
     env:
       baseDir: test_othermlpackages
@@ -32,11 +32,16 @@ jobs:
           conda env create --name $condaEnv --file=$baseDir/conda-${{inputs.mlpackage}}.yaml
         name: Create conda environment
       - run: |
+          if [[ ${{ inputs.mlpackage }} == "tensorflow" ]]; then
+            export NUMPY_DEP="numpy<2"
+          else
+            export NUMPY_DEP="numpy"
+          fi
           # For some reason, 'conda init bash' doesn't stick so
           # We have to keep doing the following
           source /usr/share/miniconda/etc/profile.d/conda.sh
           conda activate $condaEnv
-          pip install .
+          pip install . $NUMPY_DEP
         name: Install Fairlearn
       - run: |
           source /usr/share/miniconda/etc/profile.d/conda.sh
@@ -45,7 +50,7 @@ jobs:
           conda list
           echo
           # Override the filterwarnings set in the TOML file
-          python -v -m pytest -o filterwarnings=default --cov=fairlearn --cov-report=xml $baseDir/test_${{inputs.mlpackage}}.py 
+          python -v -m pytest -o filterwarnings=default --cov=fairlearn --cov-report=xml $baseDir/test_${{inputs.mlpackage}}.py
         name: Run ${{matrix.mlpackage}} tests
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test-other-ml.yml
+++ b/.github/workflows/test-other-ml.yml
@@ -32,7 +32,7 @@ jobs:
           conda env create --name $condaEnv --file=$baseDir/conda-${{inputs.mlpackage}}.yaml
         name: Create conda environment
       - run: |
-          if [[ ${{ inputs.mlpackage }} == "tensorflow" ]]; then
+          if [[ ${{ inputs.mlpackage }} == "tensorflow" && ${{ inputs.mlpackage }} == "lightgbm"]]; then
             export NUMPY_DEP="numpy<2"
           else
             export NUMPY_DEP="numpy"

--- a/.github/workflows/test-other-ml.yml
+++ b/.github/workflows/test-other-ml.yml
@@ -32,7 +32,12 @@ jobs:
           conda env create --name $condaEnv --file=$baseDir/conda-${{inputs.mlpackage}}.yaml
         name: Create conda environment
       - run: |
-          if [[ ${{ inputs.mlpackage }} == "tensorflow" && ${{ inputs.mlpackage }} == "lightgbm"]]; then
+          if [[ ${{ inputs.mlpackage }} == "tensorflow" ]]; then
+            export NUMPY_DEP="numpy<2"
+          else
+            export NUMPY_DEP="numpy"
+          fi
+          if [[ ${{ inputs.mlpackage }} == "lightgbm" ]]; then
             export NUMPY_DEP="numpy<2"
           else
             export NUMPY_DEP="numpy"

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -100,7 +100,7 @@ prediction task.
     >>> import matplotlib.pyplot as plt
     >>> from fairlearn.datasets import fetch_diabetes_hospital
     >>> data = fetch_diabetes_hospital(as_frame=True)
-    >>> X = data.data
+    >>> X = data.data.copy()
     >>> X.drop(columns=["readmitted", "readmit_binary"], inplace=True)
     >>> y = data.target
     >>> X_ohe = pd.get_dummies(X)
@@ -143,7 +143,7 @@ we can evaluate metrics for subgroups within the data as below:
     DecisionTreeClassifier(...)
     >>> y_pred = (classifier.predict_proba(X_test)[:,1] >= 0.1)
     >>> mf = MetricFrame(metrics=accuracy_score, y_true=y_test, y_pred=y_pred, sensitive_features=A_test)
-    >>> mf.overall
+    >>> mf.overall.item()
     0.514...
     >>> mf.by_group
     race
@@ -173,7 +173,7 @@ the model does not predict that outcome.
 
     >>> from fairlearn.metrics import false_negative_rate
     >>> mf = MetricFrame(metrics=false_negative_rate, y_true=y_test, y_pred=y_pred, sensitive_features=A_test)
-    >>> mf.overall
+    >>> mf.overall.item()
     0.309...
     >>> mf.by_group
     race
@@ -224,7 +224,7 @@ as the objective, leading to a vastly reduced difference in accuracy:
     ExponentiatedGradient(...)
     >>> y_pred_mitigated = mitigator.predict(X_test)
     >>> mf_mitigated = MetricFrame(metrics=accuracy_score, y_true=y_test, y_pred=y_pred_mitigated, sensitive_features=A_test)
-    >>> mf_mitigated.overall
+    >>> mf_mitigated.overall.item()
     0.5251...
     >>> mf_mitigated.by_group
     race

--- a/docs/user_guide/assessment/advanced_metricframe.rst
+++ b/docs/user_guide/assessment/advanced_metricframe.rst
@@ -48,7 +48,7 @@ required arguments to the metric function:
     ...                           y_true=y_true,
     ...                           y_pred=y_pred,
     ...                           sensitive_features=sf_data)
-    >>> metric_beta.overall
+    >>> metric_beta.overall.item()
     0.56983...
     >>> metric_beta.by_group
     sensitive_feature_0
@@ -61,7 +61,7 @@ required arguments to the metric function:
 Per-Sample Arguments
 ^^^^^^^^^^^^^^^^^^^^
 
-If there are per-sample arguments (such as sample weights), these can also be 
+If there are per-sample arguments (such as sample weights), these can also be
 provided in a dictionary via the ``sample_params`` argument.
 The keys of this dictionary are the argument names, and the values are 1-D
 arrays equal in length to ``y_true`` etc.:
@@ -80,7 +80,7 @@ arrays equal in length to ``y_true`` etc.:
     ...                        y_pred=y_pred,
     ...                        sensitive_features=pd.Series(sf_data, name='SF 0'),
     ...                        sample_params=s_p)
-    >>> weighted.overall
+    >>> weighted.overall.item()
     0.45...
     >>> weighted.by_group
     SF 0
@@ -89,7 +89,7 @@ arrays equal in length to ``y_true`` etc.:
     c    0.250000
     Name: recall_score, dtype: float64
 
-If multiple metrics are being evaluated, then ``sample_params`` becomes a 
+If multiple metrics are being evaluated, then ``sample_params`` becomes a
 dictionary of dictionaries.
 The first key to this dictionary is the name of the metric as specified
 in the ``metrics`` argument.
@@ -160,7 +160,7 @@ For example:
     ...                              y_true=dummy_y_true,
     ...                              y_pred=y_pred,
     ...                              sensitive_features=pd.Series(sf_data, name='SF 0'))
-    >>> sel_rate_frame.overall
+    >>> sel_rate_frame.overall.item()
     0.55555...
     >>> sel_rate_frame.by_group
     SF 0
@@ -287,7 +287,7 @@ inputs.
     ...      metrics=area_metric,
     ...      y_true=y_rect_true,
     ...      y_pred=y_rect_pred,
-    ...      sensitive_features=rect_groups  
+    ...      sensitive_features=rect_groups
     ... )
     >>> print(mf_non_scalar.overall)
     5.6666...
@@ -306,6 +306,5 @@ As the name implies, this metric takes two rectangles, and computes the area of 
 and divides it by the area of their union.
 If the two rectangles are disjoint, then the IoU will be zero.
 If the two rectangles are identical, then the IoU will be one.
-This is presented in full in our 
+This is presented in full in our
 `example notebook <../auto_examples/plot_metricframe_beyond_binary_classification.html#non-scalar-inputs>`_.
-

--- a/docs/user_guide/assessment/custom_fairness_metrics.rst
+++ b/docs/user_guide/assessment/custom_fairness_metrics.rst
@@ -34,12 +34,12 @@ the requested aggregation. For example:
     >>> recall_difference = make_derived_metric(metric=recall_score,
     ...                                        transform='difference')
     >>> recall_difference(y_true, y_pred,
-    ...                   sensitive_features=sf_data)
+    ...                   sensitive_features=sf_data).item()
     0.19999...
     >>> MetricFrame(metrics=recall_score,
     ...             y_true=y_true,
     ...             y_pred=y_pred,
-    ...             sensitive_features=sf_data).difference()
+    ...             sensitive_features=sf_data).difference().item()
     0.19999...
 
 We use :func:`fairlearn.metrics.make_derived_metric` to manufacture a number

--- a/docs/user_guide/assessment/intersecting_groups.rst
+++ b/docs/user_guide/assessment/intersecting_groups.rst
@@ -48,7 +48,7 @@ of these groups:
     ...                          y_true=y_true,
     ...                          y_pred=y_pred,
     ...                          sensitive_features=s_f_frame)
-    >>> metric_2sf.overall  # Same as before
+    >>> metric_2sf.overall.item()  # Same as before
     0.5
     >>> metric_2sf.by_group
     SF 0  SF 1

--- a/docs/user_guide/assessment/saving_loading_metricframe.rst
+++ b/docs/user_guide/assessment/saving_loading_metricframe.rst
@@ -21,7 +21,7 @@ format and how to load it from a stored pickle file.
     ...                            y_true=y_true,
     ...                            y_pred=y_pred,
     ...                            sensitive_features=sf_data)
-    >>> metric_frame.overall
+    >>> metric_frame.overall.item()
     0.444...
     >>> metric_frame.by_group
     sensitive_feature_0
@@ -32,7 +32,7 @@ format and how to load it from a stored pickle file.
     >>> file_name = 'metric_frame_save_load_example.pkl'
     >>> pickle.dump(metric_frame, open(file_name, 'wb'))
 	>>> loaded_metric_frame = pickle.load(open(file_name, 'rb'))
-    >>> loaded_metric_frame.overall
+    >>> loaded_metric_frame.overall.item()
     0.444...
     >>> loaded_metric_frame.by_group
     sensitive_feature_0
@@ -40,5 +40,3 @@ format and how to load it from a stored pickle file.
     b    0.666667
     c    0.375000
     Name: accuracy_score, dtype: float64
-
-

--- a/docs/user_guide/mitigation/postprocessing.rst
+++ b/docs/user_guide/mitigation/postprocessing.rst
@@ -67,7 +67,7 @@ true positive rate parity as the fairness constraint.
     >>> # Drop 3 rows of Unknown gender since it's not representative of that group.
     >>> # In a real application, this would be a red flag to investigate data collection.
     >>> keep_idx = (data.data['gender'] == "Male") | (data.data['gender'] == "Female")
-    >>> X_raw = data.data[keep_idx]
+    >>> X_raw = data.data[keep_idx].copy()
     >>> y = data.target[keep_idx]
     >>> categorical_columns = [
     ...     'race', 'gender', 'age', 'discharge_disposition_id', 'admission_source_id',

--- a/docs/user_guide/mitigation/reductions.rst
+++ b/docs/user_guide/mitigation/reductions.rst
@@ -148,9 +148,9 @@ Demographic Parity
 A binary classifier :math:`h(X)` satisfies *demographic parity* if
 
 .. math::
-    
+
     \P[h(X) = 1 \given A = a] = \P[h(X) = 1] \quad \forall a
- 
+
 In other words, the selection rate or percentage of samples with label 1
 should be equal across all groups. Implicitly this means the percentage
 with label 0 is equal as well. In this case, the utility function
@@ -193,7 +193,7 @@ the predicted labels.
     ...                                      y_true=y_true,
     ...                                      y_pred=y_pred,
     ...                                      sensitive_features=pd.Series(sensitive_features, name="SF 0"))
-    >>> selection_rate_summary.overall
+    >>> selection_rate_summary.overall.item()
         0.4
     >>> selection_rate_summary.by_group
     SF 0
@@ -208,7 +208,7 @@ the predicted labels.
     -     all    a          -0.2
                  b           0.2
     dtype: float64
- 
+
 The ratio constraints for the demographic parity with :code:`ratio_bound`
 :math:`r` (and :code:`ratio_bound_slack=0`) take form
 
@@ -281,7 +281,7 @@ In practice this can be used in a difference-based relaxation as follows:
     ...                           y_true=y_true,
     ...                           y_pred=y_pred,
     ...                           sensitive_features=sensitive_features)
-    >>> tpr_summary.overall
+    >>> tpr_summary.overall.item()
     0.5714285714285714
     >>> tpr_summary.by_group
     sensitive_feature_0
@@ -320,7 +320,7 @@ Alternatively, a ratio-based relaxation is also available:
     dtype: float64
 
 .. _equalized_odds:
-    
+
 Equalized Odds
 ~~~~~~~~~~~~~~
 
@@ -379,7 +379,7 @@ the overall error rate by more than the value of :code:`difference_bound`.
     ...                                y_true=y_true,
     ...                                y_pred=y_pred,
     ...                                sensitive_features=sensitive_features)
-    >>> accuracy_summary.overall
+    >>> accuracy_summary.overall.item()
     0.6
     >>> accuracy_summary.by_group
     sensitive_feature_0
@@ -535,7 +535,7 @@ Group :code:`"a"` has an average loss of :math:`0.05`, while group
     ...                         y_true=y_true,
     ...                         y_pred=y_pred,
     ...                         sensitive_features=pd.Series(sensitive_features, name="SF 0"))
-    >>> mae_frame.overall
+    >>> mae_frame.overall.item()
     0.275
     >>> mae_frame.by_group
     SF 0

--- a/fairlearn/reductions/_exponentiated_gradient/_lagrangian.py
+++ b/fairlearn/reductions/_exponentiated_gradient/_lagrangian.py
@@ -245,7 +245,7 @@ class _Lagrangian:
             best_value = values[best_idx]
         else:
             best_idx = -1
-            best_value = np.PINF
+            best_value = np.inf
 
         if h_value < best_value - _PRECISION:
             logger.debug("%sbest_h: val improvement %f", _LINE, best_value - h_value)

--- a/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
+++ b/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
@@ -155,7 +155,7 @@ class ExponentiatedGradient(BaseEstimator, MetaEstimatorMixin):
         Qs = []
 
         last_regret_checked = _REGRET_CHECK_START_T
-        last_gap = np.PINF
+        last_gap = np.inf
         for t in range(0, self.max_iter):
             logger.debug("...iter=%03d", t)
 
@@ -193,7 +193,7 @@ class ExponentiatedGradient(BaseEstimator, MetaEstimatorMixin):
             gaps_EG.append(gap_EG)
 
             if t == 0 or not self.run_linprog_step:
-                gap_LP = np.PINF
+                gap_LP = np.inf
             else:
                 # saddle point optimization over the convex hull of
                 # classifiers returned so far

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,8 @@ notice-rgx = "# (?i)Copyright \\(C\\) (Microsoft Corporation and )?Fairlearn con
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E4", "E7", "E9", "F"]
+#Enable linting according to the new numpy API with NPY201
+select = ["E4", "E7", "E9", "F", "NPY201"]
 ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/test_othermlpackages/conda-lightgbm.yaml
+++ b/test_othermlpackages/conda-lightgbm.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
 - python==3.11
 - pip>=19.1.1
-- numpy==1.26.4
+- numpy>=1.24.4, <2
 - pandas
 - pytest
 - pytest-cov

--- a/test_othermlpackages/conda-lightgbm.yaml
+++ b/test_othermlpackages/conda-lightgbm.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
 - python==3.11
 - pip>=19.1.1
-- numpy==1.24.4
+- numpy==1.26.4
 - pandas
 - pytest
 - pytest-cov

--- a/test_othermlpackages/conda-lightgbm.yaml
+++ b/test_othermlpackages/conda-lightgbm.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
 - python==3.11
 - pip>=19.1.1
-- numpy
+- numpy<2.0.0
 - pandas
 - pytest
 - pytest-cov

--- a/test_othermlpackages/conda-lightgbm.yaml
+++ b/test_othermlpackages/conda-lightgbm.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
 - python==3.11
 - pip>=19.1.1
-- numpy<2.0.0
+- numpy==1.24.4
 - pandas
 - pytest
 - pytest-cov

--- a/test_othermlpackages/conda-tensorflow.yaml
+++ b/test_othermlpackages/conda-tensorflow.yaml
@@ -5,6 +5,7 @@ channels:
 dependencies:
 - python>=3.10
 - pip>=19.1.1
+- numpy==1.26.4
 - pytest
 - pytest-cov
 - tensorflow

--- a/test_othermlpackages/conda-tensorflow.yaml
+++ b/test_othermlpackages/conda-tensorflow.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
 - python>=3.10
 - pip>=19.1.1
-- numpy~=1.24.4
+- numpy>=1.24.4, <2
 - pytest
 - pytest-cov
 - tensorflow

--- a/test_othermlpackages/conda-tensorflow.yaml
+++ b/test_othermlpackages/conda-tensorflow.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
 - python>=3.10
 - pip>=19.1.1
-- numpy>=1.24.4, <2.0.0
+- numpy~=1.24.4
 - pytest
 - pytest-cov
 - tensorflow

--- a/test_othermlpackages/conda-tensorflow.yaml
+++ b/test_othermlpackages/conda-tensorflow.yaml
@@ -10,4 +10,4 @@ dependencies:
 - pytest-cov
 - tensorflow
 - pip:
-   - scikeras[tensorflow-cpu]<0.13
+   - scikeras[tensorflow-cpu]

--- a/test_othermlpackages/conda-tensorflow.yaml
+++ b/test_othermlpackages/conda-tensorflow.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
 - python>=3.10
 - pip>=19.1.1
-- numpy==1.26.4
+- numpy>=1.24.4, <2.0.0
 - pytest
 - pytest-cov
 - tensorflow


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
CI won't pass for this PR. I am proposing it here as a summary of the work done today, mostly by many different tries and builds in #1385. 

This PR adds the `numpy2.0.0` API guidelines in the `ruff` linter and fixes the found issues in 1b5f0bf6aeef770a4865a99002d8642c87b7eaba.

After the update, CI failed for two packages, `lightgbm` and `tensorflow`. I tried many different combinations to solve the problems in both configurations, and it seems for `lightgbm` limiting the version helps [cabcd69](https://github.com/fairlearn/fairlearn/pull/1387/commits/cabcd69094aa017517b9cab56f540233d05fc5ca). For `tensorflow` I am not able to find a consistent solution. 

Any ideas for a solution for this? Is it better maybe not to merge these changes, and to keep the version in the range as specified in [4cbaf64](https://github.com/fairlearn/fairlearn/pull/1384/commits/4cbaf6458c873a9efc302a1a74132d9a8bc9a53e)? 

<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
