### PR TITLE
MNT Add caching for branches in the doc and doctest CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
       - save_cache:
           key: v1-build-doc-datasets-{{ .Branch }}
           paths:
-            - ~/tmp-fairlearn
+            - ~/scikit_learn_data
 
       # additionally store artifacts to make them viewable in the CircleCI UX
       - store_artifacts:
@@ -137,7 +137,7 @@ jobs:
       - save_cache:
           key: v1-build-doctest-datasets-{{ .Branch }}
           paths:
-            - ~/tmp-fairlearn
+            - ~/scikit_learn_data
 
   deploy-doc:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,14 @@ jobs:
       # check out PR branch
       - checkout
 
+      - restore_cache:
+          key: v1-build-doc-datasets-{{ .Branch }}
+
+      - restore_cache:
+          keys:
+            - build-doc-ccache-{{ .Branch }}
+            - build-doc-ccache
+
       - run:
           name: Show Python version
           command: python --version
@@ -51,15 +59,26 @@ jobs:
           name: "Copy static pages"
           command: cp -r docs/static_landing_page/ docs/_build/
 
-      - persist_to_workspace:
-          root: docs/_build
-          paths: 
-            - html
-            - static_landing_page
+      - save_cache:
+          key: build-doc-ccache-{{ .Branch }}-{{ .BuildNum }}
+          paths:
+            - ~/.ccache
+            - ~/.cache/pip
+
+      - save_cache:
+          key: v1-build-doc-datasets-{{ .Branch }}
+          paths:
+            - ~/tmp-fairlearn
 
       # additionally store artifacts to make them viewable in the CircleCI UX
       - store_artifacts:
           path: docs/_build/html
+
+      - persist_to_workspace:
+          root: docs/_build
+          paths:
+            - html
+            - static_landing_page
 
   build-doctest:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,14 @@ jobs:
       # check out PR branch
       - checkout
 
+      - restore_cache:
+          key: v1-build-doctest-datasets-{{ .Branch }}
+
+      - restore_cache:
+          keys:
+            - build-doctest-ccache-{{ .Branch }}
+            - build-doctest-ccache
+
       - run:
           name: Show Python version
           command: python --version
@@ -119,6 +127,17 @@ jobs:
           name: 'Build doctest'
           command: python -m sphinx -v -b doctest -n -j auto docs docs/_build/html
           no_output_timeout: 30m
+
+      - save_cache:
+          key: build-doctest-ccache-{{ .Branch }}-{{ .BuildNum }}
+          paths:
+            - ~/.ccache
+            - ~/.cache/pip
+
+      - save_cache:
+          key: v1-build-doctest-datasets-{{ .Branch }}
+          paths:
+            - ~/tmp-fairlearn
 
   deploy-doc:
     docker:

--- a/fairlearn/adversarial/_preprocessor.py
+++ b/fairlearn/adversarial/_preprocessor.py
@@ -203,11 +203,11 @@ class FloatTransformer(BaseEstimator, TransformerMixin):
 
             # Because we are kind, we try to translate back to the original data
             # type, but we only support DataFrame, Series, list(, ndarray).
-            if self.in_type_ == DataFrame:
+            if self.in_type_ is DataFrame:
                 inverse = DataFrame(inverse, columns=self.columns_)
-            elif self.in_type_ == Series:
+            elif self.in_type_ is Series:
                 inverse = Series(inverse)
-            elif self.in_type_ == list:
+            elif self.in_type_ is list:
                 inverse = inverse.tolist()
         elif self.transformer is None:
             inverse = y


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
This PR follows up on the discussion in #703, specifically [this comment](https://github.com/fairlearn/fairlearn/issues/703#issuecomment-2200224570), in hopes to have less CI failures when OpenML datasets aren't available to download in order to run the examples.

More information about the CircleCI process [here](https://circleci.com/docs/caching/).
Inspiration taken from [scikit-learn](https://github.com/scikit-learn/scikit-learn/blob/main/.circleci/config.yml#L34-L49).

<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
