### PR TITLE
FIX all estimator checks related to: check_supervised_y_no_nan

### DIFF
--- a/fairlearn/adversarial/_adversarial_mitigation.py
+++ b/fairlearn/adversarial/_adversarial_mitigation.py
@@ -1000,7 +1000,6 @@ class AdversarialFairnessClassifier(_AdversarialFairness, ClassifierMixin):
                 "check_classifiers_train": ("the output must be of type numpy.array."),
                 "check_estimators_overwrite_params": "pickling is not possible.",
                 "check_classifier_data_not_an_array": ("data must be transformed into an array."),
-                "check_supervised_y_no_nan": ("cannot fit an array with inf values."),
                 "check_non_transformer_estimators_n_iter": (
                     "estimator is missing the _n_iter attribute."
                 ),
@@ -1248,7 +1247,6 @@ class AdversarialFairnessRegressor(_AdversarialFairness, RegressorMixin):
                 "check_estimators_dtypes": ("regressor estimator cannot look like multiclass."),
                 "check_fit2d_1feature": ("regressor estimator cannot look like binary."),
                 "check_fit2d_1sample": ("regressor estimator cannot look like binary."),
-                "check_supervised_y_no_nan": ("cannot fit an array with inf values."),
                 "check_regressor_data_not_an_array": ("data must be transformed into an array."),
                 "check_regressors_no_decision_function": (
                     "regressors should not have a decision function."

--- a/fairlearn/adversarial/_adversarial_mitigation.py
+++ b/fairlearn/adversarial/_adversarial_mitigation.py
@@ -14,7 +14,7 @@ from sklearn.base import (
 )
 from sklearn.exceptions import NotFittedError
 from sklearn.utils import check_scalar
-from sklearn.utils.validation import check_array, check_is_fitted, check_random_state
+from sklearn.utils.validation import check_is_fitted, check_random_state
 
 from ._backend_engine import BackendEngine
 from ._constants import (
@@ -577,7 +577,9 @@ class _AdversarialFairness(BaseEstimator):
             Two-dimensional array containing the model's (soft-)predictions
         """
         check_is_fitted(self)
-        X = check_X(X)
+        X = self._validate_data(
+            X, accept_sparse=False, accept_large_sparse=False, dtype=float, allow_nd=True
+        )
 
         Y_pred = self.backendEngine_.evaluate(X)
         return Y_pred
@@ -601,7 +603,9 @@ class _AdversarialFairness(BaseEstimator):
             the (discrete) :code:`predictor_function`
         """
         check_is_fitted(self)
-        X = check_X(X)
+        X = self._validate_data(
+            X, accept_sparse=False, accept_large_sparse=False, dtype=float, allow_nd=True
+        )
 
         Y_pred = self.backendEngine_.evaluate(X)
         Y_pred = self.predictor_function_(Y_pred)
@@ -617,7 +621,10 @@ class _AdversarialFairness(BaseEstimator):
         then always call `__setup`.
         """
         if not self.skip_validation:
-            X = check_X(X)
+            X = self._validate_data(
+                X, accept_sparse=False, accept_large_sparse=False, dtype=float, allow_nd=True
+            )
+            Y = self._validate_data(Y, ensure_2d=False)
 
         try:  # TODO check this
             check_is_fitted(self)
@@ -1255,24 +1262,3 @@ class AdversarialFairnessRegressor(_AdversarialFairness, RegressorMixin):
             },
             "requires_positive_X": True,
         }
-
-
-def check_X(X):
-    """
-    Validate the input array, and possible coerce to 2D.
-
-    Calls :code:`sklearn.utils.check_array` on parameter X with the
-    parameters suited for Adversarial Mitigation.
-
-    Returns
-    -------
-    X : numpy.ndarray
-        Cleaned data.
-    """
-    return check_array(
-        X,
-        accept_sparse=False,
-        accept_large_sparse=False,
-        dtype=float,
-        allow_nd=True,
-    ).astype(float)

--- a/test_othermlpackages/adversarial_fairness.py
+++ b/test_othermlpackages/adversarial_fairness.py
@@ -105,7 +105,7 @@ def test_examples():
             predictions == pos_label,
             sensitive_features=Z_test,
         )
-        accuracy = mean(predictions.values == Y_test.values)
+        accuracy = mean(predictions == Y_test.values)
         selection_rate = mean(predictions == pos_label)
         return dp_diff, accuracy, selection_rate
 


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
This PR fixes all failing estimator checks related to: `check_supervised_y_no_nan`. The custom `check_X` in `_adversarial_mitigation` is not necessary any more, so the API docs are accordingly generated. By inheriting from `sklearn.base.BaseEstimator`, we also inherit `BaseEstimator._validate_data` which contains the functionality.

The way the values are validated can be possibly further revised, but for the sake of a shorter PR and making progress on the xfailed estimator tests I'm proposing these changes now.

@adrinjalali 
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [ ] user guide added or updated
- [x] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
