### PR TITLE
FIX failing estimator checks: "check_classifiers_train" and "check_regressors_no_decision_function"

### DIFF
--- a/docs/user_guide/installation_and_version_guide/v0.11.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.11.0.rst
@@ -8,3 +8,6 @@ v0.11.0
 
 * Added disparity metric :code:`equal_opportunity_{difference,ratio}` as a frequently used alias
   for :code:`true_positive_rate_{difference,ratio}`.
+
+* Removed :code:`_AdversarialFairness.decision_function` because it did not follow the expected contract with
+  :code:`_AdversarialFairness.predict`.

--- a/fairlearn/adversarial/_adversarial_mitigation.py
+++ b/fairlearn/adversarial/_adversarial_mitigation.py
@@ -1005,10 +1005,6 @@ class AdversarialFairnessClassifier(_AdversarialFairness, ClassifierMixin):
         return {
             "_xfail_checks": {
                 "check_estimators_pickle": "pickling is not possible.",
-                "check_classifiers_train(readonly_memmap=True)": (
-                    "the output must be of type numpy.array."
-                ),
-                "check_classifiers_train": ("the output must be of type numpy.array."),
                 "check_estimators_overwrite_params": "pickling is not possible.",
                 "check_classifier_data_not_an_array": ("data must be transformed into an array."),
                 "check_non_transformer_estimators_n_iter": (

--- a/fairlearn/adversarial/_adversarial_mitigation.py
+++ b/fairlearn/adversarial/_adversarial_mitigation.py
@@ -1022,6 +1022,7 @@ class AdversarialFairnessClassifier(_AdversarialFairness, ClassifierMixin):
                 "check_supervised_y_2d": "DataConversionWarning not caught.",
             },
             "requires_positive_X": True,
+            "poor_score": True,
         }
 
 

--- a/fairlearn/adversarial/_adversarial_mitigation.py
+++ b/fairlearn/adversarial/_adversarial_mitigation.py
@@ -266,6 +266,7 @@ class _AdversarialFairness(BaseEstimator):
         infer something appropriate from data (see interpret_keyword).
         """
         self._validate_backend()
+        # Y = self._validate_data(Y)
 
         # Verify the constraints and set up the corresponding network structure.
         if self.constraints == "demographic_parity":

--- a/fairlearn/adversarial/_preprocessor.py
+++ b/fairlearn/adversarial/_preprocessor.py
@@ -5,7 +5,7 @@ from numpy import all as np_all
 from numpy import isin
 from numpy import sum as np_sum
 from numpy import unique
-from pandas import DataFrame, Series
+from pandas import DataFrame
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.preprocessing import OneHotEncoder
 from sklearn.utils import check_array
@@ -188,32 +188,17 @@ class FloatTransformer(BaseEstimator, TransformerMixin):
 
     def inverse_transform(self, y):
         """Transform y back to X using the inverse transform of the encoder."""
-        inverse = None
-        if isinstance(self.transformer, str):
-            if self.inferred_type_ in ["binary", "multiclass"]:
-                inverse = self.transform_.inverse_transform(y)
-            else:
-                # This is for:
-                # self.inferred_type_ in "continuous", "continuous-multioutput",
-                #                        "multilabel-indicator"
-                inverse = y
-
-            if self.input_dim_ == 1:
-                inverse = inverse.reshape(-1)
-
-            # Because we are kind, we try to translate back to the original data
-            # type, but we only support DataFrame, Series, list(, ndarray).
-            if self.in_type_ is DataFrame:
-                inverse = DataFrame(inverse, columns=self.columns_)
-            elif self.in_type_ is Series:
-                inverse = Series(inverse)
-            elif self.in_type_ is list:
-                inverse = inverse.tolist()
-        elif self.transformer is None:
+        if (
+            self.transformer is None
+            or isinstance(self.transformer, str)
+            and self.inferred_type_
+            in ["continuous", "continuous-multioutput", "multilabel-indicator"]
+        ):
             inverse = y
         else:
             inverse = self.transform_.inverse_transform(y)
 
+        inverse = inverse.reshape(-1) if self.input_dim_ == 1 else inverse
         return inverse
 
 

--- a/fairlearn/adversarial/_preprocessor.py
+++ b/fairlearn/adversarial/_preprocessor.py
@@ -198,8 +198,7 @@ class FloatTransformer(BaseEstimator, TransformerMixin):
         else:
             inverse = self.transform_.inverse_transform(y)
 
-        inverse = inverse.reshape(-1) if self.input_dim_ == 1 else inverse
-        return inverse
+        return inverse.reshape(-1) if self.input_dim_ == 1 else inverse
 
 
 def _get_type(data, assumption):

--- a/test/unit/adversarial/test_preprocessing.py
+++ b/test/unit/adversarial/test_preprocessing.py
@@ -1,10 +1,11 @@
 # Copyright (c) Fairlearn contributors.
 # Licensed under the MIT License.
 
-from fairlearn.adversarial._preprocessor import FloatTransformer
 import pytest
-from pandas import DataFrame, Series
-from numpy import ndarray, asarray, issubdtype
+from numpy import asarray, issubdtype, ndarray
+from pandas import Series
+
+from fairlearn.adversarial._preprocessor import FloatTransformer
 from fairlearn.datasets import fetch_adult
 
 
@@ -63,15 +64,13 @@ def checker(data, dist_type):
         and is_equal
         or isinstance(is_equal, ndarray)
         and is_equal.all()
-        or isinstance(is_equal, Series)
-        and is_equal.all()
-        or isinstance(is_equal, DataFrame)
+        or isinstance(is_equal, ndarray)
         and is_equal.all().all()
     )
 
 
 @pytest.mark.parametrize("data", list(data_generator()))
-@pytest.mark.parametrize("data_type", [None, DataFrame, Series, asarray])
+@pytest.mark.parametrize("data_type", [None, asarray])
 def test_data_as_datatypes(data, data_type):
     data, dist_type, *other = data
     if data_type:

--- a/test/unit/adversarial/test_preprocessing.py
+++ b/test/unit/adversarial/test_preprocessing.py
@@ -3,7 +3,6 @@
 
 import pytest
 from numpy import asarray, issubdtype, ndarray
-from pandas import Series
 
 from fairlearn.adversarial._preprocessor import FloatTransformer
 from fairlearn.datasets import fetch_adult
@@ -27,17 +26,11 @@ def data_generator():
     # NOTE: we comment out mixed-type lists, as this is just weird.
     yield [0, 1, 0, 0, 1], "binary"
     yield ["hi", "person", "hi", "hi"], "binary"
-    # yield [1, "hey", "hey", 1], 'binary', [asarray, Series, DataFrame]
-    # yield [2.1, "hey", "hey", 2.1], 'binary', [asarray, Series, DataFrame]
     yield [3, 2], "binary"
     yield [3, 2, 0, 1, 2, 5], "category"
     yield ["USA", "NL", "GB", "NL"], "category"
-    # yield [1, "hey", 4, "bye"], 'category', [asarray, Series, DataFrame]
-    yield [[0, 0, 1], [0, 1, 0], [0, 0, 1], [1, 0, 0]], "category", [Series]
     yield [1, 2, 6, 2, 1.1], "continuous"
     yield [0.1, 2.0, 0.999999, 100000.1], "continuous"
-    yield [[5.5, 12.2], [86.2, 81.1]], "continuous", [Series]
-    yield [[0, 1], [1, 0], [0.1, 2]], "continuous", [Series]
 
     # Larger examples.
     X, y = fetch_adult(return_X_y=True)


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
This PR is not big, but it adds multiple non-trivial changes.
- As proposed in #1395, the `check_classifiers_train` always expect a `numpy.array`, while until now the input type was preserved for `list`, `Dataframe` and `Series`. This is now removed, and while those inputs are still allowed, the output will always be a `numpy.array`.
- I removed `_AdversarialFairness.decision_function` of not upholding the expected contract with `_AdversarialFairness.predict` that the estimator checks demand. It's output is preserved in `_raw_predict`, which someone could use if necessary, and it is called by `predict`.
- Because of the lack of a decision function, the `check_regressors_no_decision_function` passes now too so it is removed from under the xfail tag.
- Some minor refactoring on top of those changes. The class and supporting files can be refactored further, I will propose subsequent PRs with those changes at some point.

@adrinjalali 

Added to changelog.
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [ ] new tests added
- [x] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [ ] user guide added or updated
- [x] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
