### PR TITLE
MNT Fix errors caused by three estimator checks

### DIFF
--- a/fairlearn/adversarial/_adversarial_mitigation.py
+++ b/fairlearn/adversarial/_adversarial_mitigation.py
@@ -589,11 +589,32 @@ class _AdversarialFairness(BaseEstimator):
 
     def _validate_input(self, X, y, A, reinitialize=False):
         """
-        Validate the input data and possibly setup this estimator.
+        Validate input data and optionally set up the estimator.
 
-        Important note is that we follow call `__setup` from here, because the
-        setup procedure requires the validated data. If `reintialize` is True,
-        then always call `__setup`.
+        Parameters
+        ----------
+        X : array-like
+            The input features.
+        y : array-like
+            The target values.
+        A : array-like
+            The sensitive features.
+        reinitialize : bool, default=False
+            If True, force reinitialization of the estimator.
+
+        Returns
+        -------
+        X : array-like
+            Validated input features.
+        y : array-like
+            Validated target values.
+        A : array-like
+            Validated sensitive features.
+
+        Notes
+        -----
+        This method calls `__setup` if the estimator is not fitted or if
+        `reinitialize` is True. The setup procedure requires validated data.
         """
         if not self.skip_validation:
             X = self._validate_data(

--- a/fairlearn/adversarial/_adversarial_mitigation.py
+++ b/fairlearn/adversarial/_adversarial_mitigation.py
@@ -413,7 +413,6 @@ class _AdversarialFairness(BaseEstimator):
             training data.
         """
         X, y, A = self._validate_input(X, y, sensitive_features, reinitialize=True)
-        self.classes_ = unique(y)
 
         # Not checked in __setup, because partial_fit may not require it.
         if self.epochs == -1 and self.max_iter == -1:
@@ -647,6 +646,8 @@ class _AdversarialFairness(BaseEstimator):
         if (not is_fitted) or (reinitialize):
             self.__setup(X, y, A)
 
+        self.classes_ = unique(y)
+        y = self._y_transform.transform(y)
         A = self._sf_transform.transform(A)
 
         if not self.skip_validation:

--- a/fairlearn/adversarial/_adversarial_mitigation.py
+++ b/fairlearn/adversarial/_adversarial_mitigation.py
@@ -603,7 +603,7 @@ class _AdversarialFairness(BaseEstimator):
                 dtype=float,
                 allow_nd=True,
             )
-            y = self._validate_data(y, ensure_2d=False)
+            y = self._validate_data(y, dtype=None, ensure_2d=False)
 
             check_consistent_length(X, y)
             check_consistent_length(X, A)
@@ -623,7 +623,6 @@ class _AdversarialFairness(BaseEstimator):
             self.__setup(X, y, A)
 
         if not self.skip_validation:
-            y = self._y_transform.transform(y)
             A = self._sf_transform.transform(A)
 
         if not self.skip_validation:
@@ -971,9 +970,6 @@ class AdversarialFairnessClassifier(_AdversarialFairness, ClassifierMixin):
                 ),
                 "check_classifiers_regression_target": ("the data cannot look continuous."),
                 "check_estimators_partial_fit_n_features": ("number of features cannot change."),
-                "check_classifiers_classes": (
-                    "decision function output must match classifier output."
-                ),
                 "check_supervised_y_2d": "DataConversionWarning not caught.",
             },
             "poor_score": True,

--- a/fairlearn/adversarial/_adversarial_mitigation.py
+++ b/fairlearn/adversarial/_adversarial_mitigation.py
@@ -760,10 +760,6 @@ class _AdversarialFairness(BaseEstimator):
         elif isinstance(self.predictor_function_, str):
             kw = self.predictor_function_
             if kw == "binary":
-
-                def binarization(pred):
-                    return (pred >= self.threshold_value).astype(float)
-
                 self.predictor_function_ = self._binary_predictor_function
             elif kw in ["multiclass", "multilabel-indicator"]:
 

--- a/fairlearn/adversarial/_adversarial_mitigation.py
+++ b/fairlearn/adversarial/_adversarial_mitigation.py
@@ -606,7 +606,6 @@ class _AdversarialFairness(BaseEstimator):
             y = self._validate_data(y, dtype=None, ensure_2d=False)
 
             check_consistent_length(X, y)
-            check_consistent_length(X, A)
 
         try:  # TODO check this
             check_is_fitted(self)
@@ -618,6 +617,9 @@ class _AdversarialFairness(BaseEstimator):
             logger.warning("No sensitive_features provided")
             logger.warning("Setting sensitive_features to zeros")
             A = zeros(len(y))
+
+        if not self.skip_validation:
+            check_consistent_length(X, A)
 
         if (not is_fitted) or (reinitialize):
             self.__setup(X, y, A)

--- a/fairlearn/adversarial/_adversarial_mitigation.py
+++ b/fairlearn/adversarial/_adversarial_mitigation.py
@@ -261,14 +261,16 @@ class _AdversarialFairness(BaseEstimator):
 
     def __setup(self, X, y, A):
         """
-        Initialize the entire model from the parameters and the given data.
+        Initialize model from parameters and data.
 
-        Following sklearn API, we do not do intialization in `__init__`, but
-        instead in `fit`. Firstly, we validate the backend. Then, we validate
-        some key-word arguments. Then, we initialize the BackendEngine, which
-        handles the initialization of the losses and optimizers. Among these
-        steps, if a loss or function is not explicitely defined, we try to
-        infer something appropriate from data (see interpret_keyword).
+        Validates backend and arguments, then initializes BackendEngine.
+        Infers appropriate losses and functions if not explicitly defined.
+        Called from `fit` method, not `__init__`, following sklearn API.
+
+        Parameters:
+        X : array-like, input features
+        y : array-like, target values
+        A : array-like, sensitive features
         """
         self._validate_backend()
 

--- a/fairlearn/adversarial/_adversarial_mitigation.py
+++ b/fairlearn/adversarial/_adversarial_mitigation.py
@@ -986,6 +986,8 @@ class AdversarialFairnessClassifier(_AdversarialFairness, ClassifierMixin):
     def _more_tags(self):
         return {
             "_xfail_checks": {
+                "check_estimators_pickle": "pickling is not possible.",
+                "check_estimators_overwrite_params": "pickling is not possible.",
                 "check_non_transformer_estimators_n_iter": (
                     "estimator is missing the _n_iter attribute."
                 ),
@@ -1188,6 +1190,8 @@ class AdversarialFairnessRegressor(_AdversarialFairness, RegressorMixin):
     def _more_tags(self):
         return {
             "_xfail_checks": {
+                "check_estimators_pickle": "pickling is not possible.",
+                "check_estimators_overwrite_params": "pickling is not possible.",
                 "check_methods_sample_order_invariance": ("fails for the predict() method."),
                 "check_non_transformer_estimators_n_iter": (
                     "estimator is missing the _n_iter attribute."

--- a/fairlearn/adversarial/_adversarial_mitigation.py
+++ b/fairlearn/adversarial/_adversarial_mitigation.py
@@ -645,8 +645,7 @@ class _AdversarialFairness(BaseEstimator):
         if (not is_fitted) or (reinitialize):
             self.__setup(X, y, A)
 
-        if not self.skip_validation:
-            A = self._sf_transform.transform(A)
+        A = self._sf_transform.transform(A)
 
         if not self.skip_validation:
             # Some backendEngine may want to do some additional preprocessing,

--- a/fairlearn/adversarial/_constants.py
+++ b/fairlearn/adversarial/_constants.py
@@ -10,13 +10,7 @@ _INVALID_DATA = (
     "Data of '{}' can not be interpreted. Only continuous data or array " + "with only 0s and 1s."
 )
 _INVALID_OHE = "One-hot-encoded matrix does not contain precisely 0 and 1"
-_PREDICTION_FUNCTION_AMBIGUOUS = (
-    "Can not interpret prediction_function. Please provide a callable as "
-    + "key-word argument that maps soft-probabilities "
-    + "(or more precisely, predictor_model output) "
-    + "to discrete prediction. Or, pass a "
-    + "key-word such as 'binary', 'category', or 'continuous'."
-)
+_PREDICTION_FUNCTION_AMBIGUOUS = "Unknown label type"
 _DIST_TYPE_NOT_IMPLEMENTED = (
     "BackendEngine {} has no loss function defined for the given " + "distribution type {}."
 )

--- a/fairlearn/adversarial/_preprocessor.py
+++ b/fairlearn/adversarial/_preprocessor.py
@@ -94,6 +94,8 @@ class FloatTransformer(BaseEstimator, TransformerMixin):
                 self.n_features_out_ = sum(
                     len(cat) if len(cat) != 2 else 1 for cat in self.transform_.categories_
                 )
+            if self.inferred_type_ in ["continous-multioutut", "multiclass-multioutput"]:
+                raise ValueError("Multioutput not supported")
         return self
 
     def transform(self, X):
@@ -116,8 +118,7 @@ class FloatTransformer(BaseEstimator, TransformerMixin):
         if (
             self.transformer is None
             or isinstance(self.transformer, str)
-            and self.inferred_type_
-            in ["continuous", "continuous-multioutput", "multilabel-indicator"]
+            and self.inferred_type_ == "continuous"
         ):
             inverse = y
         else:

--- a/fairlearn/adversarial/_preprocessor.py
+++ b/fairlearn/adversarial/_preprocessor.py
@@ -13,15 +13,25 @@ import fairlearn.utils._compatibility as compat
 
 class FloatTransformer(BaseEstimator, TransformerMixin):
     """
-    Transformer that maps dataframes to numpy arrays of floats.
+    Transformer that converts input data to numpy arrays of floats.
 
-    It is in essence a wrapper around sklearn transformers (meta-transformer)
-    that automatically infers the type of data, or makes sure the transformer
-    encodes it as floating point numbers. It applies one-hot-encoding
-    to categorical columns, and 'passthrough' (nothing) to
-    numerical columns. The usefulness of this class is that it can
-    preprocess different kinds of data (discrete, continuous) to one
-    standard format while also remembering what kind of data was inputted.
+    This class acts as a wrapper around scikit-learn transformers, automatically
+    inferring the data type and applying appropriate transformations. It serves
+    as a meta-transformer with the following key features:
+
+    1. Automatically detects the input data type (categorical or numerical).
+    2. Applies one-hot encoding to categorical data.
+    3. Passes numerical data through without modification.
+    4. Ensures all output is in the form of floating-point numpy arrays.
+
+    Attributes:
+        transformer : str, sklearn.base.TransformerMixin, or None
+            Specifies the transformation method. Can be "auto", a specific transformer
+            name (e.g., "one_hot_encoder"), None for pass-through, or a custom transformer object.
+
+    Note:
+        When using "auto", the class will attempt to choose the most appropriate
+        transformation based on the input data type.
     """
 
     def __init__(self, transformer="auto"):

--- a/test/unit/adversarial/helper.py
+++ b/test/unit/adversarial/helper.py
@@ -23,6 +23,7 @@ from fairlearn.adversarial._pytorch_engine import PytorchEngine
 from fairlearn.adversarial._tensorflow_engine import TensorflowEngine
 
 model_class = type("Model", (object,), {})
+Model = type("Model", (model_class,), {})
 
 
 Keyword_BINARY = "binary"
@@ -161,7 +162,7 @@ class fake_tensorflow:
             class GlorotNormal:  # noqa: D106
                 pass
 
-        Model = type("Model", (model_class,), {})
+        Model = Model
 
         class losses:
             """Mock of tf.keras.losses."""

--- a/test/unit/adversarial/helper.py
+++ b/test/unit/adversarial/helper.py
@@ -23,8 +23,6 @@ from fairlearn.adversarial._pytorch_engine import PytorchEngine
 from fairlearn.adversarial._tensorflow_engine import TensorflowEngine
 
 model_class = type("Model", (object,), {})
-Model = type("Model", (model_class,), {})
-
 
 Keyword_BINARY = "binary"
 Keyword_CATEGORY = "category"
@@ -162,7 +160,7 @@ class fake_tensorflow:
             class GlorotNormal:  # noqa: D106
                 pass
 
-        Model = Model
+        Model = type("Model", (model_class,), {})
 
         class losses:
             """Mock of tf.keras.losses."""

--- a/test/unit/adversarial/helper.py
+++ b/test/unit/adversarial/helper.py
@@ -13,7 +13,7 @@ here. Additionally, we generate data here.
 import sys
 
 import numpy as np
-from sklearn.datasets import make_classification, make_multilabel_classification
+from sklearn.datasets import make_classification
 
 from fairlearn.adversarial._adversarial_mitigation import (
     _AdversarialFairness,  # We just test the base class because this covers all
@@ -203,7 +203,6 @@ MultiClass2d, _ = make_classification(
     random_state=42, n_classes=3, n_clusters_per_class=1, n_samples=rows, n_features=cols
 )
 MultiClass1d = np.random.choice([0.0, 1.0, 0.2], size=(rows, 1))
-MultiLabel, _ = make_multilabel_classification(random_state=42, n_samples=rows, n_features=cols)
 
 
 def generate_data_combinations(n=10):

--- a/test/unit/adversarial/test_adversarial_mitigation.py
+++ b/test/unit/adversarial/test_adversarial_mitigation.py
@@ -24,7 +24,6 @@ from .helper import (
     KeywordToClass,
     MultiClass1d,
     MultiClass2d,
-    MultiLabel,
     cols,
     generate_data_combinations,
     get_instance,
@@ -328,7 +327,6 @@ def test_fake_models_df_inputs():
         (Cont2d, "continuous"),
         (MultiClass1d, "multiclass"),
         (MultiClass2d, "multiclass"),
-        (MultiLabel, "multilabel-indicator"),
     ],
 )
 def test_valid_input_data_types(data, valid_choice):


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
This PR fixes the errors raised by these three scikit-learn estimator checks:
- `check_estimators_pickle`
- `check_estimators_overwrite_params`
- `check_classifiers_classes`
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [ ] new tests added
- [x] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [ ] user guide added or updated
- [x] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->

@adrinjalali 