### PR TITLE
Update release wheel (deprecated actions)

### DIFF
--- a/.github/workflows/release-wheel.yml
+++ b/.github/workflows/release-wheel.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
     - name: Update pip and setuptools
@@ -46,7 +46,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Remove Fairlearn source directory

--- a/.github/workflows/release-wheel.yml
+++ b/.github/workflows/release-wheel.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 
-concurrency: 
+concurrency:
   # this ensures after each commit the old jobs are cancelled and the new ones
   # run instead.
   group: ${{ github.head_ref || github.run_id }}
@@ -31,7 +31,7 @@ jobs:
     - name: Build wheels
       run: python ./scripts/build_wheels.py --version-filename $VERSION_FILE_NAME
     - name: Save wheels to artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: env.WHEEL_ARTIFACT
         path: dist/


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
This PR updates the release wheel. 
Unfortunately, the `JesseTG/rm@v1.0.3` action hasn't been maintained in a long time and it cannot be updated straightforward, but [we could reference the hash of a merged commit as suggested in this issue](https://github.com/JesseTG/rm/issues/15#issuecomment-2328257081). That commit makes the necessary changes to move away from `node 16` which is deprecated. Anyone that has a replacement for it? 

@fairlearn/fairlearn-maintainers @adrinjalali 
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
