### PR TITLE
chore: revamp input manipulation unit tests

### DIFF
--- a/test/unit/utils/test_input_manipulations.py
+++ b/test/unit/utils/test_input_manipulations.py
@@ -1,91 +1,56 @@
 # Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
+from contextlib import AbstractContextManager
+
 import numpy as np
 import pytest
+from numpy.typing import NDArray
 
-import fairlearn.utils._input_manipulations as fmim
-
-
-class TestConvertToNDArrayAndSqueeze:
-    def test_simple_list(self):
-        X = [0, 1, 2]
-
-        result = fmim._convert_to_ndarray_and_squeeze(X)
-
-        assert isinstance(result, np.ndarray)
-        assert result.shape == (3,)
-        assert result[0] == 0
-        assert result[1] == 1
-        assert result[2] == 2
-
-    def test_multi_rows(self):
-        X = [[0], [1]]
-
-        result = fmim._convert_to_ndarray_and_squeeze(X)
-
-        assert isinstance(result, np.ndarray)
-        assert result.shape == (2,)
-        assert result[0] == 0
-        assert result[1] == 1
-
-    def test_multi_columns(self):
-        X = [[0, 1]]
-
-        result = fmim._convert_to_ndarray_and_squeeze(X)
-
-        assert isinstance(result, np.ndarray)
-        assert result.shape == (2,)
-        assert result[0] == 0
-        assert result[1] == 1
-
-    def test_single_element(self):
-        X = [[[1]]]
-
-        result = fmim._convert_to_ndarray_and_squeeze(X)
-
-        assert isinstance(result, np.ndarray)
-        assert result.shape == (1,)
-        assert result[0] == 1
+from fairlearn.utils._input_manipulations import (
+    _convert_to_ndarray_1d,
+    _convert_to_ndarray_and_squeeze,
+)
 
 
-class TestConvertToNDArray1D:
-    def test_simple_list(self):
-        X = [0, 1, 2]
+@pytest.mark.parametrize(
+    "X, expected",
+    [
+        ([0, 1, 2], np.array([0, 1, 2])),
+        ([[0], [1]], np.array([0, 1])),
+        ([[0, 1]], np.array([0, 1])),
+        ([[[1]]], np.array([1])),
+    ],
+)
+def test_convert_to_ndarray_and_squeeze(X, expected: NDArray):
+    result = _convert_to_ndarray_and_squeeze(X)
+    np.testing.assert_array_equal(result, expected)
 
-        result = fmim._convert_to_ndarray_1d(X)
 
-        assert isinstance(result, np.ndarray)
-        assert result.shape == (3,)
-        assert result[0] == 0
-        assert result[1] == 1
-        assert result[2] == 2
+@pytest.mark.parametrize(
+    "X, expected",
+    [
+        ([0, 1, 2], np.array([0, 1, 2])),
+        ([[4, 5]], np.array([4, 5])),
+        ([[5], [7]], np.array([5, 7])),
+    ],
+)
+def test_convert_to_ndarray_1d(X, expected: NDArray):
+    result = _convert_to_ndarray_1d(X)
+    np.testing.assert_array_equal(result, expected)
 
-    def test_simple_nested_list(self):
-        X = [[4, 5]]
 
-        result = fmim._convert_to_ndarray_1d(X)
-
-        assert isinstance(result, np.ndarray)
-        assert result.shape == (2,)
-        assert result[0] == 4
-        assert result[1] == 5
-
-    def test_simple_transposed_list(self):
-        X = [[5], [7]]
-
-        result = fmim._convert_to_ndarray_1d(X)
-
-        assert isinstance(result, np.ndarray)
-        assert result.shape == (2,)
-        assert result[0] == 5
-        assert result[1] == 7
-
-    def test_2d_raises_exception(self):
-        X = [[1, 2], [3, 4]]
-
-        with pytest.raises(ValueError) as exception_context:
-            _ = fmim._convert_to_ndarray_1d(X)
-
-        expected = "Supplied input array has more than one non-trivial dimension"
-        assert exception_context.value.args[0] == expected
+@pytest.mark.parametrize(
+    "X, expectation",
+    [
+        (
+            [[1, 2], [3, 4]],
+            pytest.raises(
+                ValueError, match="Supplied input array has more than one non-trivial dimension"
+            ),
+        )
+    ],
+)
+def test_convert_to_ndarray_1d_raises_exception(X, expectation: AbstractContextManager):
+    with expectation:
+        _convert_to_ndarray_1d(X)


### PR DESCRIPTION


## Description
The changes only concern rewriting the unit tests for input manipulation utils, namely:
- Used `np.testing.assert_equal_array` for array comparisons.
- Used pytest parametrization for running multiple test cases on the same function behaviour.
- Used pytest raises's `match` argument to assert equal expected error message.

No existing tests were removed/modified.
 
This a small PR suggestion whose purpose is mainly to get myself used to the dev process on `fairlearn` before potentially tackling more useful issues.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [x] new tests added
- [x] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [] user guide added or updated
- [x] API docs added or updated
- [x] example notebook added or updated

