### PR TITLE
Fix equalized odds exceptions

### DIFF
--- a/fairlearn/metrics/_disaggregated_result.py
+++ b/fairlearn/metrics/_disaggregated_result.py
@@ -103,7 +103,7 @@ class DisaggregatedResult:
 
     def apply_grouping(
         self,
-        grouping_function: str,
+        grouping_function: Literal["min", "max"],
         control_feature_names: Optional[List[str]] = None,
         errors: Literal["raise", "coerce"] = "raise",
     ) -> Union[pd.Series, pd.DataFrame]:
@@ -111,12 +111,11 @@ class DisaggregatedResult:
 
         Parameters
         ----------
-        grouping_function: string
-            Must be 'min' or 'max'
+        grouping_function: string {'min', 'max'}
         control_feature_names: Optional[List[str]]
             Names of the control features. Must appear in the index of the `overall`
             and `by_group` properties
-        errors: string {'raise', 'coerce'}, default 'raise'
+        errors: string {'raise', 'coerce'}, default :code:`raise`
             How to deal with any errors. Either coerce to `np.nan` or wrap the
             exception and reraise
 
@@ -204,9 +203,9 @@ class DisaggregatedResult:
 
         Parameters
         ----------
-        method : str
-            How to compute the aggregate. Default is :code:`between_groups`
-        errors: {'raise', 'coerce'}, default 'coerce'
+        method : {'between_groups', 'overall'}, default :code:`between_groups`
+            How to compute the aggregate.
+        errors: {'raise', 'coerce'}, default :code:`coerce`
             if 'raise', then invalid parsing will raise an exception
             if 'coerce', then invalid parsing will be set as NaN
 
@@ -263,9 +262,9 @@ class DisaggregatedResult:
 
         Parameters
         ----------
-        method : str
-            How to compute the aggregate. Default is :code:`between_groups`
-        errors: {'raise', 'coerce'}, default 'coerce'
+        method : {'between_groups', 'overall'}, default :code:`between_groups`
+            How to compute the aggregate.
+        errors: {'raise', 'coerce'}, default :code:`coerce`
             if 'raise', then invalid parsing will raise an exception
             if 'coerce', then invalid parsing will be set as NaN
 

--- a/fairlearn/metrics/_fairness_metrics.py
+++ b/fairlearn/metrics/_fairness_metrics.py
@@ -37,7 +37,7 @@ def demographic_parity_difference(
     sensitive_features : array-like
         The sensitive features over which demographic parity should be assessed
 
-    method : str
+    method : string {'between_groups', 'to_overall'}, default :code:`between_groups`
         How to compute the differences. See :func:`fairlearn.metrics.MetricFrame.difference`
         for details.
 
@@ -88,7 +88,7 @@ def demographic_parity_ratio(
     sensitive_features : array-like
         The sensitive features over which demographic parity should be assessed
 
-    method : str
+    method : string {'between_groups', 'to_overall'}, default :code:`between_groups`
         How to compute the differences. See :func:`fairlearn.metrics.MetricFrame.ratio`
         for details.
 
@@ -143,14 +143,14 @@ def equalized_odds_difference(
     sensitive_features : array-like
         The sensitive features over which equalized odds should be assessed
 
-    method : str
-        How to compute the differences.
-        See :func:`fairlearn.metrics.MetricFrame.difference` for details.
+    method : string {'between_groups', 'to_overall'}, default :code:`between_groups`
+        How to compute the differences. See :func:`fairlearn.metrics.MetricFrame.difference`
+        for details.
 
     sample_weight : array-like
         The sample weights
 
-    agg : str
+    agg : string {'worst_case', 'mean'}, default :code:`worst_case`
         The aggregation method. One of `"worst_case"` or `"mean"`.
         If `"worst_case"`, the greater one of the false positive rate
         difference and true positive rate difference is returned.
@@ -204,14 +204,14 @@ def equalized_odds_ratio(
     sensitive_features : array-like
         The sensitive features over which equalized odds should be assessed
 
-    method : str
+    method : string {'between_groups', 'to_overall'}, default :code:`between_groups`
         How to compute the differences. See :func:`fairlearn.metrics.MetricFrame.ratio`
         for details.
 
     sample_weight : array-like
         The sample weights
 
-    agg : str
+    agg : string {'worst_case', 'mean'}, default :code:`worst_case`
         The aggregation method. One of `"worst_case"` or `"mean"`.
         If `"worst_case"`, the smaller one of the false positive rate ratio
         and true positive rate ratio is returned.
@@ -275,7 +275,7 @@ def equal_opportunity_difference(
     sensitive_features : array-like
         The sensitive features over which equal opportunity should be assessed
 
-    method : str
+    method : string {'between_groups', 'to_overall'}, default :code:`between_groups`
         How to compute the differences. See :func:`fairlearn.metrics.MetricFrame.difference`
         for details.
 
@@ -326,7 +326,7 @@ def equal_opportunity_ratio(
     sensitive_features : array-like
         The sensitive features over which equal opportunity should be assessed
 
-    method : str
+    method : string {'between_groups', 'to_overall'}, default :code:`between_groups`
         How to compute the differences. See :func:`fairlearn.metrics.MetricFrame.ratio`
         for details.
 

--- a/fairlearn/metrics/_fairness_metrics.py
+++ b/fairlearn/metrics/_fairness_metrics.py
@@ -150,7 +150,7 @@ def equalized_odds_difference(
         The equalized odds difference
     """
     if agg not in ["worst_case", "mean"]:
-        return ValueError(f"agg must be one of 'worst_case' or 'mean', got {agg}")
+        raise ValueError(f"agg must be one of 'worst_case' or 'mean', got {agg}")
 
     eo = _get_eo_frame(y_true, y_pred, sensitive_features, sample_weight)
 
@@ -211,7 +211,7 @@ def equalized_odds_ratio(
         The equalized odds ratio
     """
     if agg not in ["worst_case", "mean"]:
-        return ValueError(f"agg must be one of 'worst_case' or 'mean', got {agg}")
+        raise ValueError(f"agg must be one of 'worst_case' or 'mean', got {agg}")
 
     eo = _get_eo_frame(y_true, y_pred, sensitive_features, sample_weight)
 

--- a/fairlearn/metrics/_fairness_metrics.py
+++ b/fairlearn/metrics/_fairness_metrics.py
@@ -3,12 +3,19 @@
 
 """Metrics for measuring fairness."""
 
+from typing import Literal
+
 from ._base_metrics import false_positive_rate, selection_rate, true_positive_rate
 from ._metric_frame import MetricFrame
 
 
 def demographic_parity_difference(
-    y_true, y_pred, *, sensitive_features, method="between_groups", sample_weight=None
+    y_true,
+    y_pred,
+    *,
+    sensitive_features,
+    method: Literal["between_groups", "to_overall"] = "between_groups",
+    sample_weight=None,
 ) -> float:
     """Calculate the demographic parity difference.
 
@@ -54,7 +61,12 @@ def demographic_parity_difference(
 
 
 def demographic_parity_ratio(
-    y_true, y_pred, *, sensitive_features, method="between_groups", sample_weight=None
+    y_true,
+    y_pred,
+    *,
+    sensitive_features,
+    method: Literal["between_groups", "to_overall"] = "between_groups",
+    sample_weight=None,
 ) -> float:
     """Calculate the demographic parity ratio.
 
@@ -104,9 +116,9 @@ def equalized_odds_difference(
     y_pred,
     *,
     sensitive_features,
-    method="between_groups",
+    method: Literal["between_groups", "to_overall"] = "between_groups",
     sample_weight=None,
-    agg="worst_case",
+    agg: Literal["worst_case", "mean"] = "worst_case",
 ) -> float:
     """Calculate the equalized odds difference.
 
@@ -165,9 +177,9 @@ def equalized_odds_ratio(
     y_pred,
     *,
     sensitive_features,
-    method="between_groups",
+    method: Literal["between_groups", "to_overall"] = "between_groups",
     sample_weight=None,
-    agg="worst_case",
+    agg: Literal["worst_case", "mean"] = "worst_case",
 ) -> float:
     """Calculate the equalized odds ratio.
 
@@ -236,7 +248,12 @@ def _get_eo_frame(y_true, y_pred, sensitive_features, sample_weight) -> MetricFr
 
 
 def equal_opportunity_difference(
-    y_true, y_pred, *, sensitive_features, method="between_groups", sample_weight=None
+    y_true,
+    y_pred,
+    *,
+    sensitive_features,
+    method: Literal["between_groups", "to_overall"] = "between_groups",
+    sample_weight=None,
 ) -> float:
     """Calculate the equal opportunity difference.
 
@@ -282,7 +299,12 @@ def equal_opportunity_difference(
 
 
 def equal_opportunity_ratio(
-    y_true, y_pred, *, sensitive_features, method="between_groups", sample_weight=None
+    y_true,
+    y_pred,
+    *,
+    sensitive_features,
+    method: Literal["between_groups", "to_overall"] = "between_groups",
+    sample_weight=None,
 ) -> float:
     """Calculate the equal opportunity ratio.
 

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -593,7 +593,7 @@ class MetricFrame:
     def _group(
         self,
         disagg_result: DisaggregatedResult,
-        grouping_function: str,
+        grouping_function: Literal["min", "max"],
         errors: Literal["raise", "coerce"] = "raise",
     ) -> Union[Any, pd.Series, pd.DataFrame]:
         """Return the minimum/maximum value of the metric over the sensitive features.
@@ -603,10 +603,10 @@ class MetricFrame:
         Parameters
         ----------
         disagg_result: The DisaggregatedResult containing all the metrics
-        grouping_function: {'min', 'max'}
-        errors: {'raise', 'coerce'}, default 'raise'
-        if 'raise', then invalid parsing will raise an exception
-        if 'coerce', then invalid parsing will be set as NaN
+        grouping_function: string {'min', 'max'}
+        errors: {'raise', 'coerce'}, default :code:`raise`
+            if 'raise', then invalid parsing will raise an exception
+            if 'coerce', then invalid parsing will be set as NaN
 
         Returns
         -------
@@ -624,7 +624,7 @@ class MetricFrame:
         self,
         bootstrap_samples: List[DisaggregatedResult],
         ci_quantiles: List[float],
-        grouping_function: str,
+        grouping_function: Literal["min", "max"],
     ) -> Union[List[Any], List[pd.Series], List[pd.DataFrame]]:
         # There is no 'errors' argument because everything must have been a scalar for
         # np.quantiles
@@ -654,7 +654,7 @@ class MetricFrame:
 
         Parameters
         ----------
-        errors: {'raise', 'coerce'}, default 'raise'
+        errors: {'raise', 'coerce'}, default :code:`raise`
             if 'raise', then invalid parsing will raise an exception
             if 'coerce', then invalid parsing will be set as NaN
 
@@ -705,7 +705,7 @@ class MetricFrame:
 
         Parameters
         ----------
-        errors: {'raise', 'coerce'}, default 'raise'
+        errors: {'raise', 'coerce'}, default :code:`raise`
             if 'raise', then invalid parsing will raise an exception
             if 'coerce', then invalid parsing will be set as NaN
 
@@ -768,9 +768,9 @@ class MetricFrame:
 
         Parameters
         ----------
-        method : str
-            How to compute the aggregate. Default is :code:`between_groups`
-        errors: {'raise', 'coerce'}, default 'coerce'
+        method : string {'between_groups', 'to_overall'}, default :code:`between_groups`
+            How to compute the aggregate.
+        errors: {'raise', 'coerce'}, default :code:`coerce`
             if 'raise', then invalid parsing will raise an exception
             if 'coerce', then invalid parsing will be set as NaN
 
@@ -805,6 +805,11 @@ class MetricFrame:
 
         Unlike :meth:`MetricFrame.difference` there is no :code:`errors` parameter, because
         a bootstrapped :class:`MetricFrame` requires all the metrics to return scalars.
+
+        Parameters
+        ----------
+        method : string {'between_groups', 'to_overall'}, default :code:`between_groups`
+            How to compute the aggregate.
         """
         if method not in _COMPARE_METHODS:
             raise ValueError(_INVALID_COMPARE_METHOD.format(method))
@@ -842,9 +847,9 @@ class MetricFrame:
 
         Parameters
         ----------
-        method : str
-            How to compute the aggregate. Default is :code:`between_groups`
-        errors: {'raise', 'coerce'}, default 'coerce'
+        method : string {'between_groups', 'to_overall'}, default :code:`between_groups`
+            How to compute the aggregate.
+        errors: {'raise', 'coerce'}, default :code:`coerce`
             if 'raise', then invalid parsing will raise an exception
             if 'coerce', then invalid parsing will be set as NaN
 
@@ -879,6 +884,11 @@ class MetricFrame:
 
         Unlike :meth:`MetricFrame.ratio` there is no :code:`errors` parameter, because
         a bootstrapped :class:`MetricFrame` requires all the metrics to return scalars.
+
+        Parameters
+        ----------
+        method : string {'between_groups', 'to_overall'}, default :code:`between_groups`
+            How to compute the aggregate.
         """
         if method not in _COMPARE_METHODS:
             raise ValueError(_INVALID_COMPARE_METHOD.format(method))

--- a/test/unit/metrics/test_fairness_metrics.py
+++ b/test/unit/metrics/test_fairness_metrics.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
+from collections.abc import Callable
 from contextlib import AbstractContextManager
 from contextlib import nullcontext as does_not_raise
 from itertools import product
@@ -171,29 +172,14 @@ def test_equalized_odds_ratio_weighted(agg_method, agg):
         ("worst_case", does_not_raise()),
     ],
 )
-def test_equalized_odds_difference_raises_on_invalid_agg(
-    agg: str, expectation: AbstractContextManager
+@pytest.mark.parametrize(
+    "equalized_odds_metric", [equalized_odds_difference, equalized_odds_ratio]
+)
+def test_equalized_odds_metrics_raise_on_invalid_agg(
+    equalized_odds_metric: Callable, agg: str, expectation: AbstractContextManager
 ):
     with expectation:
-        equalized_odds_difference(y_t, y_p, sensitive_features=g_1, agg=agg)
-
-
-@pytest.mark.parametrize(
-    ["agg", "expectation"],
-    [
-        (
-            "wrong-arg",
-            pytest.raises(
-                ValueError, match="agg must be one of 'worst_case' or 'mean', got wrong-arg"
-            ),
-        ),
-        ("mean", does_not_raise()),
-        ("worst_case", does_not_raise()),
-    ],
-)
-def test_equalized_odds_ratio_raises_on_invalid_agg(agg: str, expectation: AbstractContextManager):
-    with expectation:
-        equalized_odds_ratio(y_t, y_p, sensitive_features=g_1, agg=agg)
+        equalized_odds_metric(y_t, y_p, sensitive_features=g_1, agg=agg)
 
 
 @pytest.mark.parametrize("agg_method", _aggregate_methods)

--- a/test/unit/metrics/test_fairness_metrics.py
+++ b/test/unit/metrics/test_fairness_metrics.py
@@ -1,7 +1,10 @@
 # Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
+from contextlib import AbstractContextManager
+from contextlib import nullcontext as does_not_raise
 from itertools import product
+
 import pytest
 
 from fairlearn.metrics import (
@@ -153,6 +156,44 @@ def test_equalized_odds_ratio_weighted(agg_method, agg):
         assert actual == ratios.min()
     else:
         assert actual == ratios.mean()
+
+
+@pytest.mark.parametrize(
+    ["agg", "expectation"],
+    [
+        (
+            "wrong-arg",
+            pytest.raises(
+                ValueError, match="agg must be one of 'worst_case' or 'mean', got wrong-arg"
+            ),
+        ),
+        ("mean", does_not_raise()),
+        ("worst_case", does_not_raise()),
+    ],
+)
+def test_equalized_odds_difference_raises_on_invalid_agg(
+    agg: str, expectation: AbstractContextManager
+):
+    with expectation:
+        equalized_odds_difference(y_t, y_p, sensitive_features=g_1, agg=agg)
+
+
+@pytest.mark.parametrize(
+    ["agg", "expectation"],
+    [
+        (
+            "wrong-arg",
+            pytest.raises(
+                ValueError, match="agg must be one of 'worst_case' or 'mean', got wrong-arg"
+            ),
+        ),
+        ("mean", does_not_raise()),
+        ("worst_case", does_not_raise()),
+    ],
+)
+def test_equalized_odds_ratio_raises_on_invalid_agg(agg: str, expectation: AbstractContextManager):
+    with expectation:
+        equalized_odds_ratio(y_t, y_p, sensitive_features=g_1, agg=agg)
 
 
 @pytest.mark.parametrize("agg_method", _aggregate_methods)


### PR DESCRIPTION
## Context
Hello ! This small PR has two commits:
- The first commit is the main one: it fixes the `agg` argument's validation in the two `equalized odds` functions, by raising instead of returning an exception. I added a couple of unit tests to cover that branch.
- The second commit is less important, it's just a follow-up on [my previous PR,](https://github.com/fairlearn/fairlearn/pull/1432) where I missed a couple of literals :sweat_smile: 

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [x] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

