### PR TITLE
fix: type hints within metrics

### DIFF
--- a/fairlearn/metrics/_annotated_metric_function.py
+++ b/fairlearn/metrics/_annotated_metric_function.py
@@ -1,9 +1,10 @@
 # Copyright (c) Fairlearn contributors.
 # Licensed under the MIT License.
+from __future__ import annotations
 
 import logging
 import warnings
-from typing import Callable, Dict, List, Optional
+from typing import Callable
 
 import numpy as np
 import pandas as pd
@@ -30,12 +31,12 @@ class AnnotatedMetricFunction:
     ----------
     func : callable
         The metric function we wish to invoke
-    name: str
+    name: str | None
         An optional string defining the name of the function
-    positional_argument_names: List[str]
+    positional_argument_names: list[str] | None
         The column names to be extracted and passed as positional arguments
         when invoking the function
-    kw_argument_mapping: Dict[str, str]
+    kw_argument_mapping: dict[str, str] | None
         The column names which are to be passed as keyword arguments
         when invoking the function. Since the DataFrame column names may
         not match the function's argument names, this is a dictionary
@@ -47,9 +48,9 @@ class AnnotatedMetricFunction:
         self,
         *,
         func: Callable,
-        name: Optional[str],
-        positional_argument_names: Optional[List[str]] = None,
-        kw_argument_mapping: Optional[Dict[str, str]] = None,
+        name: str | None = None,
+        positional_argument_names: list[str] | None = None,
+        kw_argument_mapping: dict[str, str] | None = None,
     ):
         if func is None:
             raise ValueError(_METRIC_FUNCTION_NONE)

--- a/fairlearn/metrics/_annotated_metric_function.py
+++ b/fairlearn/metrics/_annotated_metric_function.py
@@ -48,8 +48,8 @@ class AnnotatedMetricFunction:
         *,
         func: Callable,
         name: Optional[str],
-        positional_argument_names: List[str] = None,
-        kw_argument_mapping: Dict[str, str] = None,
+        positional_argument_names: Optional[List[str]] = None,
+        kw_argument_mapping: Optional[Dict[str, str]] = None,
     ):
         if func is None:
             raise ValueError(_METRIC_FUNCTION_NONE)

--- a/fairlearn/metrics/_bootstrap.py
+++ b/fairlearn/metrics/_bootstrap.py
@@ -1,8 +1,9 @@
 # Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
+from __future__ import annotations
 
 import logging
-from typing import Dict, List, Optional, Union
+from typing import List
 
 import numpy as np
 import pandas as pd
@@ -19,11 +20,11 @@ BOOTSTRAP_QUANTILE_ERROR = (
 
 def generate_single_bootstrap_sample(
     *,
-    random_state: Union[int, np.random.RandomState],
+    random_state: int | np.random.RandomState,
     data: pd.DataFrame,
-    annotated_functions: Dict[str, AnnotatedMetricFunction],
-    sensitive_feature_names: List[str],
-    control_feature_names: Optional[List[str]],
+    annotated_functions: dict[str, AnnotatedMetricFunction],
+    sensitive_feature_names: list[str],
+    control_feature_names: list[str] | None = None,
 ) -> DisaggregatedResult:
     """Create a single bootstrapped DisaggregatedResult."""
     assert random_state is not None, "Must specify random_state"
@@ -44,11 +45,11 @@ def generate_single_bootstrap_sample(
 def generate_bootstrap_samples(
     *,
     n_samples: int,
-    random_state: Optional[Union[int, np.random.RandomState]],
+    random_state: int | np.random.RandomState | None,
     data: pd.DataFrame,
-    annotated_functions: Dict[str, AnnotatedMetricFunction],
-    sensitive_feature_names: List[str],
-    control_feature_names: Optional[List[str]],
+    annotated_functions: dict[str, AnnotatedMetricFunction],
+    sensitive_feature_names: list[str],
+    control_feature_names: list[str] | None = None,
 ) -> List[DisaggregatedResult]:
     """Create a list of bootstrapped DisaggregatedResults.
 
@@ -84,7 +85,7 @@ def generate_bootstrap_samples(
     return result
 
 
-def _calc_series_quantiles(*, quantiles: List[float], samples: List[pd.Series]) -> List[pd.Series]:
+def _calc_series_quantiles(*, quantiles: list[float], samples: list[pd.Series]) -> list[pd.Series]:
     for s in samples:
         assert isinstance(s, pd.Series)
         assert s.name == samples[0].name
@@ -103,8 +104,8 @@ def _calc_series_quantiles(*, quantiles: List[float], samples: List[pd.Series]) 
 
 
 def _calc_dataframe_quantiles(
-    *, quantiles: List[float], samples: List[pd.DataFrame]
-) -> List[pd.DataFrame]:
+    *, quantiles: list[float], samples: list[pd.DataFrame]
+) -> list[pd.DataFrame]:
     for s in samples:
         assert isinstance(s, pd.DataFrame)
         assert all(s.columns == samples[0].columns)
@@ -127,8 +128,8 @@ def _calc_dataframe_quantiles(
 
 
 def calculate_pandas_quantiles(
-    quantiles: List[float], bootstrap_samples: List[Union[pd.Series, pd.DataFrame]]
-) -> Union[List[pd.Series], List[pd.DataFrame]]:
+    quantiles: list[float], bootstrap_samples: list[pd.Series | pd.DataFrame]
+) -> list[pd.Series] | list[pd.DataFrame]:
     """Calculate quantiles for a list of pandas objects."""
     if isinstance(bootstrap_samples[0], pd.Series):
         result = _calc_series_quantiles(quantiles=quantiles, samples=bootstrap_samples)

--- a/fairlearn/metrics/_disaggregated_result.py
+++ b/fairlearn/metrics/_disaggregated_result.py
@@ -182,7 +182,7 @@ class DisaggregatedResult:
 
     def difference(
         self,
-        control_feature_names: Optional[List[str]],
+        control_feature_names: Optional[List[str]] = None,
         method: Literal["between_groups", "to_overall"] = "between_groups",
         errors: Literal["raise", "coerce"] = "coerce",
     ) -> Union[pd.Series, pd.DataFrame]:
@@ -203,6 +203,9 @@ class DisaggregatedResult:
 
         Parameters
         ----------
+        control_feature_names: Optional[List[str]]
+            Names of the control features. Must appear in the index of the `overall`
+            and `by_group` properties
         method : {'between_groups', 'overall'}, default :code:`between_groups`
             How to compute the aggregate.
         errors: {'raise', 'coerce'}, default :code:`coerce`
@@ -239,7 +242,7 @@ class DisaggregatedResult:
 
     def ratio(
         self,
-        control_feature_names: Optional[List[str]],
+        control_feature_names: Optional[List[str]] = None,
         method: Literal["between_groups", "to_overall"] = "between_groups",
         errors: Literal["raise", "coerce"] = "coerce",
     ) -> Union[pd.Series, pd.DataFrame]:
@@ -262,6 +265,9 @@ class DisaggregatedResult:
 
         Parameters
         ----------
+        control_feature_names: Optional[List[str]]
+            Names of the control features. Must appear in the index of the `overall`
+            and `by_group` properties
         method : {'between_groups', 'overall'}, default :code:`between_groups`
             How to compute the aggregate.
         errors: {'raise', 'coerce'}, default :code:`coerce`
@@ -316,7 +322,7 @@ class DisaggregatedResult:
         data: pd.DataFrame,
         annotated_functions: Dict[str, AnnotatedMetricFunction],
         sensitive_feature_names: List[str],
-        control_feature_names: Optional[List[str]],
+        control_feature_names: Optional[List[str]] = None,
     ) -> "DisaggregatedResult":
         """Manufacture a DisaggregatedResult.
 

--- a/fairlearn/metrics/_disaggregated_result.py
+++ b/fairlearn/metrics/_disaggregated_result.py
@@ -182,7 +182,7 @@ class DisaggregatedResult:
 
     def difference(
         self,
-        control_feature_names: List[str],
+        control_feature_names: Optional[List[str]],
         method: Literal["between_groups", "to_overall"] = "between_groups",
         errors: Literal["raise", "coerce"] = "coerce",
     ) -> Union[pd.Series, pd.DataFrame]:
@@ -239,7 +239,7 @@ class DisaggregatedResult:
 
     def ratio(
         self,
-        control_feature_names: List[str],
+        control_feature_names: Optional[List[str]],
         method: Literal["between_groups", "to_overall"] = "between_groups",
         errors: Literal["raise", "coerce"] = "coerce",
     ) -> Union[pd.Series, pd.DataFrame]:

--- a/fairlearn/metrics/_disaggregated_result.py
+++ b/fairlearn/metrics/_disaggregated_result.py
@@ -1,8 +1,9 @@
 # Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
+from __future__ import annotations
 
 import logging
-from typing import Dict, List, Literal, Optional, Union
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -26,7 +27,7 @@ _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE = (
 )
 
 
-def extract_unique_classes(data: pd.DataFrame, feature_list: List[str]) -> Dict[str, np.ndarray]:
+def extract_unique_classes(data: pd.DataFrame, feature_list: list[str]) -> dict[str, np.ndarray]:
     """Compute unique values in a given set of columns."""
     result = dict()
     for feature in feature_list:
@@ -36,7 +37,7 @@ def extract_unique_classes(data: pd.DataFrame, feature_list: List[str]) -> Dict[
 
 def apply_to_dataframe(
     data: pd.DataFrame,
-    metric_functions: Dict[str, AnnotatedMetricFunction],
+    metric_functions: dict[str, AnnotatedMetricFunction],
     include_groups: bool = False,
 ) -> pd.Series:
     """Apply metric functions to a DataFrame.
@@ -85,14 +86,14 @@ class DisaggregatedResult:
         the sensitive and control features
     """
 
-    def __init__(self, overall: Union[pd.Series, pd.DataFrame], by_group: pd.DataFrame):
+    def __init__(self, overall: pd.Series | pd.DataFrame, by_group: pd.DataFrame):
         """Construct an object."""
         self._overall = overall
         assert isinstance(by_group, pd.DataFrame)
         self._by_group = by_group
 
     @property
-    def overall(self) -> Union[pd.Series, pd.DataFrame]:
+    def overall(self) -> pd.Series | pd.DataFrame:
         """Return overall metrics."""
         return self._overall
 
@@ -104,15 +105,15 @@ class DisaggregatedResult:
     def apply_grouping(
         self,
         grouping_function: Literal["min", "max"],
-        control_feature_names: Optional[List[str]] = None,
+        control_feature_names: list[str] | None = None,
         errors: Literal["raise", "coerce"] = "raise",
-    ) -> Union[pd.Series, pd.DataFrame]:
+    ) -> pd.Series | pd.DataFrame:
         """Compute mins or maxes.
 
         Parameters
         ----------
         grouping_function: string {'min', 'max'}
-        control_feature_names: Optional[List[str]]
+        control_feature_names: list[str] | None
             Names of the control features. Must appear in the index of the `overall`
             and `by_group` properties
         errors: string {'raise', 'coerce'}, default :code:`raise`
@@ -182,10 +183,10 @@ class DisaggregatedResult:
 
     def difference(
         self,
-        control_feature_names: Optional[List[str]] = None,
+        control_feature_names: list[str] | None = None,
         method: Literal["between_groups", "to_overall"] = "between_groups",
         errors: Literal["raise", "coerce"] = "coerce",
-    ) -> Union[pd.Series, pd.DataFrame]:
+    ) -> pd.Series | pd.DataFrame:
         """Return the maximum absolute difference between groups for each metric.
 
         This method calculates a scalar value for each underlying metric by
@@ -203,7 +204,7 @@ class DisaggregatedResult:
 
         Parameters
         ----------
-        control_feature_names: Optional[List[str]]
+        control_feature_names: list[str] | None
             Names of the control features. Must appear in the index of the `overall`
             and `by_group` properties
         method : {'between_groups', 'overall'}, default :code:`between_groups`
@@ -242,10 +243,10 @@ class DisaggregatedResult:
 
     def ratio(
         self,
-        control_feature_names: Optional[List[str]] = None,
+        control_feature_names: list[str] | None = None,
         method: Literal["between_groups", "to_overall"] = "between_groups",
         errors: Literal["raise", "coerce"] = "coerce",
-    ) -> Union[pd.Series, pd.DataFrame]:
+    ) -> pd.Series | pd.DataFrame:
         """Return the minimum ratio between groups for each metric.
 
         This method calculates a scalar value for each underlying metric by
@@ -265,7 +266,7 @@ class DisaggregatedResult:
 
         Parameters
         ----------
-        control_feature_names: Optional[List[str]]
+        control_feature_names: list[str] | None
             Names of the control features. Must appear in the index of the `overall`
             and `by_group` properties
         method : {'between_groups', 'overall'}, default :code:`between_groups`
@@ -320,9 +321,9 @@ class DisaggregatedResult:
     def create(
         *,
         data: pd.DataFrame,
-        annotated_functions: Dict[str, AnnotatedMetricFunction],
-        sensitive_feature_names: List[str],
-        control_feature_names: Optional[List[str]] = None,
+        annotated_functions: dict[str, AnnotatedMetricFunction],
+        sensitive_feature_names: list[str],
+        control_feature_names: list[str] | None = None,
     ) -> "DisaggregatedResult":
         """Manufacture a DisaggregatedResult.
 
@@ -342,12 +343,12 @@ class DisaggregatedResult:
         ----------
         data : DataFrame
             A DataFrame containing all of the columns required to compute the metrics
-        annotated_functions: Dict[str, AnnotatedMetricFunction]
+        annotated_functions: dict[str, AnnotatedMetricFunction]
             A dictionary of metric functions, each of which is annotated with the
             mapping of columns in `data` to argument names in the function
-        sensitive_feature_names: List[str]
+        sensitive_feature_names: list[str]
             The list of columns in `data` which correspond to the sensitive feature(s)
-        control_feature_names: Optional[List[str]]
+        control_feature_names: list[str] | None
             Optional list of columns in `data` which correspond to the control features,
             if any
 

--- a/fairlearn/metrics/_group_feature.py
+++ b/fairlearn/metrics/_group_feature.py
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
-
-from typing import Optional
+from __future__ import annotations
 
 import numpy as np
 import pandas as pd
@@ -42,11 +41,11 @@ class GroupFeature:
     index : int
         Used together with `base_name` when automatically generating a name
 
-    name : str
+    name : str | None
         Optional name for the feature
     """
 
-    def __init__(self, base_name: str, feature_vector, index: int, name: Optional[str]):
+    def __init__(self, base_name: str, feature_vector, index: int, name: str | None = None):
         """Help with the metrics."""
         self.classes_ = np.unique(feature_vector)
         self.raw_feature_ = feature_vector

--- a/fairlearn/metrics/_make_derived_metric.py
+++ b/fairlearn/metrics/_make_derived_metric.py
@@ -1,9 +1,10 @@
 # Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
+from __future__ import annotations
 
 import functools
 import inspect
-from typing import Callable, List, Union
+from typing import Callable, Union
 
 from ._metric_frame import MetricFrame
 
@@ -28,9 +29,9 @@ class _DerivedMetric:
     def __init__(
         self,
         *,
-        metric: Callable[..., Union[float, int]],
+        metric: Callable[..., float | int],
         transform: str,
-        sample_param_names: List[str],
+        sample_param_names: list[str],
     ):
         if not callable(metric):
             raise ValueError(_METRIC_CALLABLE_ERROR)
@@ -93,10 +94,10 @@ class _DerivedMetric:
 
 def make_derived_metric(
     *,
-    metric: Callable[..., Union[float, int]],
+    metric: Callable[..., float | int],
     transform: str,
-    sample_param_names: List[str] = ["sample_weight"],
-) -> Callable[..., Union[float, int]]:
+    sample_param_names: list[str] = ["sample_weight"],
+) -> Callable[..., float | int]:
     """Create a scalar returning metric function based on aggregation of a disaggregated metric.
 
     Many higher order machine learning operations (such as hyperparameter tuning)
@@ -134,7 +135,7 @@ def make_derived_metric(
         The list of possible options is:
         ['difference', 'group_min', 'group_max', 'ratio'].
 
-    sample_param_names : List[str]
+    sample_param_names : list[str]
         A list of parameters names of the underlying :code:`metric` which should
         be treated as sample parameters (i.e. the same leading dimension as the
         :code:`y_true` and :code:`y_pred` parameters). This defaults to a list with

--- a/fairlearn/metrics/_plot_model_comparison.py
+++ b/fairlearn/metrics/_plot_model_comparison.py
@@ -1,8 +1,9 @@
 # Copyright (c) Fairlearn contributors.
 # Licensed under the MIT License.
+from __future__ import annotations
 
 import logging
-from typing import Callable, Union
+from typing import Callable
 
 from numpy import array, zeros
 from sklearn.utils.validation import check_array
@@ -23,8 +24,8 @@ def plot_model_comparison(
     y_preds,
     y_true=None,
     sensitive_features=None,
-    x_axis_metric: Callable[..., Union[float, int]] = None,
-    y_axis_metric: Callable[..., Union[float, int]] = None,
+    x_axis_metric: Callable[..., float | int] | None = None,
+    y_axis_metric: Callable[..., float | int] | None = None,
     ax=None,
     axis_labels=True,
     point_labels=False,
@@ -46,19 +47,19 @@ def plot_model_comparison(
         An array-like containing predictions per model. Hence, predictions of
         model :code:`i` should be in :code:`y_preds[i]`.
 
-    y_true : List, pandas.Series, numpy.ndarray, pandas.DataFrame
+    y_true : list, pandas.Series, numpy.ndarray, pandas.DataFrame
         The ground-truth labels (for classification) or target values (for regression).
 
-    sensitive_features : List, pandas.Series, dict of 1d arrays, numpy.ndarray, pandas.DataFrame, optional
+    sensitive_features : list, pandas.Series, dict of 1d arrays, numpy.ndarray, pandas.DataFrame, None
         Sensitive features for the fairness metrics (if a fairness metric is
         specified for the x-axis or the y-axis).
 
-    x_axis_metric : Callable
+    x_axis_metric : Callable | None
         The metric function for the x-axis.
         The metric function must take `y_true`, `y_pred`, and optionally `sensitive_features`
         as arguments, and return a scalar value.
 
-    y_axis_metric : Callable
+    y_axis_metric : Callable | None
         The metric function for the y-axis, similar to x_axis_metric.
         The metric function must take `y_true`, `y_pred`, and optionally `sensitive_features`
         as arguments, and return a scalar value.

--- a/fairlearn/metrics/_plotter.py
+++ b/fairlearn/metrics/_plotter.py
@@ -3,7 +3,7 @@
 
 """Utility class for plotting metrics with and without confidence interval ranges."""
 
-from typing import List, Optional, Union
+from __future__ import annotations
 
 import numpy as np
 import pandas as pd
@@ -118,8 +118,8 @@ def plot_metric_frame(
     metric_frame: MetricFrame,
     *,
     kind: str = "point",
-    metrics: Optional[Union[List[str], str]] = None,
-    conf_intervals: Optional[Union[List[str], str]] = None,
+    metrics: list[str] | str | None = None,
+    conf_intervals: list[str] | str | None = None,
     subplots: bool = True,
     plot_ci_labels: bool = False,
     ci_labels_precision: int = 4,
@@ -149,11 +149,11 @@ def plot_metric_frame(
         The type of plot to display, e.g., "point", "bar", "line", etc.
         The supported values are "point" and those listed in :meth:`pandas.DataFrame.plot`
 
-    metrics : str or list of str
+    metrics : list[str] | str | None
         The name of the metrics to plot.
         Should match columns from the given :class:`fairlearn.metrics.MetricFrame`.
 
-    conf_intervals : str or list of str
+    conf_intervals : list[str] | str | None
         The name of the confidence intervals to plot.
         Should match columns from the given :class:`fairlearn.metrics.MetricFrame`.
 

--- a/fairlearn/metrics/_plotter.py
+++ b/fairlearn/metrics/_plotter.py
@@ -3,7 +3,7 @@
 
 """Utility class for plotting metrics with and without confidence interval ranges."""
 
-from typing import List, Union
+from typing import List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -118,8 +118,8 @@ def plot_metric_frame(
     metric_frame: MetricFrame,
     *,
     kind: str = "point",
-    metrics: Union[List[str], str] = None,
-    conf_intervals: Union[List[str], str] = None,
+    metrics: Optional[Union[List[str], str]] = None,
+    conf_intervals: Optional[Union[List[str], str]] = None,
     subplots: bool = True,
     plot_ci_labels: bool = False,
     ci_labels_precision: int = 4,


### PR DESCRIPTION
Fixed some type hints in the metrics package.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
