### PR TITLE
Raise user-friendly error on missing ci parameters

### DIFF
--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -506,6 +506,9 @@ class MetricFrame:
         The elements of the list are indexed by the `ci_quantiles` array supplied
         to the constructor.
         """
+        if self._ci_quantiles is None:
+            raise ValueError(_BOOTSTRAP_NEED_N_AND_CI)
+
         return self._result_cache["overall_ci"]
 
     @property
@@ -550,6 +553,9 @@ class MetricFrame:
         The elements of the list are indexed by the `ci_quantiles` array supplied
         to the constructor.
         """
+        if self._ci_quantiles is None:
+            raise ValueError(_BOOTSTRAP_NEED_N_AND_CI)
+
         return self._result_cache["by_group_ci"]
 
     @property
@@ -686,6 +692,9 @@ class MetricFrame:
         Unlike :meth:`MetricFrame.group_max` there is no :code:`errors` parameter, because
         a bootstrapped :class:`MetricFrame` requires all the metrics to return scalars.
         """
+        if self._ci_quantiles is None:
+            raise ValueError(_BOOTSTRAP_NEED_N_AND_CI)
+
         value = self._result_cache["group_max_ci"]
         return value
 
@@ -737,6 +746,9 @@ class MetricFrame:
         Unlike :meth:`MetricFrame.group_min` there is no :code:`errors` parameter, because
         a bootstrapped :class:`MetricFrame` requires all the metrics to return scalars.
         """
+        if self._ci_quantiles is None:
+            raise ValueError(_BOOTSTRAP_NEED_N_AND_CI)
+
         value = self._result_cache["group_min_ci"]
         return value
 
@@ -813,6 +825,9 @@ class MetricFrame:
         """
         if method not in _COMPARE_METHODS:
             raise ValueError(_INVALID_COMPARE_METHOD.format(method))
+
+        if self._ci_quantiles is None:
+            raise ValueError(_BOOTSTRAP_NEED_N_AND_CI)
 
         value = self._result_cache["difference_ci"][method]
         return value
@@ -892,6 +907,9 @@ class MetricFrame:
         """
         if method not in _COMPARE_METHODS:
             raise ValueError(_INVALID_COMPARE_METHOD.format(method))
+
+        if self._ci_quantiles is None:
+            raise ValueError(_BOOTSTRAP_NEED_N_AND_CI)
 
         value = self._result_cache["ratio_ci"][method]
         return value

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -407,7 +407,7 @@ class MetricFrame:
 
         group_functions = {"group_min_ci": "min", "group_max_ci": "max"}
         for k, v in group_functions.items():
-            self._result_cache[k] = self._result_cache[k] = self._group_ci(
+            self._result_cache[k] = self._group_ci(
                 bootstrap_samples=bootstrap_samples,
                 ci_quantiles=ci_quantiles,
                 grouping_function=v,

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -39,6 +39,10 @@ _INVALID_COMPARE_METHOD = "Unrecognised comparison method: {0}"
 _BOOTSTRAP_NEED_N_AND_CI = "Must specify both n_boot and ci_quantiles"
 _BOOTSTRAP_N_BOOT_INT_GT_ZERO = "Must have n_boot be a positive integer"
 _BOOTSTRAP_CI_INVALID = "Must have all ci_quantiles be floats in (0, 1)"
+_BOOTSTRAP_NOT_INIITIALIZED = (
+    "Could not compute confidence intervals:"
+    " Bootstrapping parameters n_boot and ci_quantiles were not specified in the MetricFrame constructor."
+)
 
 
 class MetricFrame:
@@ -281,14 +285,15 @@ class MetricFrame:
         self._populate_results(result)
 
         # Handle bootstrapping
-        self._ci_quantiles = None
+        self._ci_quantiles = ci_quantiles
+        self._n_boot = n_boot
+
         if n_boot is not None and ci_quantiles is not None and len(ci_quantiles) > 0:
             if not isinstance(n_boot, int) or n_boot < 1:
                 raise ValueError(_BOOTSTRAP_N_BOOT_INT_GT_ZERO)
             for _ci in ci_quantiles:
                 if not isinstance(_ci, float) or _ci <= 0 or _ci >= 1:
                     raise ValueError(_BOOTSTRAP_CI_INVALID)
-            self._ci_quantiles = ci_quantiles
 
             _bootstrap_samples = generate_bootstrap_samples(
                 n_samples=n_boot,
@@ -506,9 +511,7 @@ class MetricFrame:
         The elements of the list are indexed by the `ci_quantiles` array supplied
         to the constructor.
         """
-        if self._ci_quantiles is None:
-            raise ValueError(_BOOTSTRAP_NEED_N_AND_CI)
-
+        self._check_bootstrap_initialized()
         return self._result_cache["overall_ci"]
 
     @property
@@ -553,9 +556,7 @@ class MetricFrame:
         The elements of the list are indexed by the `ci_quantiles` array supplied
         to the constructor.
         """
-        if self._ci_quantiles is None:
-            raise ValueError(_BOOTSTRAP_NEED_N_AND_CI)
-
+        self._check_bootstrap_initialized()
         return self._result_cache["by_group_ci"]
 
     @property
@@ -595,6 +596,11 @@ class MetricFrame:
     def ci_quantiles(self) -> Optional[List[float]]:
         """Return the quantiles specified for bootstrapping."""
         return self._ci_quantiles
+
+    @property
+    def n_boot(self) -> Optional[int]:
+        """Return the number of bootstrap samples specified."""
+        return self._n_boot
 
     def _group(
         self,
@@ -692,11 +698,8 @@ class MetricFrame:
         Unlike :meth:`MetricFrame.group_max` there is no :code:`errors` parameter, because
         a bootstrapped :class:`MetricFrame` requires all the metrics to return scalars.
         """
-        if self._ci_quantiles is None:
-            raise ValueError(_BOOTSTRAP_NEED_N_AND_CI)
-
-        value = self._result_cache["group_max_ci"]
-        return value
+        self._check_bootstrap_initialized()
+        return self._result_cache["group_max_ci"]
 
     def group_min(
         self, errors: Literal["raise", "coerce"] = "raise"
@@ -746,11 +749,8 @@ class MetricFrame:
         Unlike :meth:`MetricFrame.group_min` there is no :code:`errors` parameter, because
         a bootstrapped :class:`MetricFrame` requires all the metrics to return scalars.
         """
-        if self._ci_quantiles is None:
-            raise ValueError(_BOOTSTRAP_NEED_N_AND_CI)
-
-        value = self._result_cache["group_min_ci"]
-        return value
+        self._check_bootstrap_initialized()
+        return self._result_cache["group_min_ci"]
 
     def difference(
         self,
@@ -826,11 +826,9 @@ class MetricFrame:
         if method not in _COMPARE_METHODS:
             raise ValueError(_INVALID_COMPARE_METHOD.format(method))
 
-        if self._ci_quantiles is None:
-            raise ValueError(_BOOTSTRAP_NEED_N_AND_CI)
+        self._check_bootstrap_initialized()
 
-        value = self._result_cache["difference_ci"][method]
-        return value
+        return self._result_cache["difference_ci"][method]
 
     def ratio(
         self,
@@ -908,11 +906,9 @@ class MetricFrame:
         if method not in _COMPARE_METHODS:
             raise ValueError(_INVALID_COMPARE_METHOD.format(method))
 
-        if self._ci_quantiles is None:
-            raise ValueError(_BOOTSTRAP_NEED_N_AND_CI)
+        self._check_bootstrap_initialized()
 
-        value = self._result_cache["ratio_ci"][method]
-        return value
+        return self._result_cache["ratio_ci"][method]
 
     def _process_functions(
         self,
@@ -1042,3 +1038,8 @@ class MetricFrame:
                 raise ValueError(_TOO_MANY_FEATURE_DIMS)
 
         return result
+
+    def _check_bootstrap_initialized(self):
+        """Check that the bootstrap parameters n_boot and ci_quantiles were correctly initialized."""
+        if self._ci_quantiles is None or len(self._ci_quantiles) == 0 or self._n_boot is None:
+            raise ValueError(_BOOTSTRAP_NOT_INIITIALIZED)

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -41,7 +41,8 @@ _BOOTSTRAP_N_BOOT_INT_GT_ZERO = "Must have n_boot be a positive integer"
 _BOOTSTRAP_CI_INVALID = "Must have all ci_quantiles be floats in (0, 1)"
 _BOOTSTRAP_NOT_INIITIALIZED = (
     "Could not compute confidence intervals:"
-    " Bootstrapping parameters n_boot and ci_quantiles were not specified in the MetricFrame constructor."
+    " Bootstrapping parameters n_boot and ci_quantiles were not specified"
+    " in the MetricFrame constructor."
 )
 
 

--- a/test/unit/metrics/test_metricframe_bootstrap.py
+++ b/test/unit/metrics/test_metricframe_bootstrap.py
@@ -1,5 +1,7 @@
 # Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
+from contextlib import AbstractContextManager
+from contextlib import nullcontext as does_not_raise
 
 import numpy as np
 import pytest
@@ -472,3 +474,105 @@ class TestErrors:
         with pytest.raises(ValueError) as execInfo:
             _ = mf_1mdict_0cf.ratio_ci(method="Another Random String")
         assert execInfo.value.args[0] == msg
+
+
+@pytest.mark.parametrize(
+    ["n_boot", "ci_quantiles", "expectation"],
+    [
+        (100, [0.05, 0.5, 0.95], does_not_raise()),
+        (
+            None,
+            None,
+            pytest.raises(
+                ValueError,
+                match=(
+                    "Could not compute confidence intervals: "
+                    "Bootstrapping parameters n_boot and ci_quantiles were not specified "
+                    "in the MetricFrame constructor."
+                ),
+            ),
+        ),
+        (
+            None,
+            [],
+            pytest.raises(
+                ValueError,
+                match=(
+                    "Could not compute confidence intervals: "
+                    "Bootstrapping parameters n_boot and ci_quantiles were not specified "
+                    "in the MetricFrame constructor."
+                ),
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "method",
+    ["group_min_ci", "group_max_ci", "difference_ci", "ratio_ci"],
+)
+def test_ci_methods_raise_on_uninitialized_bootstrap_params(
+    method, n_boot, ci_quantiles, expectation: AbstractContextManager
+) -> None:
+    mf = MetricFrame(
+        metrics={"mse": skm.mean_squared_error},
+        y_true=y_t,
+        y_pred=y_p,
+        sensitive_features=g_1,
+        n_boot=n_boot,
+        ci_quantiles=ci_quantiles,
+        random_state=13489623,
+    )
+
+    with expectation:
+        getattr(mf, method)()
+
+
+@pytest.mark.parametrize(
+    ["n_boot", "ci_quantiles", "expectation"],
+    [
+        (100, [0.05, 0.5, 0.95], does_not_raise()),
+        (
+            None,
+            None,
+            pytest.raises(
+                ValueError,
+                match=(
+                    "Could not compute confidence intervals: "
+                    "Bootstrapping parameters n_boot and ci_quantiles were not specified "
+                    "in the MetricFrame constructor."
+                ),
+            ),
+        ),
+        (
+            None,
+            [],
+            pytest.raises(
+                ValueError,
+                match=(
+                    "Could not compute confidence intervals: "
+                    "Bootstrapping parameters n_boot and ci_quantiles were not specified "
+                    "in the MetricFrame constructor."
+                ),
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "method",
+    ["overall_ci", "by_group_ci"],
+)
+def test_ci_properties_raise_on_uninitialized_bootstrap_params(
+    method, n_boot, ci_quantiles, expectation: AbstractContextManager
+) -> None:
+    mf = MetricFrame(
+        metrics={"mse": skm.mean_squared_error},
+        y_true=y_t,
+        y_pred=y_p,
+        sensitive_features=g_1,
+        n_boot=n_boot,
+        ci_quantiles=ci_quantiles,
+        random_state=13489623,
+    )
+
+    with expectation:
+        getattr(mf, method)


### PR DESCRIPTION
## Description
Hi again !  this small MR aims to improve the user experience a bit by hiding the metric frames internals more.

Basically, when the user tries to access a confidence-intervals-related attribute of a `MetricFrame` object which was not initialized with the confidence-intervals-related parameters (`n_boot` , `ci_quantiles`), she gets a `KeyError` exposing the internal `result_cache` object, which imho is not user-friendly (example in the figure below).
![image](https://github.com/user-attachments/assets/bb40e254-eb99-4380-8b1c-9bb513639124)

If you agree with these changes, please let me know, I'll go ahead and add associated unit tests :pray: 

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [x] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

