### PR TITLE
Fix correlation remover none case

### DIFF
--- a/fairlearn/preprocessing/_correlation_remover.py
+++ b/fairlearn/preprocessing/_correlation_remover.py
@@ -86,6 +86,7 @@ class CorrelationRemover(BaseEstimator, TransformerMixin):
 
     def fit(self, X, y=None):
         """Learn the projection required to make the dataset uncorrelated with sensitive columns."""  # noqa: E501
+        self._check_sensitive_features_in_X(X)
         self._create_lookup(X)
         X = self._validate_data(X)
         X_use, X_sensitive = self._split_X(X)
@@ -115,11 +116,26 @@ class CorrelationRemover(BaseEstimator, TransformerMixin):
         X_filtered = np.atleast_2d(X_filtered)
         return self.alpha * X_filtered + (1 - self.alpha) * X_use
 
+    def _check_sensitive_features_in_X(self, X) -> None:
+        """Check if the sensitive features are in X."""
+        if isinstance(X, pd.DataFrame):
+            missing_columns = [c for c in self.sensitive_feature_ids if c not in X.columns]
+        else:
+            if X.ndim == 1:
+                return
+            missing_columns = [i for i in self.sensitive_feature_ids if i not in range(X.shape[1])]
+
+        if len(missing_columns) > 0:
+            raise ValueError(f"Columns {missing_columns} not found in the input data.")
+
     def _more_tags(self):
         return {
             "_xfail_checks": {
                 "check_transformer_data_not_an_array": (
                     "this estimator only accepts pandas dataframes or numpy ndarray as input."
+                ),
+                "check_estimators_empty_data_messages": (
+                    "this estimator raises on missing sensitive features in data."
                 ),
             }
         }

--- a/fairlearn/preprocessing/_correlation_remover.py
+++ b/fairlearn/preprocessing/_correlation_remover.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
+from collections.abc import Iterable
+
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
@@ -22,7 +24,7 @@ class CorrelationRemover(BaseEstimator, TransformerMixin):
     ----------
         sensitive_feature_ids : list
             list of columns to filter out this can be a sequence of
-            either int ,in the case of numpy, or string, in the case of pandas.
+            either int, in the case of numpy, or string, in the case of pandas.
         alpha : float
             parameter to control how much to filter, for alpha=1.0 we filter out
             all information while for alpha=0.0 we don't apply any.
@@ -61,7 +63,7 @@ class CorrelationRemover(BaseEstimator, TransformerMixin):
 
     """
 
-    def __init__(self, *, sensitive_feature_ids=None, alpha=1):
+    def __init__(self, *, sensitive_feature_ids: Iterable = (), alpha: float = 1):
         self.sensitive_feature_ids = sensitive_feature_ids
         self.alpha = alpha
 

--- a/test/unit/preprocessing/linear_dep_remover/test_sklearn_compat.py
+++ b/test/unit/preprocessing/linear_dep_remover/test_sklearn_compat.py
@@ -1,8 +1,12 @@
 # Copyright (c) Microsoft Corporation and Fairlearn contributors.
 # Licensed under the MIT License.
 
+import re
+from contextlib import nullcontext as does_not_raise
+
 import numpy as np
 import pandas as pd
+import pytest
 from sklearn.utils.estimator_checks import parametrize_with_checks
 
 from fairlearn.preprocessing import CorrelationRemover
@@ -18,61 +22,96 @@ def test_sklearn_compatible_estimator(estimator, check):
     check(estimator)
 
 
-def test_linear_dependence():
-    X = np.array(
-        [
-            [
-                0,
-                0,
-                1,
-                1,
-            ],
-            [
-                1,
-                1,
-                2,
-                2,
-            ],
-            [
-                0.1,
-                0.2,
-                1.2,
-                1.1,
-            ],
-        ]
-    ).T
+@pytest.mark.parametrize(
+    ["sensitive_feature_ids", "X", "expected_result"],
+    [
+        (
+            [0],
+            np.array(
+                [
+                    [0, 0, 1, 1],
+                    [1, 1, 2, 2],
+                    [0.1, 0.2, 1.2, 1.1],
+                ]
+            ).T,
+            np.array([[1.5, 0.6], [1.5, 0.7], [1.5, 0.7], [1.5, 0.6]]),
+        ),
+        (
+            ("a",),
+            pd.DataFrame(
+                np.array(
+                    [
+                        [0, 0, 1, 1],
+                        [1, 1, 2, 2],
+                        [0.1, 0.2, 1.2, 1.1],
+                    ]
+                ).T,
+                columns=["a", "b", "c"],
+            ),
+            np.array([[1.5, 0.6], [1.5, 0.7], [1.5, 0.7], [1.5, 0.6]]),
+        ),
+    ],
+)
+def test_linear_dependence(sensitive_feature_ids, X, expected_result) -> None:
+    X_tfm = CorrelationRemover(sensitive_feature_ids=sensitive_feature_ids).fit_transform(X)
+    np.testing.assert_array_almost_equal(expected_result, X_tfm)
 
-    X_tfm = CorrelationRemover(sensitive_feature_ids=[0]).fit(X).transform(X)
-    assert X_tfm.shape[1] == 2
-    assert np.allclose(X_tfm[:, 0], 1.5)
+
+@pytest.mark.parametrize(
+    ["alpha", "expected_result"],
+    [
+        (0.0, np.array([[2, 3], [5, 6], [8, 9]])),
+        (0.5, np.array([[3.5, 4.5], [5, 6], [6.5, 7.5]])),
+        (1.0, np.array([[5, 6], [5, 6], [5, 6]])),
+    ],
+)
+def test_correlation_remover_handles_alpha(alpha, expected_result) -> None:
+    X = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+
+    X_tfm = CorrelationRemover(sensitive_feature_ids=[0], alpha=alpha).fit_transform(X)
+    np.testing.assert_array_almost_equal(expected_result, X_tfm)
 
 
-def test_linear_dependence_pd():
-    X = np.array(
-        [
-            [
-                0,
-                0,
-                1,
-                1,
-            ],
-            [
-                1,
-                1,
-                2,
-                2,
-            ],
-            [
-                0.1,
-                0.2,
-                1.2,
-                1.1,
-            ],
-        ]
-    ).T
+@pytest.mark.parametrize(
+    "X",
+    [
+        np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
+        pd.DataFrame({"a": [1, 4, 7], "b": [2, 5, 8], "c": [3, 6, 9]}),
+    ],
+)
+def test_correlation_remover_handles_default_sensitive_features(X) -> None:
+    X = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
 
-    df = pd.DataFrame(X, columns=["a", "b", "c"])
+    X_tfm = CorrelationRemover().fit_transform(X)
+    np.testing.assert_array_equal(np.array(X), X_tfm)
 
-    X_tfm = CorrelationRemover(sensitive_feature_ids=["a"]).fit(df).transform(df)
-    assert X_tfm.shape[1] == 2
-    assert np.allclose(X_tfm[:, 0], 1.5)
+
+@pytest.mark.parametrize(
+    ["sensitive_feature_ids", "X", "expectation"],
+    [
+        (None, np.array([]), does_not_raise()),
+        ([], np.array([[1, 2], [3, 4]]), does_not_raise()),
+        ([0], np.array([[1, 2], [3, 4]]), does_not_raise()),
+        ((1, 0), np.array([[1, 2]]), does_not_raise()),
+        (["a", "b"], pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]}), does_not_raise()),
+        (
+            [-1, 0, 3, 4],
+            np.array([[1, 2], [3, 4]]),
+            pytest.raises(
+                ValueError, match=re.escape("Columns [-1, 3, 4] not found in the input data.")
+            ),
+        ),
+        (
+            ["a", "b", "c", "d"],
+            pd.DataFrame({"a": [1, 2], "b": [3, 4]}),
+            pytest.raises(
+                ValueError, match=re.escape("Columns ['c', 'd'] not found in the input data.")
+            ),
+        ),
+    ],
+)
+def test__check_sensitive_features_in_X(sensitive_feature_ids, X, expectation) -> None:
+    remover = CorrelationRemover(sensitive_feature_ids=sensitive_feature_ids)
+
+    with expectation:
+        remover._check_sensitive_features_in_X(X)


### PR DESCRIPTION
## Description
Hi again ! This PR is all about the `CorrelationRemover`, and it basically does three things:
- Fix the default `None` `sensitive_feature_ids` value, which yields a `TypeError: 'NoneType' object is not iterable`.
- Adds an input validation checking the compatibility of `sensitive_feature_ids` and `X` , it has the same motivation as #1437, namely hiding the internals of our class (here it's the `lookup`) from the user.
- I refactored the existing tests, added tests for the `alpha` parameter and the new features that this PR introduces.


In the next PR, I'm planning to give #1419 a try on this mitigation method.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [x] new tests added
- [x] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
This is the exception raised when using the `None` default value
![image](https://github.com/user-attachments/assets/ac29db6a-5aa0-4e31-aed4-330da7e1cfcc)


This the exception raised when some `sensitive_feature_ids` are not found in `X`
![image](https://github.com/user-attachments/assets/8d83e1ca-7156-41a7-bdc4-f4e0a0e8d993)

