### PR TITLE
MNT Fix pipi page layout 

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -37,3 +37,4 @@ All names are sorted alphabetically by last name. Contributors, please add your 
 - [Beth Zeranski](https://github.com/bethz)
 - [Vlad Iliescu](https://vladiliescu.net)
 - [Hrittik RoyChoudhury](https://github.com/Hrittik20)
+- [Tamara Atanasoska](https://github.com/tamaraatanasoska)

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Current release
 
 -  Our current version may differ substantially from earlier versions.
    Users of earlier versions should visit our
-   `version guide <https://fairlearn.org/main/user_guide/installation_and_version_guide/version_guide.html>`_
+   `version guide <https://fairlearn.org/main/user_guide/installation_and_version_guide/version_guide.html>`__
    to navigate significant changes and find information on how to migrate.
 
 What we mean by *fairness*
@@ -85,8 +85,7 @@ The Fairlearn Python package has two components:
 Fairlearn metrics
 ~~~~~~~~~~~~~~~~~
 
-Check out our in-depth `guide on the Fairlearn
-metrics <https://fairlearn.org/main/user_guide/assessment>`__.
+Check out our in-depth `guide on the Fairlearn metrics <https://fairlearn.org/main/user_guide/assessment>`__.
 
 Fairlearn algorithms
 ~~~~~~~~~~~~~~~~~~~~
@@ -97,8 +96,7 @@ For an overview of our algorithms please refer to our
 Install Fairlearn
 -----------------
 
-For instructions on how to install Fairlearn check out our `Quickstart
-guide <https://fairlearn.org/main/quickstart.html>`__.
+For instructions on how to install Fairlearn check out our `Quickstart guide <https://fairlearn.org/main/quickstart.html>`__.
 
 Usage
 -----
@@ -114,8 +112,7 @@ locate the appropriate version of the notebook.
 Contributing
 ------------
 
-To contribute please check our `contributor
-guide <https://fairlearn.org/main/contributor_guide/index.html>`__.
+To contribute please check our `contributor guide <https://fairlearn.org/main/contributor_guide/index.html>`__.
 
 Maintainers
 -----------

--- a/fairlearn/datasets/_fetch_adult.py
+++ b/fairlearn/datasets/_fetch_adult.py
@@ -25,8 +25,8 @@ def fetch_adult(*, cache=True, data_home=None, as_frame=True, return_X_y=False) 
 
     Source:
 
-    - UCI Repository :footcite:`kohavi1996adult`
-    - Paper: Kohavi and Becker :footcite:`kohavi1996scaling`
+    - UCI Repository [1]_
+    - Paper: Kohavi and Becker [2]_
 
     Prediction task is to determine whether a person makes over $50,000 a
     year.
@@ -90,7 +90,10 @@ def fetch_adult(*, cache=True, data_home=None, as_frame=True, return_X_y=False) 
 
     References
     ----------
-    .. footbibliography::
+    .. [1] Kohavi, R. (1996). UCI Adult dataset.
+       https://archive.ics.uci.edu/ml/datasets/adult
+    .. [2] Kohavi, R., & Becker, B. (1996). Scaling Up the Accuracy of
+       Naive-Bayes Classifiers: a Decision-Tree Hybrid. KDD.
 
     """
     if not data_home:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     version=fairlearn.__version__,
     author=(
         "Miroslav Dudik, Richard Edgar, Adrin Jalali, Roman Lutz, Michael Madaio, Hilde"
-        " Weerts, Allie Saizan"
+        " Weerts, Allie Saizan, Tamara Atanasoska"
     ),
     author_email="fairlearn-internal@python.org",
     description="A Python package to assess and improve fairness of machine learning models.",


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
I went to grab a fairlearn link and I noticed that the pipi page `.rst` has been broken for several versions. I just changed some links and I see correct html when rendering, but I am not sure if this will fix the issue over there (do they do some kind of conversion in-between?).

The references in the UCI dataset page wouldn't build properly and were giving a non-breaking error, so I reverted them to a bibliography format for a lack of better idea after trying several different things. It might be something about being part of a docstring in a function, not sure. I noticed this unrelated to my changes and fixed it, I haven't seen it before.

Lastly I added my name in two places where I forgot initially. 

<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [ ] user guide added or updated
- [x] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
<img width="317" alt="Screenshot 2024-11-27 at 15 46 27" src="https://github.com/user-attachments/assets/164a5e7c-721d-4e80-81dd-ae022e9f00bc">
<img width="764" alt="Screenshot 2024-11-27 at 15 46 33" src="https://github.com/user-attachments/assets/f8427045-2086-444d-8a73-844604256e20">

