### PR TITLE
Plot thresold optimizer weighted objective

### DIFF
--- a/docs/user_guide/mitigation/postprocessing.rst
+++ b/docs/user_guide/mitigation/postprocessing.rst
@@ -93,7 +93,6 @@ true positive rate parity as the fairness constraint.
     ... )
     >>> categorical_transformer = Pipeline(
     ...     [
-    ...         # ("impute", SimpleImputer(strategy="most_frequent")),
     ...         ("ohe", OneHotEncoder(handle_unknown="ignore")),
     ...     ]
     ... )
@@ -157,7 +156,6 @@ true positive rate parity as the fairness constraint.
     >>> plot_threshold_optimizer(threshold_optimizer)
 
 When calling :code:`predict`, :class:`ThresholdOptimizer` uses one of the
-
 thresholds at random based on the probabilities :math:`p_0` and :math:`p_1`.
 The results can be interpreted as follows based on the following formula for
 the probability to predict label 1:
@@ -167,7 +165,7 @@ the probability to predict label 1:
     p_0 \cdot \text{operation}_0(\text{score}) + p_1 \cdot \text{operation}_1(\text{score})
 
 
-- "Female: :math:`0.628 \cdot \mathbb{I}(\text{score}>0.110) + 0.371 \cdot \mathbb{I}(\text{score}>0.096)`
+- "Female": :math:`0.628 \cdot \mathbb{I}(\text{score}>0.110) + 0.371 \cdot \mathbb{I}(\text{score}>0.096)`
 
   - if the score is above :math:`0.110` predict 1
   - if the score is between :math:`0.110` and :math:`0.096` predict 1 with

--- a/fairlearn/postprocessing/_plotting.py
+++ b/fairlearn/postprocessing/_plotting.py
@@ -3,6 +3,7 @@
 
 """Utilities for plotting curves."""
 
+import pandas as pd
 from sklearn.utils.validation import check_is_fitted
 
 from ._constants import _MATPLOTLIB_IMPORT_ERROR_MESSAGE
@@ -42,6 +43,18 @@ def _plot_solution(ax, x_best, y_best, solution_label, xlabel, ylabel):
     ax.set_ylabel(ylabel)
 
 
+def _plot_overall_tradeoff_curve(ax, overall_tradeoff_curve: pd.DataFrame) -> None:
+    """Plot the overall tradeoff curve."""
+    ax.plot(
+        overall_tradeoff_curve["x"],
+        overall_tradeoff_curve["y"],
+        c="b",
+        ls="--",
+        lw=2.0,
+        label="overall tradeoff curve",
+    )
+
+
 def _plot_overlap(ax, x_grid, y_min):
     """Plot the overlap region."""
     highlight_color = [0.95, 0.90, 0.40]
@@ -69,7 +82,7 @@ def _raise_if_not_threshold_optimizer(obj):
         )
 
 
-def plot_threshold_optimizer(threshold_optimizer, ax=None, show_plot=True):
+def plot_threshold_optimizer(threshold_optimizer: ThresholdOptimizer, ax=None, show_plot=True):
     r"""Plot the chosen solution of the threshold optimizer.
 
     For :class:`.ThresholdOptimizer` objects that have their
@@ -119,6 +132,7 @@ def plot_threshold_optimizer(threshold_optimizer, ax=None, show_plot=True):
             "$P[\\hat{Y}=1|Y=1]$",
         )
     else:
+        _plot_overall_tradeoff_curve(ax, threshold_optimizer._overall_tradeoff_curve)
         _plot_solution(
             ax,
             threshold_optimizer._x_best,

--- a/fairlearn/postprocessing/_threshold_optimizer.py
+++ b/fairlearn/postprocessing/_threshold_optimizer.py
@@ -441,6 +441,10 @@ class ThresholdOptimizer(BaseEstimator, MetaEstimatorMixin):
             logger.debug("Tradeoff curve")
             logger.debug(roc_convex_hull)
 
+        self._overall_tradeoff_curve = pd.DataFrame(
+            {"x": self._x_grid, "y": overall_tradeoff_curve}
+        )
+
         # Find maximum objective point given that at each point the constraint value for each
         # sensitive feature value is identical by design.
         i_best = overall_tradeoff_curve.idxmax()

--- a/fairlearn/postprocessing/_tradeoff_curve_utilities.py
+++ b/fairlearn/postprocessing/_tradeoff_curve_utilities.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import pandas as pd
+from numpy.typing import NDArray
 from sklearn.utils import Bunch
 
 from ._constants import LABEL_KEY, P0_KEY, P1_KEY, SCORE_KEY
@@ -141,7 +142,9 @@ def _filter_points_to_get_convex_hull(points_sorted):
     return selected
 
 
-def _interpolate_curve(data, x_col, y_col, content_col, x_grid):
+def _interpolate_curve(
+    data: pd.DataFrame, x_col: str, y_col: str, content_col: str, x_grid: NDArray
+):
     """Interpolates the DataFrame in `data` along the values in `x_grid`.
 
     Assumes: (1) data[y_col] is convex and non-decreasing in data[x_col]


### PR DESCRIPTION
## Description
Hello, this PR is mainly about the user guide for the `ThresholdOptimizer` with constraints other than equalized-odds. It has two parts:
- The first one consists of small fixes to the docs (commented out code line, extra space, missing double-quotation...).
- The second one is more interesting: I added the curve of the objective weighted by the size of the groups to the plot so that the quantity we are maximizing is displayed, and the user can understand why the solution's vertical line happen to be at that exact spot.

> To ensure that the fairness constraint is upheld [ThresholdOptimizer](https://fairlearn.org/v0.11/api_reference/generated/fairlearn.postprocessing.ThresholdOptimizer.html#fairlearn.postprocessing.ThresholdOptimizer) simultaneously walks along all the curves while monitoring the objective value, and picks the spot on the x-axis with the optimal objective weighed by the sizes of the groups corresponding to each sensitive feature value.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

By the way I would have expected that [these tests](https://github.com/fairlearn/fairlearn/blob/main/test/unit/postprocessing/test_plots.py#L67-77) would fail, but they don't, and I can't find the corresponding snapshot files anywhere :eyes: 
 
## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [x] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/eff461ab-0261-46a4-8c55-5fd45d398028)

After:
![image](https://github.com/user-attachments/assets/c398ece7-e52f-4c20-be16-6c7cf5d1d20c)

