### PR TITLE
fix: bootstrapping with missing sampled value

### DIFF
--- a/fairlearn/metrics/_bootstrap.py
+++ b/fairlearn/metrics/_bootstrap.py
@@ -63,12 +63,14 @@ def generate_bootstrap_samples(
     assert n_samples >= 1
     if random_state is None:
         generator = np.random.default_rng()
-        rs = generator.integers(low=0, high=np.iinfo(np.uint32).max, size=n_samples)
+        rs = generator.integers(low=0, high=np.iinfo(np.uint32).max, size=n_samples, dtype="int64")
     elif isinstance(random_state, np.random.RandomState):
-        rs = random_state.randint(low=0, high=np.iinfo(np.uint32).max, size=n_samples)
+        rs = random_state.randint(
+            low=0, high=np.iinfo(np.uint32).max, size=n_samples, dtype="int64"
+        )
     elif isinstance(random_state, int):
         generator = np.random.default_rng(seed=random_state)
-        rs = generator.integers(low=0, high=np.iinfo(np.uint32).max, size=n_samples)
+        rs = generator.integers(low=0, high=np.iinfo(np.uint32).max, size=n_samples, dtype="int64")
     else:
         raise ValueError(f"Unsupported random_state: {random_state}")
 

--- a/fairlearn/metrics/_bootstrap.py
+++ b/fairlearn/metrics/_bootstrap.py
@@ -63,14 +63,18 @@ def generate_bootstrap_samples(
     assert n_samples >= 1
     if random_state is None:
         generator = np.random.default_rng()
-        rs = generator.integers(low=0, high=np.iinfo(np.uint32).max, size=n_samples, dtype="int64")
+        rs = generator.integers(
+            low=0, high=np.iinfo(np.uint32).max, size=n_samples, dtype=np.uint32
+        )
     elif isinstance(random_state, np.random.RandomState):
         rs = random_state.randint(
-            low=0, high=np.iinfo(np.uint32).max, size=n_samples, dtype="int64"
+            low=0, high=np.iinfo(np.uint32).max, size=n_samples, dtype=np.uint32
         )
     elif isinstance(random_state, int):
         generator = np.random.default_rng(seed=random_state)
-        rs = generator.integers(low=0, high=np.iinfo(np.uint32).max, size=n_samples, dtype="int64")
+        rs = generator.integers(
+            low=0, high=np.iinfo(np.uint32).max, size=n_samples, dtype=np.uint32
+        )
     else:
         raise ValueError(f"Unsupported random_state: {random_state}")
 

--- a/fairlearn/metrics/_disaggregated_result.py
+++ b/fairlearn/metrics/_disaggregated_result.py
@@ -2,8 +2,6 @@
 # Licensed under the MIT License.
 from __future__ import annotations
 
-from __future__ import annotations
-
 import logging
 from typing import Literal
 

--- a/test/unit/metrics/test_bootstrap.py
+++ b/test/unit/metrics/test_bootstrap.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pandas as pd
 import pytest

--- a/test/unit/metrics/test_bootstrap.py
+++ b/test/unit/metrics/test_bootstrap.py
@@ -1,0 +1,144 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from fairlearn.metrics._bootstrap import _align_sample_indices
+
+
+@pytest.mark.parametrize(
+    ["samples", "expected"],
+    [
+        (
+            [
+                pd.DataFrame(
+                    {
+                        "sensitive_feature_0": ["a", "b", "c"],
+                        "metric_1": [1, 2, 3],
+                        "metric_2": [4, 5, 6],
+                    },
+                ).set_index("sensitive_feature_0"),
+                pd.DataFrame(
+                    {
+                        "sensitive_feature_0": ["a", "b", "c"],
+                        "metric_1": [10, 20, 30],
+                        "metric_2": [40, 50, 60],
+                    },
+                ).set_index("sensitive_feature_0"),
+            ],
+            [
+                pd.DataFrame(
+                    {
+                        "sensitive_feature_0": ["a", "b", "c"],
+                        "metric_1": [1, 2, 3],
+                        "metric_2": [4, 5, 6],
+                    },
+                ).set_index("sensitive_feature_0"),
+                pd.DataFrame(
+                    {
+                        "sensitive_feature_0": ["a", "b", "c"],
+                        "metric_1": [10, 20, 30],
+                        "metric_2": [40, 50, 60],
+                    },
+                ).set_index("sensitive_feature_0"),
+            ],
+        ),
+        (
+            [
+                pd.DataFrame(
+                    {"sensitive_feature_0": ["a"], "metric_1": [1], "metric_2": [4]},
+                ).set_index("sensitive_feature_0"),
+                pd.DataFrame(
+                    {
+                        "sensitive_feature_0": ["b", "c"],
+                        "metric_1": [20, 30],
+                        "metric_2": [50, 60],
+                    },
+                ).set_index("sensitive_feature_0"),
+                pd.DataFrame(
+                    {"sensitive_feature_0": ["c"], "metric_1": [10], "metric_2": [40]},
+                ).set_index("sensitive_feature_0"),
+            ],
+            [
+                pd.DataFrame(
+                    {
+                        "sensitive_feature_0": ["a", "b", "c"],
+                        "metric_1": [1, np.nan, np.nan],
+                        "metric_2": [4, np.nan, np.nan],
+                    },
+                ).set_index("sensitive_feature_0"),
+                pd.DataFrame(
+                    {
+                        "sensitive_feature_0": ["a", "b", "c"],
+                        "metric_1": [np.nan, 20, 30],
+                        "metric_2": [np.nan, 50, 60],
+                    },
+                ).set_index("sensitive_feature_0"),
+                pd.DataFrame(
+                    {
+                        "sensitive_feature_0": ["a", "b", "c"],
+                        "metric_1": [np.nan, np.nan, 10],
+                        "metric_2": [np.nan, np.nan, 40],
+                    },
+                ).set_index("sensitive_feature_0"),
+            ],
+        ),
+        (
+            [
+                pd.DataFrame(
+                    {
+                        "sensitive_feature_0": ["a", "a"],
+                        "control_feature_0": ["x", "y"],
+                        "metric_1": [1, 2],
+                        "metric_2": [4, 5],
+                    },
+                ).set_index(["sensitive_feature_0", "control_feature_0"]),
+                pd.DataFrame(
+                    {
+                        "sensitive_feature_0": ["b", "c"],
+                        "control_feature_0": ["x", "z"],
+                        "metric_1": [20, 30],
+                        "metric_2": [50, 60],
+                    },
+                ).set_index(["sensitive_feature_0", "control_feature_0"]),
+                pd.DataFrame(
+                    {
+                        "sensitive_feature_0": ["c", "c"],
+                        "control_feature_0": ["y", "z"],
+                        "metric_1": [10, 30],
+                        "metric_2": [40, 60],
+                    },
+                ).set_index(["sensitive_feature_0", "control_feature_0"]),
+            ],
+            [
+                pd.DataFrame(
+                    {
+                        "sensitive_feature_0": ["a", "a", "b", "c", "c"],
+                        "control_feature_0": ["x", "y", "x", "y", "z"],
+                        "metric_1": [1, 2, np.nan, np.nan, np.nan],
+                        "metric_2": [4, 5, np.nan, np.nan, np.nan],
+                    },
+                ).set_index(["sensitive_feature_0", "control_feature_0"]),
+                pd.DataFrame(
+                    {
+                        "sensitive_feature_0": ["a", "a", "b", "c", "c"],
+                        "control_feature_0": ["x", "y", "x", "y", "z"],
+                        "metric_1": [np.nan, np.nan, 20, np.nan, 30],
+                        "metric_2": [np.nan, np.nan, 50, np.nan, 60],
+                    },
+                ).set_index(["sensitive_feature_0", "control_feature_0"]),
+                pd.DataFrame(
+                    {
+                        "sensitive_feature_0": ["a", "a", "b", "c", "c"],
+                        "control_feature_0": ["x", "y", "x", "y", "z"],
+                        "metric_1": [np.nan, np.nan, np.nan, 10, 30],
+                        "metric_2": [np.nan, np.nan, np.nan, 40, 60],
+                    },
+                ).set_index(["sensitive_feature_0", "control_feature_0"]),
+            ],
+        ),
+    ],
+)
+def test_align_sample_indices(samples: list[pd.DataFrame], expected: list[pd.DataFrame]) -> None:
+    aligned_samples = _align_sample_indices(samples=samples)
+    for aligned, exp in zip(aligned_samples, expected):
+        pd.testing.assert_frame_equal(aligned, exp)

--- a/test/unit/metrics/test_metricframe_bootstrap.py
+++ b/test/unit/metrics/test_metricframe_bootstrap.py
@@ -576,3 +576,23 @@ def test_ci_properties_raise_on_uninitialized_bootstrap_params(
 
     with expectation:
         getattr(mf, method)
+
+
+def test_bootstrapping_can_handle_missing_sensitive_feature_values_in_samples() -> None:
+    y_true = [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0]
+    y_pred = [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0]
+    sensitive_features = ["a", "b", "c", "a", "b", "c", "a", "b", "c", "a", "b"]
+
+    # using this random state yields a sample with a missing value, "b", for the sensitive feature
+    random_state = np.random.RandomState(1234)
+
+    with does_not_raise():
+        MetricFrame(
+            metrics=count,
+            y_true=y_true,
+            y_pred=y_pred,
+            sensitive_features=sensitive_features,
+            ci_quantiles=[0.1, 0.5, 0.9],
+            n_boot=3,
+            random_state=random_state,
+        )

--- a/test/unit/metrics/test_metricframe_bootstrap.py
+++ b/test/unit/metrics/test_metricframe_bootstrap.py
@@ -579,9 +579,9 @@ def test_ci_properties_raise_on_uninitialized_bootstrap_params(
 
 
 def test_bootstrapping_can_handle_missing_sensitive_feature_values_in_samples() -> None:
-    y_true = [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0]
-    y_pred = [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0]
-    sensitive_features = ["a", "b", "c", "a", "b", "c", "a", "b", "c", "a", "b"]
+    sensitive_features = ["a"] * 99 + ["b"]
+    y_true = np.ones(100)
+    y_pred = np.ones(100)
 
     # using this random state yields a sample with a missing value, "b", for the sensitive feature
     random_state = np.random.RandomState(1234)


### PR DESCRIPTION
Fixes #1441 (Notice, that I do not implement the stratified sampling here, as it would be a new feature that could go intro a dedicated PR)

## Description
Hello this my attempt to implement the [suggested](https://github.com/fairlearn/fairlearn/issues/1441#issuecomment-2504665116) solution to fix bootstrapping:

> When the bootstrap replicate does not contain any elements from a given group, it should return np.nan, and we should use np.nanquantile to get the values of various *_ci quantities. This will yield valid quantiles (under the same assumptions as the standard bootstrap). I don't think that we should allow substituting some other default value (like 0 or 1) in this case, because that is likely to lead to wrong quantiles. This approach would be also backward compatible re. random seeds. One possible downside is that *_ci might sometimes still include np.nan.

NB: With this implementation, if a a group happens to be missing from **all the samples**, it will simply not appear in the `ci` attributes. If we absolutely want to make it appear with a `NaN` , I can think of a couple of ways to achieve it (for instance, aligning the groups of each `*_ci` attributes with those of the corresponding "non-ci" attribute of the metric frame).

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [x] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

