### PR TITLE
MNT Fix CorrelationRemover failing estimator checks

### DIFF
--- a/fairlearn/preprocessing/_correlation_remover.py
+++ b/fairlearn/preprocessing/_correlation_remover.py
@@ -100,6 +100,7 @@ class CorrelationRemover(TransformerMixin, BaseEstimator):
             self.lookup_ = {c: i for i, c in enumerate(X.columns)}
             return X.values
         # correctly handle a 1d input
+        X = validate_data(self, X, ensure_2d=False, ensure_min_samples=0)
         if len(X.shape) == 1:
             return {0: 0}
         self.lookup_ = {i: i for i in range(X.shape[1])}
@@ -155,6 +156,7 @@ class CorrelationRemover(TransformerMixin, BaseEstimator):
         if isinstance(X, pd.DataFrame):
             missing_columns = [c for c in self.sensitive_feature_ids if c not in X.columns]
         else:
+            X = validate_data(self, X, ensure_2d=False, ensure_min_samples=0)
             if X.ndim == 1:
                 return
             missing_columns = [i for i in self.sensitive_feature_ids if i not in range(X.shape[1])]

--- a/test/unit/preprocessing/linear_dep_remover/test_sklearn_compat.py
+++ b/test/unit/preprocessing/linear_dep_remover/test_sklearn_compat.py
@@ -7,17 +7,9 @@ from contextlib import nullcontext as does_not_raise
 import numpy as np
 import pandas as pd
 import pytest
+from sklearn.utils.estimator_checks import parametrize_with_checks
 
 from fairlearn.preprocessing import CorrelationRemover
-from fairlearn.utils._fixes import parametrize_with_checks
-
-EXPECTED_FAILED_CHECKS = {
-    "CorrelationRemover": {
-        "check_transformer_data_not_an_array": (
-            "this estimator only accepts pandas dataframes or numpy ndarray as input."
-        ),
-    },
-}
 
 
 @parametrize_with_checks(
@@ -25,7 +17,6 @@ EXPECTED_FAILED_CHECKS = {
         CorrelationRemover(sensitive_feature_ids=[]),
         CorrelationRemover(sensitive_feature_ids=[0]),
     ],
-    expected_failed_checks=lambda x: EXPECTED_FAILED_CHECKS.get(x.__class__.__name__, {}),
 )
 def test_sklearn_compatible_estimator(estimator, check):
     check(estimator)


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
This PR removes resolves the failing estimator checks in the `Correlation Remover`.
The class could use some additional refactoring, added to my list for the future.

ping @adrinjalali this is what I mentioned in https://github.com/fairlearn/fairlearn/pull/1451

<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [ ] new tests added
- [x] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
