### PR TITLE
feat: relaxed threshold optimizer for simple constraints

### DIFF
--- a/fairlearn/postprocessing/_plotting.py
+++ b/fairlearn/postprocessing/_plotting.py
@@ -132,15 +132,32 @@ def plot_threshold_optimizer(threshold_optimizer: ThresholdOptimizer, ax=None, s
             "$P[\\hat{Y}=1|Y=1]$",
         )
     else:
-        _plot_overall_tradeoff_curve(ax, threshold_optimizer._overall_tradeoff_curve)
-        _plot_solution(
-            ax,
-            threshold_optimizer._x_best,
-            None,
-            "solution",
-            threshold_optimizer.x_metric_,
-            threshold_optimizer.y_metric_,
-        )
+        if hasattr(threshold_optimizer, "_overall_tradeoff_curve"):
+            _plot_overall_tradeoff_curve(ax, threshold_optimizer._overall_tradeoff_curve)
+            _plot_solution(
+                ax,
+                threshold_optimizer._x_best,
+                None,
+                "solution",
+                threshold_optimizer.x_metric_,
+                threshold_optimizer.y_metric_,
+            )
+        else:
+            _plot_solution_with_tol(threshold_optimizer, ax)
 
     if show_plot:
         plt.show()
+
+
+def _plot_solution_with_tol(threshold_optimizer: ThresholdOptimizer, ax):
+    for sensitive_feature_value, x_best in threshold_optimizer._x_best_per_group.items():
+        color = _get_debug_color(sensitive_feature_value)
+        ax.axvline(
+            x=x_best,
+            label=f"constraint (sensitive feature = {sensitive_feature_value})",
+            ls="--",
+            c=color,
+        )
+        ax.legend()
+        ax.set_xlabel(threshold_optimizer.x_metric_)
+        ax.set_ylabel(threshold_optimizer.y_metric_)

--- a/fairlearn/postprocessing/_relaxed_constraints.py
+++ b/fairlearn/postprocessing/_relaxed_constraints.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from collections import deque
+from typing import Iterable
+
+import pandas as pd
+
+
+def maximize_objective_with_tolerance(
+    dataframes: Iterable[pd.DataFrame],
+    weights: Iterable[float],
+    tol: float,
+    x_col: str = "x",
+    y_col: str = "y",
+) -> tuple[list[int], float]:
+    """
+    Finds the indices that maximize the sum of weighted `y` values across multiple DataFrames
+    under the constraint that the difference between the maximum and minimum `x` values
+    in the selected indices is at most `tol`.
+
+    Args:
+        dataframes (Iterable[pd.DataFrame]): An Iterable of DataFrames. Each DataFrame must have:
+                                         - An `x` column (sorted in ascending order).
+                                         - A `y` column.
+        weights (Iterable[float]): An Iterable of weights for each DataFrame `y` column.
+        tol (float): The maximum allowed range of `x` values for the selected indices.
+
+    Returns:
+        list[int], float: - A list of selected indices (one per DataFrame).
+                          - The maximum sum of weighted `y` values under the constraint.
+    """
+    # Extract `x` values (all DataFrames must share the same `x` values)
+    x_values = dataframes[0][x_col].values
+    n = len(x_values)
+
+    # Extract weighted `y` columns
+    y_columns = [df[y_col].values * weight for df, weight in zip(dataframes, weights)]
+    m = len(y_columns)
+
+    # Initialize a deque for each DataFrame to store indices in descending order of y values
+    deques = [deque() for _ in range(m)]
+
+    # Variables to track the best solution
+    best_indices = []
+    max_sum = float("-inf")
+
+    # Sliding window start pointer
+    start = 0
+
+    # Traverse with the end pointer
+    for end in range(n):
+        # Add the current `end` index to the deques, maintaining descending order of y values
+        for k in range(m):
+            while deques[k] and y_columns[k][deques[k][-1]] <= y_columns[k][end]:
+                deques[k].pop()
+            deques[k].append(end)
+
+        # Adjust the window to ensure the range of x values is within tol
+        while x_values[end] - x_values[start] > tol:
+            for k in range(m):
+                if deques[k] and deques[k][0] <= start:
+                    deques[k].popleft()
+            start += 1
+
+        # Calculate the sum of the maximum weighted `y` values in the current window
+        current_sum = sum(y_columns[k][deques[k][0]] for k in range(m))
+
+        # Update the best solution if the current sum is larger
+        if current_sum >= max_sum:
+            max_sum = current_sum
+            best_indices = [deques[k][0] for k in range(m)]
+
+    return best_indices, max_sum

--- a/fairlearn/postprocessing/_threshold_optimizer.py
+++ b/fairlearn/postprocessing/_threshold_optimizer.py
@@ -35,6 +35,7 @@ from ._constants import (
     SENSITIVE_FEATURE_KEY,
 )
 from ._interpolated_thresholder import InterpolatedThresholder
+from ._relaxed_constraints import maximize_objective_with_tolerance
 from ._tradeoff_curve_utilities import (
     METRIC_DICT,
     _extend_confusion_matrix,
@@ -237,6 +238,7 @@ class ThresholdOptimizer(BaseEstimator, MetaEstimatorMixin):
         flip=False,
         prefit=False,
         predict_method="auto",
+        tol: float | None = None,
     ):
         self.estimator = estimator
         self.constraints = constraints
@@ -245,6 +247,7 @@ class ThresholdOptimizer(BaseEstimator, MetaEstimatorMixin):
         self.flip = flip
         self.prefit = prefit
         self.predict_method = predict_method
+        self.tol = tol
 
     def fit(self, X, y, *, sensitive_features, **kwargs):
         """Fit the model.
@@ -272,9 +275,12 @@ class ThresholdOptimizer(BaseEstimator, MetaEstimatorMixin):
                         self.constraints
                     )
                 )
+
         elif self.constraints == "equalized_odds":
             if self.objective not in OBJECTIVES_FOR_EQUALIZED_ODDS:
                 raise ValueError(NOT_SUPPORTED_OBJECTIVES_FOR_EQUALIZED_ODDS_ERROR_MESSAGE)
+            if self.tol is not None:
+                raise ValueError("Relaxed constraints are not supported for equalized odds.")
         else:
             raise ValueError(NOT_SUPPORTED_CONSTRAINTS_ERROR_MESSAGE)
 
@@ -408,12 +414,15 @@ class ThresholdOptimizer(BaseEstimator, MetaEstimatorMixin):
             sensitive_features, labels, scores
         )
 
+        sensitive_feature_proportions = {}
+
         for (
             sensitive_feature_value,
             group,
         ) in data_grouped_by_sensitive_feature:
             # Determine probability of current sensitive feature group based on data.
             p_sensitive_feature_value = len(group) / n
+            sensitive_feature_proportions[sensitive_feature_value] = p_sensitive_feature_value
 
             roc_convex_hull = _tradeoff_curve(
                 group,
@@ -427,12 +436,6 @@ class ThresholdOptimizer(BaseEstimator, MetaEstimatorMixin):
                 roc_convex_hull, "x", "y", "operation", self._x_grid
             )
 
-            # Add up objective for the current group multiplied by the probability of the current
-            # group. This will help us in identifying the maximum overall objective.
-            overall_tradeoff_curve += (
-                p_sensitive_feature_value * self._tradeoff_curve[sensitive_feature_value]["y"]
-            )
-
             logger.debug(OUTPUT_SEPARATOR)
             logger.debug("Processing %s", str(sensitive_feature_value))
             logger.debug(OUTPUT_SEPARATOR)
@@ -441,37 +444,61 @@ class ThresholdOptimizer(BaseEstimator, MetaEstimatorMixin):
             logger.debug("Tradeoff curve")
             logger.debug(roc_convex_hull)
 
-        self._overall_tradeoff_curve = pd.DataFrame(
-            {"x": self._x_grid, "y": overall_tradeoff_curve}
-        )
+        if not self.tol:
+            overall_tradeoff_curve = pd.concat(
+                [
+                    p * self._tradeoff_curve[value]["y"]
+                    for value, p in sensitive_feature_proportions.items()
+                ],
+                axis=1,
+            ).sum(axis=1)
 
-        # Find maximum objective point given that at each point the constraint value for each
-        # sensitive feature value is identical by design.
-        i_best = overall_tradeoff_curve.idxmax()
-        self._x_best = self._x_grid[i_best]
+            self._overall_tradeoff_curve = pd.DataFrame(
+                {"x": self._x_grid, "y": overall_tradeoff_curve}
+            )
+
+            # Find maximum objective point given that at each point the constraint value for each
+            # sensitive feature value is identical by design.
+            i_best = overall_tradeoff_curve.idxmax()
+            self._x_best = self._x_grid[i_best]
+            self._y_best = overall_tradeoff_curve[i_best]
+            optimal_indices = [i_best] * len(sensitive_feature_proportions)
+
+            logger.debug(OUTPUT_SEPARATOR)
+            logger.debug("From tradeoff curves")
+            logger.debug(
+                "Best point (simple constraints): %s=%.3f, %s=%.3f",
+                self.y_metric_,
+                self._y_best,
+                self.x_metric_,
+                self._x_best,
+            )
+            logger.debug(OUTPUT_SEPARATOR)
+
+        else:
+            optimal_indices, self._y_best = maximize_objective_with_tolerance(
+                dataframes=[tradeoff_curve for tradeoff_curve in self._tradeoff_curve.values()],
+                weights=sensitive_feature_proportions.values(),
+                tol=self.tol,
+            )
+
+            self._x_best_per_group = {
+                group: self._x_grid[idx]
+                for group, idx in zip(self._tradeoff_curve.keys(), optimal_indices)
+            }
 
         # Create the solution as interpolation of multiple points with a separate
         # interpolation per sensitive feature value.
         interpolation_dict = {}
-        for sensitive_feature_value in self._tradeoff_curve.keys():
-            best_interpolation = self._tradeoff_curve[sensitive_feature_value].transpose()[i_best]
+
+        for sensitive_feature_value, idx_best in zip(self._tradeoff_curve, optimal_indices):
+            best_interpolation = self._tradeoff_curve[sensitive_feature_value].iloc[idx_best]
             interpolation_dict[sensitive_feature_value] = Bunch(
                 p0=best_interpolation.p0,
                 operation0=best_interpolation.operation0,
                 p1=best_interpolation.p1,
                 operation1=best_interpolation.operation1,
             )
-
-        logger.debug(OUTPUT_SEPARATOR)
-        logger.debug("From tradeoff curves")
-        logger.debug(
-            "Best point (simple constraints): %s=%.3f, %s=%.3f",
-            self.y_metric_,
-            overall_tradeoff_curve[i_best],
-            self.x_metric_,
-            self._x_best,
-        )
-        logger.debug(OUTPUT_SEPARATOR)
 
         return InterpolatedThresholder(
             self.estimator_,

--- a/test/unit/postprocessing/test_relaxed_constraints.py
+++ b/test/unit/postprocessing/test_relaxed_constraints.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from numpy.typing import NDArray
+
+from fairlearn.postprocessing._relaxed_constraints import (
+    maximize_objective_with_tolerance,
+)
+from fairlearn.postprocessing._threshold_optimizer import (
+    OBJECTIVES_FOR_SIMPLE_CONSTRAINTS,
+    SIMPLE_CONSTRAINTS,
+    ThresholdOptimizer,
+)
+
+from .conftest import ExamplePredictor
+
+
+@pytest.mark.parametrize(
+    ["x", "ys", "weights", "tol", "expected_indices", "expected_maximum"],
+    [
+        (
+            np.linspace(0, 1, 10),
+            [np.linspace(0, 1, 10) for _ in range(3)],
+            [1 / 3, 1 / 3, 1 / 3],
+            0.0,
+            [9, 9, 9],
+            1.0,
+        ),
+        (
+            np.array([0, 0.5, 1]),
+            [np.array([0, 1.0, 1.0]), np.array([0.0, 1.0, 1.0])],
+            [0.5, 0.5],
+            0.5,
+            [2, 2],
+            1.0,
+        ),
+        (
+            np.linspace(0, 1, 3),
+            [np.array([0, 2, 0]), np.array([0, 1, 2])],
+            [0.5, 0.5],
+            0.6,
+            [1, 2],
+            2.0,
+        ),
+        (
+            np.array([0, 0.5, 1]),
+            [np.array([1, 0.2, 0.0]), np.array([0.1, 0.2, 0.6]), np.array([0.0, 0.1, 0.5])],
+            [0.1, 0.8, 0.1],
+            0.6,
+            [1, 2, 2],
+            0.55,
+        ),
+    ],
+)
+def test_maximize_objective_with_tolerance_returns_correct_values(
+    x: NDArray,
+    ys: list[NDArray],
+    weights: NDArray,
+    tol: float,
+    expected_indices: list[int],
+    expected_maximum: float,
+) -> None:
+    dataframes = [pd.DataFrame({"x": x, "y": y}) for y in ys]
+    optimal_indices, maximum = maximize_objective_with_tolerance(
+        dataframes=dataframes, weights=weights, tol=tol
+    )
+
+    assert expected_indices == optimal_indices
+    assert expected_maximum == maximum
+
+
+@pytest.mark.parametrize("objective", OBJECTIVES_FOR_SIMPLE_CONSTRAINTS)
+@pytest.mark.parametrize("constraints", SIMPLE_CONSTRAINTS)
+def test_threshold_optimization_with_tolerance_only_increases_objective_and_respects_constraints(
+    constraints: str, objective: str
+) -> None:
+    scores = [0.1, 0.2, 0.3, 0.4, 0.5]
+    X = np.array([[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]])
+    y = np.array([1, 0, 1, 1, 0])
+    sensitive_features = np.array(["a", "b", "a", "b", "a"])
+    tol = 0.2
+
+    strict_predictor = ThresholdOptimizer(
+        estimator=ExamplePredictor(scores),
+        constraints=constraints,
+        objective=objective,
+        flip=True,
+        predict_method="predict",
+        grid_size=50,
+        tol=None,
+    )
+
+    relaxed_predictor = ThresholdOptimizer(
+        estimator=ExamplePredictor(scores),
+        constraints=constraints,
+        objective=objective,
+        flip=True,
+        predict_method="predict",
+        grid_size=50,
+        tol=tol,
+    )
+
+    strict_predictor.fit(X, y, sensitive_features=sensitive_features)
+    relaxed_predictor.fit(X, y, sensitive_features=sensitive_features)
+
+    assert relaxed_predictor._y_best >= strict_predictor._y_best
+    assert (
+        max(relaxed_predictor._x_best_per_group.values())
+        - min(relaxed_predictor._x_best_per_group.values())
+        <= tol
+    )


### PR DESCRIPTION
## Description
Hello again !

This is a small MR that aims to allow for a relaxed optimization of the threshold for simple constraints.

This is complementary to the work that has started in #1246 and #1248, and which only allows tolerance for `equalized odds`. The main difference though is that this does very minimal changes to the API, and doesn't require adding any new dependencies (no LP to solve).

Implementation-wise, I leveraged the fact that the `x_metric` values stored in the interpolated curves are the same (by construction) and are sorted in an ascending order for all the sensitive feature groups. \
The algorithm is a combination of a sliding window and a double-ended queue which makes it quite efficient ($O(n x m)$, where n is `x_grid` size and m is the number of sensitive groups).

This obviously lacking examples and user-guide etc.. But I wanted to first get some feedback from the maintainers before putting more effort into documentation. 

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [x] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
These are the different plots I get when running the current [user-guide example](https://fairlearn.org/v0.11/user_guide/mitigation/postprocessing.html) with different levels of `tol`.

### `tol = None (or 0)`
![image](https://github.com/user-attachments/assets/01f82869-5474-4239-9c43-b00c32b6c18f)

### `tol = 0.05`
![Screenshot from 2024-12-05 17-25-19](https://github.com/user-attachments/assets/0d2a9c17-c224-4034-be3d-f647dca17a3c)

### `tol = 0.5`
![Screenshot from 2024-12-05 17-24-34](https://github.com/user-attachments/assets/10cbc5b8-3008-4e3a-9c3c-5ec83e6c360a)
