### PR TITLE
Fix exponentiated gradient citation

### DIFF
--- a/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
+++ b/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
@@ -95,6 +95,10 @@ class ExponentiatedGradient(BaseEstimator, MetaEstimatorMixin):
 
         .. versionadded:: 0.5.0
 
+    References
+    ----------
+    .. footbibliography::
+        
     """
 
     def __init__(

--- a/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
+++ b/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
@@ -98,7 +98,7 @@ class ExponentiatedGradient(BaseEstimator, MetaEstimatorMixin):
     References
     ----------
     .. footbibliography::
-        
+
     """
 
     def __init__(


### PR DESCRIPTION
## Description
During the PyLadiesCon fastlearn sprint, @TamaraAtanasoska and I paired on fixing the broken citation on the [fairlearn.reductions.ExponentiatedGradient](https://fairlearn.org/v0.11/api_reference/generated/fairlearn.reductions.ExponentiatedGradient.html#fairlearn.reductions.ExponentiatedGradient) page.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [ ] user guide added or updated
- [X] API docs added or updated
- [ ] example notebook added or updated
