### PR TITLE
DOC Add a BibTeX reference to `plot_grid_search_census.py`; fix markdown

### DIFF
--- a/examples/plot_grid_search_census.py
+++ b/examples/plot_grid_search_census.py
@@ -245,8 +245,8 @@ plt.ylabel("selection rate difference")
 #
 # In a real example, we would pick the model which represented the best trade-off
 # between accuracy and disparity given the relevant business constraints.
-#
-# %% [markdown]
+
+# %%
 # Comparing models easily
 # -----------------------
 # Fairlearn also provides functionality to compare models much more easily.

--- a/examples/plot_grid_search_census.py
+++ b/examples/plot_grid_search_census.py
@@ -138,8 +138,8 @@ metric_frame.by_group.plot.bar(
 # --------------------------
 #
 # The :class:`fairlearn.reductions.GridSearch` class implements a simplified
-# version of the exponentiated gradient reduction of `Agarwal et al. 2018
-# <https://arxiv.org/abs/1803.02453>`_. The user supplies a standard ML
+# version of the exponentiated gradient reduction of Agarwal et al.
+# :footcite:`agarwal2018reductions`. The user supplies a standard ML
 # estimator, which is treated as a blackbox. `GridSearch` works by generating a
 # sequence of relabellings and reweightings, and trains a predictor for each.
 #
@@ -264,3 +264,9 @@ plot_model_comparison(
     show_plot=True,
 )
 # End model comparison
+
+# %%
+# ===========================
+# References
+# ===========================
+# .. footbibliography::


### PR DESCRIPTION
## Description
- related to #1069
- created during the sprint at PyLadiesCon

## Tests
- [x] no new tests required

## Screenshots

### 1. Added a BibTeX reference
![plot_grid_search_census__before_after](https://github.com/user-attachments/assets/05882ccb-53c5-4ade-a9ec-524ff4367b59)

### 2. Fixed a markdown header 
<img width="1111" alt="comparing_models_before_after" src="https://github.com/user-attachments/assets/cce76054-b9cf-4997-9667-6573a0e3fe1d">
