### PR TITLE
Fix:Add regex promptcopybutton, switch prompt to code-block

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,6 +70,9 @@ extensions = [
     "sphinx_issues",
 ]
 
+copybutton_prompt_text = r"\$\s+"
+copybutton_prompt_is_regexp = True
+
 source_suffix = [".rst"]
 
 # sphinx-issues config

--- a/docs/contributor_guide/contributing_documentation.rst
+++ b/docs/contributor_guide/contributing_documentation.rst
@@ -11,9 +11,9 @@ check the documentation of the version of the package that they are using.
 
 To contribute, make sure to install sphinx and its add-ons by running
 
-.. prompt:: bash
+.. code-block:: bash
 
-    python scripts/install_requirements.py --pinned False
+    $ python scripts/install_requirements.py --pinned False
 
 in the repository root directory.
 You may also need to `install Pandoc <https://pandoc.org/installing.html>`_.
@@ -21,9 +21,9 @@ You may also need to `install Pandoc <https://pandoc.org/installing.html>`_.
 Since plotting is an optional addition to Fairlearn, you may also need to
 install matplotlib
 
-.. prompt:: bash
+.. code-block:: bash
 
-    pip install matplotlib>=3.2.1
+    $ pip install matplotlib>=3.2.1
 
 You can contribute updates to existing documentation by navigating to the
 relevant part of the repository (typically in the `docs` directory), and
@@ -32,15 +32,15 @@ editing the restructured text files (`.rst`) corresponding to your updates.
 To build the webpage run the following command from the repository root
 directory:
 
-.. prompt:: bash
+.. code-block:: bash
 
-    python -m sphinx -v -b html -n -j auto docs docs/_build/html
+    $ python -m sphinx -v -b html -n -j auto docs docs/_build/html
 
 or use the shortcut
 
-.. prompt:: bash
+.. code-block:: bash
 
-        make doc
+        $ make doc
 
 This will generate the website in the directory mentioned at the end of the
 command. Rerunning this after making changes to individual files only
@@ -49,12 +49,12 @@ rebuilds the changed pages, so the build time should be a lot shorter.
 You can check that the document(s) render properly by inspecting the HTML with
 the following commands:
 
-.. prompt:: bash
+.. code-block:: bash
 
-    start docs/_build/html/index.html
-    start docs/_build/html/quickstart.html
+    $ start docs/_build/html/index.html
+    $ start docs/_build/html/quickstart.html
     ...
-    start docs/_build/html/auto_examples/plot_*.html
+    $ start docs/_build/html/auto_examples/plot_*.html
 
 .. line-block::
 

--- a/docs/contributor_guide/development_process.rst
+++ b/docs/contributor_guide/development_process.rst
@@ -37,30 +37,30 @@ While working on Fairlearn itself you may want to install it in editable mode.
 This allows you to test the changed functionality. First, clone the repository
 locally via:
 
-.. prompt:: bash
+.. code-block:: bash
 
-    git clone git@github.com:fairlearn/fairlearn.git
+   $ git clone git@github.com:fairlearn/fairlearn.git
 
 To install in editable mode, from the repository root path run:
 
-.. prompt:: bash
+.. code-block:: bash
 
-    pip install -e .
+   $ pip install -e .
 
 To verify that the code works as expected run:
 
-.. prompt:: bash
+.. code-block:: bash
 
-    python ./scripts/install_requirements.py --pinned False
-    python -m pytest -s ./test/unit
+   $ python ./scripts/install_requirements.py --pinned False
+   $ python -m pytest -s ./test/unit
 
 Fairlearn currently includes plotting functionality provided by
 :code:`matplotlib`. This is for a niche use case, so it isn't a default requirement. To install run:
 
-.. prompt:: bash
+.. code-block:: bash
 
-    pip install -e .
-    pip install matplotlib
+   $ pip install -e .
+   $ pip install matplotlib
 
 The Requirements Files
 """"""""""""""""""""""
@@ -118,7 +118,7 @@ Follow the steps below to create a pull request.
 #. Clone your fork of the fairlern repo from your GitHub account to your
    local machine:
 
-   .. prompt:: bash
+   .. code-block:: bash
 
       git clone git@github.com:YourLogin/fairlearn.git  # add --depth 1 if your connection is slow
       cd fairlearn
@@ -127,9 +127,9 @@ Follow the steps below to create a pull request.
    fairlearn repository, which you can use to keep your repository
    synchronized with the latest changes:
 
-   .. prompt:: bash
+   .. code-block:: bash
 
-        git remote add upstream git@github.com:fairlearn/fairlearn.git
+      $ git remote add upstream git@github.com:fairlearn/fairlearn.git
 
 #. Check that the :code:`upstream` and :code:`origin` remote aliases are configured correctly
    by running
@@ -146,10 +146,10 @@ Follow the steps below to create a pull request.
 
 #. (Optional) Install `pre-commit <https://pre-commit.com/#install>`_ to run code style checks before each commit:
 
-   .. prompt:: bash
+   .. code-block:: bash
 
-    pip install pre-commit
-    pre-commit install
+   $ pip install pre-commit
+   $ pre-commit install
 
    Pre-commit checks can be disabled for a particular commit with :code:`git commit -n`.
 

--- a/docs/contributor_guide/release.rst
+++ b/docs/contributor_guide/release.rst
@@ -10,9 +10,9 @@ The following steps assume git remote's :code:`origin` points to
 #. Ensure the maintainers listed in :code:`scripts/generate_maintainers_table.py`
    are up to date. Run the command below from the repository root directory:
 
-   .. prompt:: bash
+   .. code-block:: bash
 
-            python scripts/generate_maintainers_table.py
+        $ python scripts/generate_maintainers_table.py
 
    If the generated file :code:`docs/about/maintainers.rst` does not change
    you can proceed with the next step. Otherwise, create a PR to update
@@ -28,15 +28,15 @@ The following steps assume git remote's :code:`origin` points to
 
     #. Create a new branch:
 
-        .. prompt:: bash
+        .. code-block:: bash
 
-            git checkout -b release/v<x.y>.X
+            $ git checkout -b release/v<x.y>.X
 
     #. Push the branch to GitHub:
 
-        .. prompt:: bash
+        .. code-block:: bash
 
-            git push -u origin release/v<x.y>.X
+            $ git push -u origin release/v<x.y>.X
 
        You may need to temporarily add an exception to the
        `branch protection rules <https://github.com/fairlearn/fairlearn/settings/branches>`_
@@ -54,15 +54,15 @@ The following steps assume git remote's :code:`origin` points to
 
 #. On the release branch, place an annotated tag:
 
-        .. prompt:: bash
+        .. code-block:: bash
 
-            git tag -a v<x.y.z> -m "v<x.y.z> release"
+            $ git tag -a v<x.y.z> -m "v<x.y.z> release"
 
 #. Push the tag to GitHub:
 
-        .. prompt:: bash
+        .. code-block:: bash
 
-            git push origin v<x.y.z>
+            $ git push origin v<x.y.z>
 
 #. On `GitHub's release page <https://github.com/fairlearn/fairlearn/releases>`_,
    draft a new release. Choose the new tag, title the release `v<x.y.z>`,


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->
General summary change:
1. Add `copybutton_prompt_text` and `copybutton_prompt_is_regexp` attribute in conf.py
2. Switch the `.. prompt::` directive to `..code-block::`
3. Add static `$` in paragraph

Mention issue: https://github.com/fairlearn/fairlearn/issues/1456

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [x] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
The result changed from
 `
span.prompt1:before {
  content: "$ ";
}
python scripts/install_requirements.py --pinned False
` 

to only 

`python scripts/install_requirements.py --pinned False` 

<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
<img width="795" alt="image" src="https://github.com/user-attachments/assets/a8a39697-7467-417c-b92e-b78398d69349">
@TamaraAtanasoska can you please review my pull request 🙏 🚀