### PR TITLE
MNT Fix for the nightly init initialisation failure

### DIFF
--- a/fairlearn/adversarial/_adversarial_mitigation.py
+++ b/fairlearn/adversarial/_adversarial_mitigation.py
@@ -203,6 +203,11 @@ class _AdversarialFairness(BaseEstimator):
         Controls the randomized aspects of this algorithm, such as shuffling.
         Useful to get reproducible output across multiple function calls.
 
+    max_iter : int, default = -1
+        Maximum number of training iterations to perform. If set to -1, the number
+        of iterations is determined by epochs parameter. Either epochs or max_iter
+        must be positive.
+
     References
     ----------
     .. footbibliography::
@@ -996,6 +1001,8 @@ class AdversarialFairnessClassifier(ClassifierMixin, _AdversarialFairness):
 
     """  # noqa : E501
 
+    _estimator_type = "classifier"
+
     def __init__(
         self,
         *,
@@ -1018,7 +1025,6 @@ class AdversarialFairnessClassifier(ClassifierMixin, _AdversarialFairness):
         random_state=None,
     ):
         """Initialize model by setting the predictor loss and function."""
-        self._estimator_type = "classifier"
         super(AdversarialFairnessClassifier, self).__init__(
             backend=backend,
             predictor_model=predictor_model,
@@ -1194,6 +1200,8 @@ class AdversarialFairnessRegressor(RegressorMixin, _AdversarialFairness):
 
     """  # noqa : E501
 
+    _estimator_type = "regressor"
+
     def __init__(
         self,
         *,
@@ -1216,7 +1224,6 @@ class AdversarialFairnessRegressor(RegressorMixin, _AdversarialFairness):
         random_state=None,
     ):
         """Initialize model by setting the predictor loss and function."""
-        self._estimator_type = "regressor"
         super(AdversarialFairnessRegressor, self).__init__(
             backend=backend,
             predictor_model=predictor_model,


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
This PR removes init initialisations from the estimators in the adversarial module inheriting from `scikit-learn`'s `BaseEstimator` and being subject to the `scikit-learn` `estimator_checks`.

Additionally, a doc string for a parameter I added in a previous PR and forgot to add to the docstring is added (`max_iter`, for `scikit-learn` compliance).

Since @adrinjalali is away for a few weeks, I'd appreciate a review and a merge to make the nightly fully pass again @fairlearn/fairlearn-maintainers 🙏 
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [ ] user guide added or updated
- [x] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
