### PR TITLE
doc: remove outputs and python and bash prompts

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,8 +70,9 @@ extensions = [
     "sphinx_issues",
 ]
 
-copybutton_prompt_text = r"\$\s+"
+copybutton_prompt_text = r">>> |\.\.\. "
 copybutton_prompt_is_regexp = True
+copybutton_exclude = "style"
 
 source_suffix = [".rst"]
 

--- a/docs/contributor_guide/contributing_documentation.rst
+++ b/docs/contributor_guide/contributing_documentation.rst
@@ -39,9 +39,9 @@ documentation specific guidelines.
 
 You may also need to `install pandoc <https://pandoc.org/installing.html>`_. and :code:`matplotlib`.
 
-.. code-block:: bash
+.. prompt:: bash
 
-    $ pip install matplotlib>=3.2.1
+    pip install matplotlib>=3.2.1
 
 You can contribute updates to existing documentation by navigating to the
 relevant part of the repository (typically in the `docs` directory), and
@@ -50,15 +50,15 @@ editing the restructured text files (`.rst`) corresponding to your updates.
 To build the webpage run the following command from the repository root
 directory:
 
-.. code-block:: bash
+.. prompt:: bash
 
-    $ python -m sphinx -v -b html -n -j auto docs docs/_build/html
+    python -m sphinx -v -b html -n -j auto docs docs/_build/html
 
 or use the shortcut:
 
-.. code-block:: bash
+.. prompt:: bash
 
-        $ make doc
+    make doc
 
 This will generate the website in the directory mentioned at the end of the
 command. Rerunning this after making changes to individual files only
@@ -67,13 +67,13 @@ rebuilds the changed pages, so the build time should be a lot shorter.
 You can check that the document(s) render properly by inspecting the HTML with
 the following commands:
 
-.. code-block:: bash
+.. prompt:: bash
 
-    $ #replace start with open for MacOS and xdg-open for Linux
-    $ start docs/_build/html/index.html
-    $ start docs/_build/html/quickstart.html
+    #replace start with open for MacOS and xdg-open for Linux
+    start docs/_build/html/index.html
+    start docs/_build/html/quickstart.html
     ...
-    $ start docs/_build/html/auto_examples/plot_*.html
+    start docs/_build/html/auto_examples/plot_*.html
 
 The rendered HTML files can be explored in any file explorer and then opened
 using a browser (e.g., Chrome/Firefox/Safari).

--- a/docs/contributor_guide/development_process.rst
+++ b/docs/contributor_guide/development_process.rst
@@ -39,9 +39,9 @@ You will need a GitHub account to contribute to this project. Authenticating wit
 
 First, clone the repository locally via:
 
-.. code-block:: bash
+.. prompt:: bash
 
-   $ git clone git@github.com:fairlearn/fairlearn.git
+   git clone git@github.com:fairlearn/fairlearn.git
 
 
 (Optional) Set up a virtual environment:
@@ -71,16 +71,16 @@ If you are using a virtual environment(highly recommended), make sure it is acti
 To install in editable mode, from the repository root path run:
 
 
-.. code-block:: bash
+.. prompt:: bash
 
-   $ pip install -e .
+   pip install -e .
 
 To verify that the code works as expected run:
 
-.. code-block:: bash
+.. prompt:: bash
 
-   $ python ./scripts/install_requirements.py --pinned False
-   $ python -m pytest -s ./test/unit
+   python ./scripts/install_requirements.py --pinned False
+   python -m pytest -s ./test/unit
 
 .. note::
 
@@ -90,10 +90,10 @@ To verify that the code works as expected run:
 Fairlearn currently includes plotting functionality provided by
 :code:`matplotlib`. This is for a niche use case, so it isn't a default requirement. To install run:
 
-.. code-block:: bash
+.. prompt:: bash
 
-   $ pip install -e .
-   $ pip install matplotlib
+   pip install -e .
+   pip install matplotlib
 
 The Requirements Files
 """"""""""""""""""""""
@@ -156,7 +156,7 @@ Follow the steps below to create a pull request.
 #. Clone your fork of the fairlern repo from your GitHub account to your
    local machine:
 
-   .. code-block:: bash
+   .. prompt:: bash
 
       git clone git@github.com:YourLogin/fairlearn.git  # add --depth 1 if your connection is slow
       cd fairlearn
@@ -165,7 +165,7 @@ Follow the steps below to create a pull request.
    fairlearn repository, which you can use to keep your repository
    synchronized with the latest changes:
 
-   .. code-block:: bash
+   .. prompt:: bash
 
       $ git remote add upstream git@github.com:fairlearn/fairlearn.git
 
@@ -184,10 +184,10 @@ Follow the steps below to create a pull request.
 
 #. (Optional) Install `pre-commit <https://pre-commit.com/#install>`_ to run code style checks before each commit:
 
-   .. code-block:: bash
+   .. prompt:: bash
 
-      $ pip install pre-commit
-      $ pre-commit install
+      pip install pre-commit
+      pre-commit install
 
    Pre-commit checks can be disabled for a particular commit with :code:`git commit -n`.
 

--- a/docs/contributor_guide/release.rst
+++ b/docs/contributor_guide/release.rst
@@ -10,9 +10,9 @@ The following steps assume git remote's :code:`origin` points to
 #. Ensure the maintainers listed in :code:`scripts/generate_maintainers_table.py`
    are up to date. Run the command below from the repository root directory:
 
-   .. code-block:: bash
+   .. prompt:: bash
 
-        $ python scripts/generate_maintainers_table.py
+        python scripts/generate_maintainers_table.py
 
    If the generated file :code:`docs/about/maintainers.rst` does not change
    you can proceed with the next step. Otherwise, create a PR to update
@@ -28,15 +28,15 @@ The following steps assume git remote's :code:`origin` points to
 
     #. Create a new branch:
 
-        .. code-block:: bash
+        .. prompt:: bash
 
-            $ git checkout -b release/v<x.y>.X
+            git checkout -b release/v<x.y>.X
 
     #. Push the branch to GitHub:
 
-        .. code-block:: bash
+        .. prompt:: bash
 
-            $ git push -u origin release/v<x.y>.X
+            git push -u origin release/v<x.y>.X
 
        You may need to temporarily add an exception to the
        `branch protection rules <https://github.com/fairlearn/fairlearn/settings/branches>`_
@@ -54,15 +54,15 @@ The following steps assume git remote's :code:`origin` points to
 
 #. On the release branch, place an annotated tag:
 
-        .. code-block:: bash
+        .. prompt:: bash
 
-            $ git tag -a v<x.y.z> -m "v<x.y.z> release"
+            git tag -a v<x.y.z> -m "v<x.y.z> release"
 
 #. Push the tag to GitHub:
 
-        .. code-block:: bash
+        .. prompt:: bash
 
-            $ git push origin v<x.y.z>
+            git push origin v<x.y.z>
 
 #. On `GitHub's release page <https://github.com/fairlearn/fairlearn/releases>`_,
    draft a new release. Choose the new tag, title the release `v<x.y.z>`,

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -9,14 +9,14 @@ Installation
 Fairlearn can be installed with :code:`pip` from
 `PyPI <https://pypi.org/project/fairlearn>`_ as follows:
 
-.. code-block:: bash
+.. prompt:: bash
 
    pip install fairlearn
 
 Fairlearn is also available on
 `conda-forge <https://anaconda.org/conda-forge/fairlearn>`_:
 
-.. code-block:: bash
+.. prompt:: bash
 
     conda install -c conda-forge fairlearn
 
@@ -71,7 +71,7 @@ Prerequisites
 In order to run the code samples in the Quickstart tutorial, you need to
 install the following dependencies:
 
-.. code-block:: bash
+.. prompt:: bash
 
     pip install fairlearn matplotlib
 

--- a/docs/user_guide/installation_and_version_guide/installation_guide.rst
+++ b/docs/user_guide/installation_and_version_guide/installation_guide.rst
@@ -9,14 +9,14 @@ Installation
 Fairlearn can be installed with :code:`pip` from
 `PyPI <https://pypi.org/project/fairlearn>`_ as follows:
 
-.. code-block:: bash
+.. prompt:: bash
 
     pip install fairlearn
 
 Fairlearn is also available on
 `conda-forge <https://anaconda.org/conda-forge/fairlearn>`_:
 
-.. code-block:: bash
+.. prompt:: bash
 
     conda install -c conda-forge fairlearn
 
@@ -27,7 +27,7 @@ the basic installation.
 These dependencies are grouped in **extras**, which can be installed
 like so (by the example of the ``customplot`` extra):
 
-.. code-block:: bash
+.. prompt:: bash
 
     pip install fairlearn[customplot]
 
@@ -36,10 +36,10 @@ like so (by the example of the ``customplot`` extra):
 Dependencies
 ------------
 
-Fairlearn has the following optional dependencies which can be 
+Fairlearn has the following optional dependencies which can be
 installed via the corresponding **extra**, ordered by dependent module:
 
-.. list-table:: 
+.. list-table::
     :widths: 50 25 25
     :header-rows: 1
 


### PR DESCRIPTION
## Description
Closes #731 

If this is merged, copying the python code blocks (>>>) or bash($) will leave the prompt and outputs out of the clipboard.
I inspired myself from the way `sklearn` does it.

I'm aware I'm reverting some recent changes concerning `.. prompt:: bash`, but it makes more sense in my opinion, since sphinx adds the prompt for us (we do not to add the $ in the `.rst`), and leaves it out of the copy.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [x] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated
