### PR TITLE
DOC Fixes backtick typo for footnote display

### DIFF
--- a/examples/plot_credit_loan_decisions.py
+++ b/examples/plot_credit_loan_decisions.py
@@ -159,7 +159,7 @@ dataset.shape
 dataset.head()
 
 # %%
-# From the `dataset description` :footcite:`yeh2009comparisons`,
+# From the dataset description :footcite:`yeh2009comparisons`,
 # we see there are three categorical features:
 #
 # - :code:`SEX`: Sex of the applicant (as a binary feature)

--- a/examples/plot_credit_loan_decisions.py
+++ b/examples/plot_credit_loan_decisions.py
@@ -159,7 +159,7 @@ dataset.shape
 dataset.head()
 
 # %%
-# From the `dataset description :footcite:`yeh2009comparisons`,
+# From the `dataset description` :footcite:`yeh2009comparisons`,
 # we see there are three categorical features:
 #
 # - :code:`SEX`: Sex of the applicant (as a binary feature)


### PR DESCRIPTION
Fixes #1506
## Description
As pointed out by @sylvaincom in #1506, there's a missing backtick to render text in italics, which prevents a citation from displaying correctly in `examples/plot_credit_loan_decisions.html`. This PR adds the backtick.
I've rebuilt the html documentation to check that it now displays correctly.

## Tests
- [X] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
- [ ] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [X] example notebook added or updated
