### PR TITLE
MNT Enable xboost testing with sklearn 1.6 again

### DIFF
--- a/docs/user_guide/installation_and_version_guide/v0.13.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.13.0.rst
@@ -12,8 +12,3 @@ Other improvements
 * Vectorized the curve interpolation step in :code:`ThresholdOptimizer` to improve performance and readability: :pr:`1448` by :user:`Tahar Allouche <taharallouche>`.
 * Allowed multi-dimensional input data :code:`X` (:code:`ndims > 2`) in :code:`ThresholdOptimizer` and :code:`ExponentiatedGradient`: :pr:`1470` by :user:`Tahar Allouche <taharallouche>`.
 * Removed support for python 3.8 and added support for python 3.12: :pr:`1488` by :user:`Tamara Atanasoska <tamaraatanasoska>`.
-
-
-Notes
-----
-* Fairlearn can be now used with the latest versions of :code:`scikit-learn` and :code:`xgboost`: :pr:`1517` by :user:`Tamara Atanasoska <tamaraatanasoska>`.

--- a/docs/user_guide/installation_and_version_guide/v0.13.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.13.0.rst
@@ -12,3 +12,8 @@ Other improvements
 * Vectorized the curve interpolation step in :code:`ThresholdOptimizer` to improve performance and readability: :pr:`1448` by :user:`Tahar Allouche <taharallouche>`.
 * Allowed multi-dimensional input data :code:`X` (:code:`ndims > 2`) in :code:`ThresholdOptimizer` and :code:`ExponentiatedGradient`: :pr:`1470` by :user:`Tahar Allouche <taharallouche>`.
 * Removed support for python 3.8 and added support for python 3.12: :pr:`1488` by :user:`Tamara Atanasoska <tamaraatanasoska>`.
+
+
+Notes
+----
+* Fairlearn can be now used with the latest versions of :code:`scikit-learn` and :code:`xgboost`: :pr:`1517` by :user:`Tamara Atanasoska <tamaraatanasoska>`.

--- a/test_othermlpackages/test_pytorch.py
+++ b/test_othermlpackages/test_pytorch.py
@@ -90,10 +90,6 @@ def _should_skip_test():
     return parse(sklearn.__version__) >= parse("1.6.0")
 
 
-@pytest.mark.skipif(
-    _should_skip_test(),
-    reason="Skipped because of scikit-learn >= 1.6. Will be enabled again when the issues in the external library are fixed.",
-)
 def test_examples():
     af.test_examples()
 

--- a/test_othermlpackages/test_xgboost.py
+++ b/test_othermlpackages/test_xgboost.py
@@ -2,8 +2,6 @@
 # Licensed under the MIT License.
 
 import pytest
-import sklearn
-from packaging.version import parse
 
 from fairlearn.reductions import DemographicParity
 
@@ -12,14 +10,6 @@ from . import package_test_common as ptc
 xgb = pytest.importorskip("xgboost")
 
 
-def _should_skip_test():
-    return parse(sklearn.__version__) >= parse("1.6.0")
-
-
-@pytest.mark.skipif(
-    _should_skip_test(),
-    reason="Skipped because of scikit-learn >= 1.6. Will be enabled again when the issues in the external library are fixed.",
-)
 def test_expgrad_classification():
     estimator = xgb.XGBClassifier()
     disparity_moment = DemographicParity()
@@ -27,10 +17,6 @@ def test_expgrad_classification():
     ptc.run_expgrad_classification(estimator, disparity_moment)
 
 
-@pytest.mark.skipif(
-    _should_skip_test(),
-    reason="Skipped because of scikit-learn >= 1.6. Will be enabled again when the issues in the external library are fixed.",
-)
 def test_gridsearch_classification():
     estimator = xgb.XGBClassifier()
     disparity_moment = DemographicParity()
@@ -38,10 +24,6 @@ def test_gridsearch_classification():
     ptc.run_gridsearch_classification(estimator, disparity_moment)
 
 
-@pytest.mark.skipif(
-    _should_skip_test(),
-    reason="Skipped because of scikit-learn >= 1.6. Will be enabled again when the issues in the external library are fixed.",
-)
 def test_thresholdoptimizer_classification():
     estimator = xgb.XGBClassifier()
 


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
As #1459 outlines, we had issues with some packages not being compatible with the newest scikit-learn version. `Xgboost` has issued a release that covers these updates so we can remove skipping the tests.

Unfortunately no changes for `pytorch` or `tensorflow` yet.
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [ ] new tests added
- [x] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
