### PR TITLE
MNT remove `pandas` from `_merge_columns`

### DIFF
--- a/fairlearn/utils/_input_validation.py
+++ b/fairlearn/utils/_input_validation.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import logging
+from typing import Sequence
 
 import numpy as np
 import pandas as pd
@@ -148,26 +149,22 @@ def _merge_columns(feature_columns: np.ndarray) -> np.ndarray:
     -------
     numpy.ndarray
         One-dimensional array of merged columns
-
     """
     if not isinstance(feature_columns, np.ndarray):
         raise ValueError(
-            "Received argument of type {} instead of expected numpy.ndarray".format(
-                type(feature_columns).__name__
-            )
+            f"Received argument of type {type(feature_columns).__name__} instead of expected numpy.ndarray"
         )
-    return (
-        pd.DataFrame(feature_columns)
-        .apply(
-            lambda row: _MERGE_COLUMN_SEPARATOR.join(
-                [
-                    str(row[i])
-                    .replace("\\", "\\\\")  # escape backslash and separator
-                    .replace(_MERGE_COLUMN_SEPARATOR, "\\" + _MERGE_COLUMN_SEPARATOR)
-                    for i in range(len(row))
-                ]
-            ),
-            axis=1,
+
+    def _join_names(names: Sequence[str]) -> str:
+        return _MERGE_COLUMN_SEPARATOR.join(
+            [
+                name
+                # escape backslash and separator
+                .replace("\\", "\\\\").replace(
+                    _MERGE_COLUMN_SEPARATOR, f"\\{_MERGE_COLUMN_SEPARATOR}"
+                )
+                for name in names
+            ]
         )
-        .values
-    )
+
+    return np.array([_join_names(row) for row in feature_columns.astype(str)])

--- a/test/unit/utils/test_utils.py
+++ b/test/unit/utils/test_utils.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import pandas as pd
+import pytest
 
 import fairlearn.utils._input_validation as iv
 
@@ -61,3 +62,37 @@ def test_validate_and_reformat_input_allow_ndims_greater_than_2() -> None:
     X_update, _, _, _ = iv._validate_and_reformat_input(X=X, sensitive_features=sf, expect_y=False)
 
     np.testing.assert_array_equal(X, X_update)
+
+
+@pytest.mark.parametrize(
+    ("input_data", "expected"),
+    [
+        (np.array([["A", "B"], ["C", "D"]]), np.array(["A,B", "C,D"])),
+        (
+            np.array(
+                [
+                    ["test\\with\\backslash", "normal"],
+                    ["normal", "test,with,,separator"],
+                    ["both\\types,test", "value"],
+                ]
+            ),
+            np.array(
+                [
+                    "test\\\\with\\\\backslash,normal",
+                    "normal,test\\,with\\,\\,separator",
+                    "both\\\\types\\,test,value",
+                ]
+            ),
+        ),
+    ],
+)
+def test_merge_columns(input_data, expected):
+    result = iv._merge_columns(input_data)
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_merge_columns_value_error():
+    with pytest.raises(
+        ValueError, match=r"Received argument of type list instead of expected numpy\.ndarray"
+    ):
+        iv._merge_columns([["A", "1"], ["B", "2"]])


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
Towards #1522 . Discovered while working on narwhalifying `utils/_input_validation`, I think this can safely go to `main`

Given that the input and output  are `np.ndarray`s we can skip going via pandas.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [x] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
