### PR TITLE
MNT remove extra noqa

### DIFF
--- a/fairlearn/metrics/__init__.py
+++ b/fairlearn/metrics/__init__.py
@@ -31,7 +31,7 @@ from ._base_metrics import false_positive_rate  # noqa: F401
 from ._base_metrics import mean_prediction  # noqa: F401
 from ._base_metrics import selection_rate  # noqa: F401
 from ._base_metrics import true_negative_rate  # noqa: F401
-from ._base_metrics import true_positive_rate  # noqa: F401; noqa: F401
+from ._base_metrics import true_positive_rate  # noqa: F401
 from ._fairness_metrics import demographic_parity_difference  # noqa: F401
 from ._fairness_metrics import demographic_parity_ratio  # noqa: F401
 from ._fairness_metrics import equal_opportunity_difference  # noqa: F401


### PR DESCRIPTION
## Description
I saw that some linting pipelines are failing the linting-ruff job (eg, https://github.com/fairlearn/fairlearn/actions/runs/13834889623/job/38732324210?pr=1478 and https://github.com/fairlearn/fairlearn/actions/runs/13852686923/job/38821917874?pr=1527). This is an attempt to fix it.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
