### PR TITLE
FIX Add newline to the pinned numpy req in install_requirements

### DIFF
--- a/scripts/install_requirements.py
+++ b/scripts/install_requirements.py
@@ -22,8 +22,8 @@ _REQUIREMENTS_EXTENSION = "txt"
 # Configuration for the --pinned argument including explicit package versions
 # that are minimally required for the latest Python versions.
 _PINNED_REQUIREMENTS = {
-    "3.12": "numpy==1.26.0",
-    "3.13": "numpy==2.1.0",
+    "3.12": "numpy==1.26.0\n",
+    "3.13": "numpy==2.1.0\n",
 }
 
 _logger = logging.getLogger(__file__)


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
I am not sure how the newline was deleted, but it is necessary, somehow got lots between the commits. Otherwise the `requirements.txt` cannot be written properly. I am so sorry for the inconvenience. 

ping @riedgar-ms and @adrinjalali with regards to #1491
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
