### PR TITLE
DOC Improving code style guide

### DIFF
--- a/docs/contributor_guide/code_style.rst
+++ b/docs/contributor_guide/code_style.rst
@@ -1,0 +1,61 @@
+Code style
+==========
+
+Github conventions
+------------------
+
+Because the Fairlearn team squash merges pull requests, you do not need to put
+much effort into the commit messages you submit when pushing code.
+
+Titles should be descriptive and include one of the following prefixes:
+* DOC: any documentation-related PRs (including the user guide, API reference, and other 
+website-related PRs).
+* MNT: code maintenance (refactoring, improve efficiency, etc.).
+* CI: anything related to our automated tests (nightly builds, CircleCI, releases, etc.).
+* FIX: bug fixes.
+* FEAT/ENH: adds or removes a new feature in the codebase.
+
+Test coverage is checked with ``codecov`` and line missing tests will show up in CI 
+as a failure. Therefore, we recommend contributors ensure all new content 
+they introduce has adequate test coverage.
+
+
+Code conventions
+----------------
+
+Linting
+^^^^^^^
+
+We recommend using a linter to check your code before you submit a PR. 
+We use ``ruff`` to check for PEP8 compatibility issues. You can either follow
+the guidelines, or you can run ``black`` on your code. The generated
+formatting by ``black`` is compatible our formatting requirements. You can
+configure your IDE to use ``black`` to format your code. Please refer to your
+IDE's instructions for further details.
+
+Considerations for new methods
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you are introducing new estimators to the Fairlearn, you must ensure the 
+estimator is fully compatible with scikit-learn (defined `here <https://scikit-learn.org/stable/developers/develop.html>`_
+). For more resources on how to develop scikit-learn estimators, review this 
+`post <https://tamaraatanasoska.github.io/learning/2025/01/15/week-2-2024.html>`_ 
+by one of the Fairlearn maintainers.
+
+The Fairlearn team is in the process of swapping out the ``pandas`` library for
+``narwhals`` for data manipulation tasks. If you are contributing code that 
+includes Pandas, we recommend you use Narwhals instead to stay ahead of this effort.
+
+Because there are many complex sources of unfairness — some societal and some technical — it is not 
+possible to fully “debias” a system or to guarantee fairness. In Fairlearn, we therefore try to 
+avoid naming mitigation techniques in a way that could suggest they offer a simple fix towards a 
+"fair" model. Instead, we opt for descriptive names, such as "ThresholdOptimizer" (rather than 
+e.g. "FairThresholder") and "CorrelationRemover" (instead of e.g. "BiasRemover").
+
+Documentation
+-------------
+
+All restructured text (ReST) files submitted for documentation issues should adhere to a max line 
+limit of 99 characters. If a line of text runs past that limit, start a new 
+line with the overflow text. You should be able to set this limit in ``black``
+so you can automatically ensure you meet this requirement. 

--- a/docs/contributor_guide/code_style.rst
+++ b/docs/contributor_guide/code_style.rst
@@ -29,7 +29,7 @@ Linting
 We recommend using a linter to check your code before you submit a PR. 
 We use ``ruff`` to check for PEP8 compatibility issues. You can either follow
 the guidelines, or you can run ``black`` on your code. The generated
-formatting by ``black`` is compatible our formatting requirements. You can
+formatting by ``black`` is compatible our with formatting requirements. You can
 configure your IDE to use ``black`` to format your code. Please refer to your
 IDE's instructions for further details.
 Attaining the project compatible linting is also possible without changing your local setup. You can enable the pre-commit hooks, which will run the linters described above with the settings defined in the [pyproject.toml](https://github.com/fairlearn/fairlearn/blob/main/pyproject.toml). The installation instructions are described in step 6 of `"Contributing a Pull Request"`<https://fairlearn.org/main/contributor_guide/development_process.html#contributing-a-pull-request>`_ .

--- a/docs/contributor_guide/code_style.rst
+++ b/docs/contributor_guide/code_style.rst
@@ -15,7 +15,7 @@ website-related PRs).
 * FIX: bug fixes.
 * FEAT/ENH: adds or removes a new feature in the codebase.
 
-Test coverage is checked with ``codecov`` and line missing tests will show up in CI 
+Test coverage is checked with ``codecov`` and lines missing tests will show up in CI 
 as a failure. Therefore, we recommend contributors ensure all new content 
 they introduce has adequate test coverage.
 

--- a/docs/contributor_guide/code_style.rst
+++ b/docs/contributor_guide/code_style.rst
@@ -52,3 +52,8 @@ possible to fully “debias” a system or to guarantee fairness. In Fairlearn, 
 avoid naming mitigation techniques in a way that could suggest they offer a simple fix towards a 
 "fair" model. Instead, we opt for descriptive names, such as "ThresholdOptimizer" (rather than 
 e.g. "FairThresholder") and "CorrelationRemover" (instead of e.g. "BiasRemover").
+
+Code coverage
+^^^^^^^^^^^^^
+For more information about Fairlean's default coverage settings check the `codecov documentation <https://docs.codecov.com/docs/coverage-
+configuration#:~:text=Codecov%20will%20round%20coverage%20down,45.15313%25%20would%20become%2045.15%25>`_.

--- a/docs/contributor_guide/code_style.rst
+++ b/docs/contributor_guide/code_style.rst
@@ -32,6 +32,7 @@ the guidelines, or you can run ``black`` on your code. The generated
 formatting by ``black`` is compatible our formatting requirements. You can
 configure your IDE to use ``black`` to format your code. Please refer to your
 IDE's instructions for further details.
+Attaining the project compatible linting is also possible without changing your local setup. You can enable the pre-commit hooks, which will run the linters described above with the settings defined in the [pyproject.toml](https://github.com/fairlearn/fairlearn/blob/main/pyproject.toml). The installation instructions are described in step 6 of `"Contributing a Pull Request"`<https://fairlearn.org/main/contributor_guide/development_process.html#contributing-a-pull-request>`_ .
 
 Considerations for new methods
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/contributor_guide/code_style.rst
+++ b/docs/contributor_guide/code_style.rst
@@ -53,7 +53,7 @@ avoid naming mitigation techniques in a way that could suggest they offer a simp
 "fair" model. Instead, we opt for descriptive names, such as "ThresholdOptimizer" (rather than 
 e.g. "FairThresholder") and "CorrelationRemover" (instead of e.g. "BiasRemover").
 
-Code coverage
+Test coverage
 ^^^^^^^^^^^^^
 For more information about Fairlean's default coverage settings check the `codecov documentation <https://docs.codecov.com/docs/coverage-
 configuration#:~:text=Codecov%20will%20round%20coverage%20down,45.15313%25%20would%20become%2045.15%25>`_.

--- a/docs/contributor_guide/code_style.rst
+++ b/docs/contributor_guide/code_style.rst
@@ -52,11 +52,3 @@ possible to fully “debias” a system or to guarantee fairness. In Fairlearn, 
 avoid naming mitigation techniques in a way that could suggest they offer a simple fix towards a 
 "fair" model. Instead, we opt for descriptive names, such as "ThresholdOptimizer" (rather than 
 e.g. "FairThresholder") and "CorrelationRemover" (instead of e.g. "BiasRemover").
-
-Documentation
--------------
-
-All restructured text (ReST) files submitted for documentation issues should adhere to a max line 
-limit of 99 characters. If a line of text runs past that limit, start a new 
-line with the overflow text. You should be able to set this limit in ``black``
-so you can automatically ensure you meet this requirement. 

--- a/docs/contributor_guide/code_style.rst
+++ b/docs/contributor_guide/code_style.rst
@@ -13,9 +13,9 @@ website-related PRs).
 * MNT: code maintenance (refactoring, improve efficiency, etc.).
 * CI: anything related to our automated tests (nightly builds, CircleCI, releases, etc.).
 * FIX: bug fixes.
-* FEAT/ENH: adds or removes a new feature in the codebase.
+* FEAT/ENH: adds a new feature or removes a feature in the codebase.
 
-Test coverage is checked with ``codecov`` and lines missing tests will show up in CI 
+Test coverage is checked with ``codecov`` and line(s) missing tests will show up in CI 
 as a failure. Therefore, we recommend contributors ensure all new content 
 they introduce has adequate test coverage.
 

--- a/docs/contributor_guide/contributing_code.rst
+++ b/docs/contributor_guide/contributing_code.rst
@@ -19,6 +19,10 @@ For metrics, Fairlearn currently only supports disaggregated methods, so
 any proposed metrics that do not fall into the group fairness metric
 paradigm would first require thorough discussion with maintainers.
 
+Code Style
+----------
+View the :ref:`code_style` section for an overview of the style we expect for contributed code.
+
 
 API conventions
 ---------------
@@ -88,12 +92,3 @@ optional if the sensitive features are already provided through :code:`X`.
 
     postprocessor.fit(X, y, sensitive_features=sensitive_features)
     postprocessor.predict(X, sensitive_features=sensitive_features)
-
-Code Style
-----------
-
-We use ``ruff`` to check for PEP8 compatibility issues. You can either follow
-the guidelines, or you could run ``black`` on your code. The generated
-formatting by ``black`` is compatible with the requirements we have. You can
-configure your IDE to use ``black`` to format your code. Please refer to your
-IDE's instructions for further details.

--- a/docs/contributor_guide/contributing_documentation.rst
+++ b/docs/contributor_guide/contributing_documentation.rst
@@ -96,8 +96,10 @@ ensure that they all render properly.
 
 Code Style
 ^^^^^^^^^^
-View the :ref:`code_style` section for an overview of the style we expect for contributed
-documentation files.
+All restructured text (ReST) files submitted for documentation issues should adhere to a max line 
+limit of 99 characters. If a line of text runs past that limit, start a new 
+line with the overflow text. You should be able to set this limit in ``black``
+so you can automatically ensure you meet this requirement. 
 
 Citations
 ^^^^^^^^^

--- a/docs/contributor_guide/contributing_documentation.rst
+++ b/docs/contributor_guide/contributing_documentation.rst
@@ -94,6 +94,10 @@ ensure that they all render properly.
     pull request) and need help, simply @mention
     :code:`@fairlearn/fairlearn-maintainers` to get help.
 
+Code Style
+^^^^^^^^^^
+View the :ref:`code_style` section for an overview of the style we expect for contributed
+documentation files.
 
 Citations
 ^^^^^^^^^

--- a/docs/contributor_guide/index.rst
+++ b/docs/contributor_guide/index.rst
@@ -17,6 +17,7 @@ The contribution guide explains how to structure your contributions. Please
    fairlearn_repository_overview
    development_process
    contributing_code
+   code_style
    contributing_example_notebooks
    contributing_documentation
    fairlearn_proposals


### PR DESCRIPTION
Addresses #952 to improve the code style guide within the contributor guide. Adds a new page named "code style" with the guidance mentioned in the issue, and adds references to this page throughout the contributor guide.

## Tests
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
- [ ] no documentation changes needed
- [x] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

Requesting inputs from @taharallouche, @hildeweerts, and @TamaraAtanasoska on whether I left any important information out!