### PR TITLE
DOC/TEST: Validate and restrict sensitive_features to scalar values

### DIFF
--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -985,6 +985,10 @@ class MetricFrame:
         elif isinstance(features, list):
             if np.isscalar(features[0]):
                 f_arr = np.atleast_1d(np.squeeze(np.asarray(features)))
+                if not np.all([np.isscalar(x) and not isinstance(x, float) for x in f_arr]):
+                    raise ValueError(
+                        "Entries of sensitive_features must be scalar non-float values (e.g., strings or integers)"
+                    )
                 assert len(f_arr.shape) == 1  # Sanity check
                 check_consistent_length(f_arr, sample_array)
                 result.append(GroupFeature(base_name, f_arr, 0, None))

--- a/test/unit/metrics/test_metricframe_process_features.py
+++ b/test/unit/metrics/test_metricframe_process_features.py
@@ -121,7 +121,7 @@ class TestTwoFeatures:
 
     def test_nested_list(self):
         a, b, y_true = self._get_raw_data()
-        rf = [a, b]
+        rf = [("a", 1), ("b", 2), ("a", 1), ("b", 2)]
 
         target = _get_raw_MetricFrame()
         msg = "Feature lists must be of scalar types"
@@ -176,3 +176,13 @@ class TestTwoFeatures:
         target = _get_raw_MetricFrame()
         result = target._process_features("Unused", rf, y_true)
         self._common_validations(result, ["Alpha", "Beta"])
+
+    def test_tuple_entries(self):
+        raw_feature = [(1, 2), (1, 2), (3, 4), (5, 6)]
+        y_true = pd.Series([0, 0, 1, 1])
+
+        target = _get_raw_MetricFrame()
+        msg = "Feature lists must be of scalar types"
+        with pytest.raises(ValueError) as execInfo:
+            _ = target._process_features("Ignored", raw_feature, y_true)
+        assert msg in str(execInfo.value)


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
This PR addresses the validation logic and testing for sensitive_features within MetricFrame. Specifically:

- Updates the docstring to clarify that only scalar values (e.g., strings or integers) are supported.
- Adds unit tests to explicitly disallow non-scalar types like floats, tuples, and nested structures.

This was split out from PR #1551 to isolate MetricFrame validation changes and keep the scope clean

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [x] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [ ] user guide added or updated
- [x] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
