### PR TITLE
MNT Temporarily limit scipy version to less than 1.16.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ narwhals>=1.14.0
 numpy>=1.24.4
 pandas>=2.0.3
 scikit-learn>=1.2.1
-scipy>=1.9.3
+scipy>=1.9.3, < 1.16.0


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
To make `fairlearn` fully `scipy` 1.16.0 compatible, we would need to add some changes to the codebase. 
In order to not stall the merging of some other outstanding PRs, I propose to temporarily limit the version until someone can pick it up to update some of the issues that arise. 

Here is a relevant issue #1562.

I would love to move a few things forward(including merging solutions for bugs etc.) and have a green `CI` for next week at EuroPython where I hope to meet and talk with folks about the library after the presentation. If someone has the time to fix the `scipy` issues this week, that would be amazing, but it can also wait for a few weeks. I can take a look after I am back from EuroPython. 

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
