### PR TITLE
patch: Test pandas with pyarrow backend conditionally of having pyarrow installed

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -38,7 +38,7 @@ pandas_ge_v2 = parse_version(pd.__version__) >= parse_version("2.0.0")
 
 if pandas_ge_v2:
     constructors.append(pandas_nullable_constructor)
-    
+
 if pandas_ge_v2 and is_pyarrow_installed:
     # pandas 2.0+ supports pyarrow dtype backend
     # https://pandas.pydata.org/docs/whatsnew/v2.0.0.html#new-dtype-backends


### PR DESCRIPTION
## Description

Fix issue in https://github.com/fairlearn/fairlearn/pull/1542: requirements-min.txt does not have pyarrow, which causes the pandas with pyarrow dtype backend to fail.

This PR makes sure that such constructor is added only if pyarrow is installed and pandas version is greater or equal than 2.0.0

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
