### PR TITLE
Close Matplotlib figures before/after tests to avoid deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,6 @@ filterwarnings = [
     "default:The LGBMClassifier or classes from which it inherits use `_get_tags` and `_more_tags`:FutureWarning",
 
     # Warnings in release-wheel
-    # Matplotlib
-    #"ignore:Auto-close.*backend switching is deprecated",
     # Pillow
     "ignore:.*parameter is deprecated and will be removed in Pillow 13.*:DeprecationWarning"
 ]

--- a/test/unit/postprocessing/conftest.py
+++ b/test/unit/postprocessing/conftest.py
@@ -92,18 +92,6 @@ _data_ex3 = _data(
     scores_ex,
 )
 
-def pytest_configure(config):
-    # Runs very early (before tests are collected), so is safe place to ensure no open figures
-    import matplotlib.pyplot as plt
-    plt.close("all")
-
-@pytest.fixture(autouse=True)
-def _close_figs_around_test():
-    # Close before AND after each test to avoid lingering figures between tests
-    import matplotlib.pyplot as plt
-    plt.close("all")     # pre-test (important for backend switches)
-    yield
-    plt.close("all")     # post-test cleanup
 
 @pytest.fixture(params=[_data_ex1, _data_ex2, _data_ex3])
 def data(request):

--- a/test/unit/postprocessing/test_plots.py
+++ b/test/unit/postprocessing/test_plots.py
@@ -21,6 +21,16 @@ a typical pytest command without extra options) or to actually compare the
 generated images with the baseline plots (using pytest --mpl)."""
 
 
+@pytest.fixture()
+def close_figs():
+    # Close before and after each test to avoid lingering figures between tests
+    import matplotlib.pyplot as plt
+
+    plt.close("all")  # pre-test (important for backend switches)
+    yield
+    plt.close("all")  # post-test cleanup
+
+
 def _fit_and_plot(constraints, plotting_data, tol: float | None = None):
     import matplotlib.pyplot as plt
 
@@ -50,6 +60,7 @@ def is_mpl_installed():
         return False
 
 
+@pytest.mark.usefixtures("close_figs")
 @pytest.mark.skipif(not is_mpl_installed(), reason=PYTEST_MPL_NOT_INSTALLED_MSG)
 class TestPlots:
     @pytest.mark.mpl_image_compare(filename="post_processing_equalized_odds_ex1.png")


### PR DESCRIPTION
## Summary
This PR prevents MatplotlibDeprecationWarning: Auto-close()ing of figures from surfacing by explicitly closing any open figures before and after each test (and once at pytest configure time).

- Add early and per-test figure closures via scoped conftest.py
- Remove pyproject.toml suppression for Matplotlib auto-close deprecation

@taharallouche 


### Root Issue
- https://github.com/fairlearn/fairlearn/issues/1583
