### PR TITLE
DOC: Fix true positive rate formulation in equal opportunity metrics

### DIFF
--- a/fairlearn/metrics/_fairness_metrics.py
+++ b/fairlearn/metrics/_fairness_metrics.py
@@ -264,7 +264,7 @@ def equal_opportunity_difference(
 
     The equal opportunity difference is defined as the difference
     between the largest and the smallest group-level true positive rates,
-    :math:`E[h(X) | A=a]`, across all values :math:`a` of the sensitive feature(s).
+    :math:`P[h(X)=1 | A=a, Y=1]`, across all values :math:`a` of the sensitive feature(s).
     The equal opportunity difference of 0 means that all groups have the same true positive rate.
 
     Read more in the :ref:`User Guide <disparity_metrics>`.
@@ -315,7 +315,7 @@ def equal_opportunity_ratio(
 
     The equal opportunity ratio is defined as the ratio
     between the smallest and the largest group-level true positive rate,
-    :math:`E[h(X) | A=a]`, across all values :math:`a` of the sensitive feature(s).
+    :math:`P[h(X)=1 | A=a, Y=1]`, across all values :math:`a` of the sensitive feature(s).
     The equal opportunity ratio of 1 means that all groups have the same true positive rate.
 
     Read more in the :ref:`User Guide <disparity_metrics>`.


### PR DESCRIPTION
- Change E[h(X) | A=a] to P[h(X)=1 | A=a, Y=1] in equal_opportunity_difference
- Change E[h(X) | A=a] to P[h(X)=1 | A=a, Y=1] in equal_opportunity_ratio
- Fixes #1594

<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
<!--- Provide a general summary of your changes. -->
Fix the true positive rate formulation in equal opportunity metrics documentation. The docstrings incorrectly defined true positive rate as E[h(X) | A=a] when it should be P[h(X)=1 | A=a, Y=1].

<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
Fixes #1594 

<!--- Tag people for whom this PR may be of interest using @<username>. -->
@taharallouche 

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [x] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
