### PR TITLE
MAINT: Remove Fairlearn repository overview from contributor guide TOC

### DIFF
--- a/docs/contributor_guide/index.rst
+++ b/docs/contributor_guide/index.rst
@@ -14,7 +14,6 @@ The contribution guide explains how to structure your contributions. Please
 
    ways_to_contribute
    how_to_talk_about_fairness
-   fairlearn_repository_overview
    development_process
    contributing_code
    code_style


### PR DESCRIPTION
## Description
Removed the outdated `fairlearn_repository_overview` entry from the contributor guide TOC (`index.rst`).
Related to issue #900.  

## Tests
- [x] no new tests required  

## Documentation
- [x] user guide updated  

## Screenshots
N/A
