### PR TITLE
Fixed input dimension calculation for >2D arrays in BackendEngine

### DIFF
--- a/fairlearn/adversarial/_backend_engine.py
+++ b/fairlearn/adversarial/_backend_engine.py
@@ -1,7 +1,7 @@
 # Copyright (c) Fairlearn contributors.
 # Licensed under the MIT License.
 
-from numpy import ndarray
+from numpy import ndarray, prod
 from sklearn.utils import shuffle
 
 from ._constants import (
@@ -33,7 +33,7 @@ class BackendEngine:
         """
         self.base = base
 
-        n_X_features = X.shape[1]  # FIXME: what if X.ndim > 2?
+        n_X_features = int(prod(X.shape[1:]))
         n_Y_features = base._y_transform.n_features_out_
         n_A_features = base._sf_transform.n_features_out_
 

--- a/test/unit/adversarial/test_adversarial_mitigation.py
+++ b/test/unit/adversarial/test_adversarial_mitigation.py
@@ -71,6 +71,29 @@ def test_model_init(fake_backend_env):
     assert len(layers) == 7
 
 
+@pytest.mark.parametrize("fake_backend_env", ["torch"], indirect=True)
+def test_model_init_3d(fake_backend_env):
+    """Test model init with 3D input (verifying the fix for >2D arrays)."""
+    X = np.random.rand(10, 5, 5)
+    Y = np.random.randint(0, 2, 10)
+    Z = np.random.randint(0, 2, 10)
+
+    mitigator = get_instance(
+        fake_backend=fake_backend_env,
+        fake_mixin=False,
+        fake_training=True,
+        predictor_model=[10, "ReLU"],
+        skip_validation=True,
+    )
+    mitigator.fit(X, Y, sensitivefeatures=Z)
+
+    layers = mitigator.backendEngine_.predictor_model.layers_
+    if hasattr(layers, "layers"):
+        layers = layers.layers
+
+    assert layers[0].a == 25
+
+
 @pytest.mark.parametrize("fake_backend_env", ["torch", "tensorflow"], indirect=True)
 def test_model_params(fake_backend_env):
     """Test training params."""


### PR DESCRIPTION
Fixed input dimension calculation for >2D arrays in BackendEngine

## Description
This PR fixes a bug in `fairlearn.adversarial._backend_engine.py` where multi-dimensional inputs, like images, weren’t being handled correctly. The number of input features is now calculated using `numpy.prod(X.shape[1:])`, so all dimensions are counted and the neural network is initialized with the correct input size. Before, only the first non-batch dimension was considered, which could lead to wrong assumptions about the input shape.

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [x] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
