### PR TITLE
Removes the obsolete Pillow deprecation warning suppression.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,6 @@ filterwarnings = [
     "default:The LGBMClassifier or classes from which it inherits use `_get_tags` and `_more_tags`:FutureWarning",
 
     # Warnings in release-wheel
-    # Pillow
-    "ignore:.*parameter is deprecated and will be removed in Pillow 13.*:DeprecationWarning"
 ]
 
 markers = [


### PR DESCRIPTION
This PR removes the obsolete Pillow deprecation warning suppression from pyproject.toml.

The original issue (#1618) was triggered by an upstream interaction between Matplotlib and Pillow. With Matplotlib 3.10.8 and Pillow 12.1.0, the 'mode' parameter warning is no longer produced during plotting tests.

Closes #1618



<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
<!--- Provide a general summary of your changes. -->
<!--- Mention related issues, pull requests, or discussions with #<issue/PR/discussion ID>. -->
<!--- Tag people for whom this PR may be of interest using @<username>. -->

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
