### PR TITLE
FIX polar dataframe interchange protocol deprecation

### DIFF
--- a/fairlearn/preprocessing/_correlation_remover.py
+++ b/fairlearn/preprocessing/_correlation_remover.py
@@ -103,7 +103,8 @@ class CorrelationRemover(TransformerMixin, BaseEstimator):
         # correctly handle a 1d input
         X = validate_data(self, X, ensure_2d=False, ensure_min_samples=0)
         if len(X.shape) == 1:
-            return {0: 0}
+            self.lookup_ = {0: 0}
+            return X
         self.lookup_ = {i: i for i in range(X.shape[1])}
         return X
 
@@ -113,7 +114,7 @@ class CorrelationRemover(TransformerMixin, BaseEstimator):
         first_call = not hasattr(self, "_n_features_in_")
 
         self._check_sensitive_features_in_X(X)
-        self._create_lookup(X)
+        X = self._create_lookup(X)
         X = validate_data(self, X)
 
         if not first_call:
@@ -137,6 +138,10 @@ class CorrelationRemover(TransformerMixin, BaseEstimator):
     def transform(self, X):
         """Transform X by applying the correlation remover."""
         check_is_fitted(self, ["beta_", "_n_features_in_", "lookup_", "sensitive_mean_"])
+
+        X = nw.from_native(X, pass_through=True, eager_only=True)
+        if isinstance(X, nw.DataFrame):
+            X = X.to_numpy()
 
         X = validate_data(self, X)
         if self._n_features_in_ != X.shape[1]:


### PR DESCRIPTION
<!--- If relevant, make sure to add a description of your changes in docs/user_guide/installation_and_version_guide/v<major>.<minor>.<patch>.rst -->

## Description
Our [CI jobs are failing](https://github.com/fairlearn/fairlearn/actions/runs/24634019946/job/72028031022?pr=1637) because of a deprecation warning from polars ([released 2 days ago](https://github.com/pola-rs/polars/releases/tag/py-1.40.0)):

```
DeprecationWarning: Support for the dataframe interchange protocol is deprecated since version 1.40.0
```

This PR fixes the issue by converting the dataframes into numpy arrays after the columns lookup map is created. I also corrected the case for 1D arrays by the same occasion (used to return the lookup instead of setting the attribute)..

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply. -->
- [ ] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If your PR makes changes to visualizations (e.g., matplotlib code) or the website, please include a screenshot of the result. -->
