### PR TITLE
DOC Add versionadded and versionchanged to fairlearn.metrics (#951)

### DIFF
--- a/docs/user_guide/installation_and_version_guide/v0.14.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.14.0.rst
@@ -13,4 +13,4 @@ Other improvements
 * Removed support for python 3.9 and added support for python 3.13: :pr:`1592` by :user:`Tamara Atanasoska <tamaraatanasoska>`.
 * Added support for scipy 1.16 :pr:`1596` by :user:`Tamara Atanasoska <tamaraatanasoska>`.
 * Fixed handling of degenerate sensitive feature values in ``PrototypeRepresentationLearner``: :pr:`1626` by :user:`BALOGUN-DAVID`.
-* Added ``versionadded`` and ``versionchanged`` directives to the ``fairlearn.metrics`` API reference docstrings: :pr:`<PR_NUMBER>` by :user:`BAder82t`.
+* Added ``versionadded`` and ``versionchanged`` directives to the ``fairlearn.metrics`` API reference docstrings: :pr:`1640` by :user:`BAder82t`.

--- a/docs/user_guide/installation_and_version_guide/v0.14.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.14.0.rst
@@ -13,3 +13,4 @@ Other improvements
 * Removed support for python 3.9 and added support for python 3.13: :pr:`1592` by :user:`Tamara Atanasoska <tamaraatanasoska>`.
 * Added support for scipy 1.16 :pr:`1596` by :user:`Tamara Atanasoska <tamaraatanasoska>`.
 * Fixed handling of degenerate sensitive feature values in ``PrototypeRepresentationLearner``: :pr:`1626` by :user:`BALOGUN-DAVID`.
+* Added ``versionadded`` and ``versionchanged`` directives to the ``fairlearn.metrics`` API reference docstrings: :pr:`<PR_NUMBER>` by :user:`BAder82t`.

--- a/fairlearn/metrics/_base_metrics.py
+++ b/fairlearn/metrics/_base_metrics.py
@@ -86,6 +86,8 @@ def true_positive_rate(y_true, y_pred, sample_weight=None, pos_label=None) -> fl
 
     Read more in the :ref:`User Guide <custom_fairness_metrics>`.
 
+    .. versionadded:: 0.4.6
+
     Parameters
     ----------
     y_true : array-like
@@ -122,6 +124,8 @@ def true_negative_rate(y_true, y_pred, sample_weight=None, pos_label=None) -> fl
     r"""Calculate the true negative rate (also called specificity or selectivity).
 
     Read more in the :ref:`User Guide <custom_fairness_metrics>`.
+
+    .. versionadded:: 0.4.6
 
     Parameters
     ----------
@@ -160,6 +164,8 @@ def false_positive_rate(y_true, y_pred, sample_weight=None, pos_label=None) -> f
 
     Read more in the :ref:`User Guide <custom_fairness_metrics>`.
 
+    .. versionadded:: 0.4.6
+
     Parameters
     ----------
     y_true : array-like
@@ -196,6 +202,8 @@ def false_negative_rate(y_true, y_pred, sample_weight=None, pos_label=None) -> f
     r"""Calculate the false negative rate (also called miss rate).
 
     Read more in the :ref:`User Guide <custom_fairness_metrics>`.
+
+    .. versionadded:: 0.4.6
 
     Parameters
     ----------
@@ -237,6 +245,8 @@ def count(y_true, y_pred) -> int:
 
     Read more in the :ref:`User Guide <assessment>`.
 
+    .. versionadded:: 0.7.0
+
     Parameters
     ----------
     y_true : array_like
@@ -259,6 +269,8 @@ def mean_prediction(y_true, y_pred, sample_weight=None) -> float:
 
     The true values are ignored, but required as an argument in order
     to maintain a consistent interface
+
+    .. versionadded:: 0.3.0
 
     Parameters
     ----------
@@ -291,6 +303,8 @@ def selection_rate(y_true, y_pred, *, pos_label: Any = 1, sample_weight=None) ->
     other metric functions, the ``y_true`` argument is required, but ignored.
 
     Read more in the :ref:`User Guide <custom_fairness_metrics>`.
+
+    .. versionadded:: 0.3.0
 
     Parameters
     ----------

--- a/fairlearn/metrics/_fairness_metrics.py
+++ b/fairlearn/metrics/_fairness_metrics.py
@@ -26,6 +26,8 @@ def demographic_parity_difference(
 
     Read more in the :ref:`User Guide <disparity_metrics>`.
 
+    .. versionadded:: 0.4.6
+
     Parameters
     ----------
     y_true : array-like
@@ -76,6 +78,8 @@ def demographic_parity_ratio(
     The demographic parity ratio of 1 means that all groups have the same selection rate.
 
     Read more in the :ref:`User Guide <disparity_metrics>`.
+
+    .. versionadded:: 0.4.6
 
     Parameters
     ----------
@@ -137,6 +141,8 @@ def equalized_odds_difference(
 
     Read more in the :ref:`User Guide <disparity_metrics>`.
 
+    .. versionadded:: 0.4.6
+
     Parameters
     ----------
     y_true : array-like
@@ -197,6 +203,8 @@ def equalized_odds_ratio(
     true positive, true negative, false positive, and false negative rates.
 
     Read more in the :ref:`User Guide <disparity_metrics>`.
+
+    .. versionadded:: 0.4.6
 
     Parameters
     ----------
@@ -269,6 +277,8 @@ def equal_opportunity_difference(
 
     Read more in the :ref:`User Guide <disparity_metrics>`.
 
+    .. versionadded:: 0.11.0
+
     Parameters
     ----------
     y_true : array-like
@@ -319,6 +329,8 @@ def equal_opportunity_ratio(
     The equal opportunity ratio of 1 means that all groups have the same true positive rate.
 
     Read more in the :ref:`User Guide <disparity_metrics>`.
+
+    .. versionadded:: 0.11.0
 
     Parameters
     ----------

--- a/fairlearn/metrics/_make_derived_metric.py
+++ b/fairlearn/metrics/_make_derived_metric.py
@@ -125,6 +125,11 @@ def make_derived_metric(
     A :ref:`sample notebook <sphx_glr_auto_examples_plot_make_derived_metric.py>` is
     also available.
 
+    .. versionadded:: 0.4.6
+
+    .. versionchanged:: 0.6.0
+        Implementation now uses :class:`MetricFrame` internally.
+
     Parameters
     ----------
     metric : callable

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -82,6 +82,12 @@ class MetricFrame:
 
     Read more in the :ref:`User Guide <assessment>`.
 
+    .. versionadded:: 0.5.0
+
+    .. versionchanged:: 0.7.0
+        The ``metric`` argument was renamed to ``metrics`` and constructor
+        arguments became keyword-only; the previous form is deprecated.
+
     Parameters
     ----------
     metrics : callable or dict

--- a/fairlearn/metrics/_plot_model_comparison.py
+++ b/fairlearn/metrics/_plot_model_comparison.py
@@ -41,6 +41,8 @@ def plot_model_comparison(
     (e.g., balanced_accuracy) and the other is a fairness metric
     (e.g., false_negative_rate_difference).
 
+    .. versionadded:: 0.8.0
+
     Parameters
     ----------
     y_preds : array-like, dict of array-like


### PR DESCRIPTION
Closes #951.

## Description

Adds ``versionadded`` and (where applicable) ``versionchanged`` directives to the docstrings of every public symbol in ``fairlearn.metrics``. Picks up where #1001 and #1247 left off, applying the per-symbol approach @romanlutz requested.

## Versions per symbol

| Symbol | versionadded | versionchanged | Source |
|---|---|---|---|
| ``MetricFrame`` | 0.5.0 | 0.7.0 (constructor: ``metric``→``metrics``, kw-only) | git #582; v0.7.0 release notes |
| ``make_derived_metric`` | 0.4.6 | 0.6.0 (now uses ``MetricFrame``) | v0.4.6 + v0.6.0 release notes |
| ``plot_model_comparison`` | 0.8.0 | — | git #947 → v0.8.0 |
| ``demographic_parity_{difference,ratio}`` | 0.4.6 | — | v0.4.6 release notes |
| ``equalized_odds_{difference,ratio}`` | 0.4.6 | — | v0.4.6 release notes |
| ``equal_opportunity_{difference,ratio}`` | 0.11.0 | — | git #1325 → v0.11.0 |
| ``{true,false}_{positive,negative}_rate`` | 0.4.6 | — | v0.4.6 release notes |
| ``count`` | 0.7.0 | — | v0.7.0 release notes |
| ``mean_prediction``, ``selection_rate`` | 0.3.0 | — | git #82/#89/#102 (Oct 2019, pre-v0.3.0) |

The 25 dynamically-generated metrics in ``_generated_metrics.py`` are out of scope: they share ``make_derived_metric``'s output and have no per-symbol docstring to attach a directive to.

## Tests
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
- [ ] no documentation changes needed
- [ ] user guide added or updated
- [x] API docs added or updated
- [ ] example notebook added or updated

Local checks:

- ``black --check`` and ``ruff check`` pass on all modified files
- ``pytest test/unit/metrics/`` 697 tests pass
- Sphinx warning count vs ``main`` baseline: identical (26 = 26, all pre-existing User Guide cross-refs)