### PR TITLE
Fix: Exclude tests from packaging distribution

### DIFF
--- a/docs/user_guide/installation_and_version_guide/v0.14.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.14.0.rst
@@ -14,4 +14,4 @@ Other improvements
 * Added support for scipy 1.16 :pr:`1596` by :user:`Tamara Atanasoska <tamaraatanasoska>`.
 * Fixed handling of degenerate sensitive feature values in ``PrototypeRepresentationLearner``: :pr:`1626` by :user:`BALOGUN-DAVID`.
 * Added ``versionadded`` and ``versionchanged`` directives to the ``fairlearn.metrics`` API reference docstrings: :pr:`1640` by :user:`BAder82t`.
-* Excluded top-level ``test*`` from ``fairlearn`` packaging distribution :pr: `1644` by :user:`Parul Gupta <parulgupta1004>`.
+* Excluded top-level ``test*`` from ``fairlearn`` packaging distribution :pr:`1644` by :user:`Parul Gupta <parulgupta1004>`.

--- a/docs/user_guide/installation_and_version_guide/v0.14.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.14.0.rst
@@ -14,3 +14,4 @@ Other improvements
 * Added support for scipy 1.16 :pr:`1596` by :user:`Tamara Atanasoska <tamaraatanasoska>`.
 * Fixed handling of degenerate sensitive feature values in ``PrototypeRepresentationLearner``: :pr:`1626` by :user:`BALOGUN-DAVID`.
 * Added ``versionadded`` and ``versionchanged`` directives to the ``fairlearn.metrics`` API reference docstrings: :pr:`1640` by :user:`BAder82t`.
+* Excluded top-level ``test*`` from ``fairlearn`` packaging distribution :pr: `1644` by :user:`Parul Gupta <parulgupta1004>`.

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,9 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/fairlearn/fairlearn",
-    packages=setuptools.find_packages(exclude=["test", "test.*", "test_othermlpackages", "test_othermlpackages.*"]),
+    packages=setuptools.find_packages(
+        exclude=["test", "test.*", "test_othermlpackages", "test_othermlpackages.*"]
+    ),
     python_requires=">=3.10",
     install_requires=install_requires,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/fairlearn/fairlearn",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=["test", "test.*", "test_othermlpackages", "test_othermlpackages.*"]),
     python_requires=">=3.10",
     install_requires=install_requires,
     classifiers=[


### PR DESCRIPTION
## Description
Excluded the entire test suite from the fairlearn distribution to avoid name collision as well as unnecessary bloat of the package. This addresses the issue mentioned in #1643. @TamaraAtanasoska @romanlutz 

Built using uv build and verified that tests are no longer included in the wheel.
```
% uv build --wheel
```

## Tests
- [X] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
- [ ] no documentation changes needed
- [X] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated
