### PR TITLE
MNT Address Dependabot security alerts (scikit-learn, torch)

### DIFF
--- a/docs/user_guide/installation_and_version_guide/v0.14.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.14.0.rst
@@ -12,10 +12,11 @@ Other improvements
 
 * Removed support for python 3.9 and added support for python 3.13: :pr:`1592` by :user:`Tamara Atanasoska <tamaraatanasoska>`.
 * Added support for scipy 1.16 :pr:`1596` by :user:`Tamara Atanasoska <tamaraatanasoska>`.
-* Raised the minimum supported version of :code:`scikit-learn` to 1.5.0 and bumped the
-  pinned :code:`torch` version in :code:`requirements-min.txt` to 2.8.0 to address
-  Dependabot security advisories (GHSA scikit-learn sensitive data leakage,
-  PyTorch CTC loss denial of service, and PyTorch improper resource shutdown).
 * Fixed handling of degenerate sensitive feature values in ``PrototypeRepresentationLearner``: :pr:`1626` by :user:`BALOGUN-DAVID`.
 * Added ``versionadded`` and ``versionchanged`` directives to the ``fairlearn.metrics`` API reference docstrings: :pr:`1640` by :user:`BAder82t`.
 * Excluded top-level ``test*`` from ``fairlearn`` packaging distribution :pr:`1644` by :user:`Parul Gupta <parulgupta1004>`.
+* Raised the minimum supported version of :code:`scikit-learn` to 1.5.0 and bumped the
+  pinned :code:`torch` version in :code:`requirements-min.txt` to 2.8.0 to address
+  Dependabot security advisories (GHSA scikit-learn sensitive data leakage,
+  PyTorch CTC loss denial of service, and PyTorch improper resource shutdown):
+  :pr:`1645` by :user:`Roman Lutz <romanlutz>`.

--- a/docs/user_guide/installation_and_version_guide/v0.14.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.14.0.rst
@@ -12,6 +12,10 @@ Other improvements
 
 * Removed support for python 3.9 and added support for python 3.13: :pr:`1592` by :user:`Tamara Atanasoska <tamaraatanasoska>`.
 * Added support for scipy 1.16 :pr:`1596` by :user:`Tamara Atanasoska <tamaraatanasoska>`.
+* Raised the minimum supported version of :code:`scikit-learn` to 1.5.0 and bumped the
+  pinned :code:`torch` version in :code:`requirements-min.txt` to 2.8.0 to address
+  Dependabot security advisories (GHSA scikit-learn sensitive data leakage,
+  PyTorch CTC loss denial of service, and PyTorch improper resource shutdown).
 * Fixed handling of degenerate sensitive feature values in ``PrototypeRepresentationLearner``: :pr:`1626` by :user:`BALOGUN-DAVID`.
 * Added ``versionadded`` and ``versionchanged`` directives to the ``fairlearn.metrics`` API reference docstrings: :pr:`1640` by :user:`BAder82t`.
 * Excluded top-level ``test*`` from ``fairlearn`` packaging distribution :pr:`1644` by :user:`Parul Gupta <parulgupta1004>`.

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,7 +1,7 @@
 #requirements
 numpy==1.24.4
 pandas==2.0.3
-scikit-learn==1.2.1
+scikit-learn==1.5.0
 scipy==1.9.3
 
 #requirements-dev
@@ -29,5 +29,5 @@ jupyterlite_sphinx==0.19.1
 jupyterlite-pyodide-kernel==0.5.2
 packaging==24.2
 seaborn==0.13.2
-torch==2.6.0
+torch==2.8.0
 sphinx-issues==5.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 narwhals>=1.14.0
 numpy>=1.24.4
 pandas>=2.0.3
-scikit-learn>=1.2.1
+scikit-learn>=1.5.0
 scipy>=1.9.3


### PR DESCRIPTION
## Description

Bumps a couple of pinned and minimum dependency versions to clear the open Dependabot advisories on `main` (4 moderate, 2 low). All of the affected packages had patched releases available; this PR just raises our floors past the vulnerable ranges.

Changes:

- `requirements.txt`: `scikit-learn>=1.5.0` (was `>=1.2.1`) so installs cannot resolve to a version affected by the scikit-learn sensitive data leakage advisory (first patched in 1.5.0). Fairlearn already supports scikit-learn 1.6 (see v0.12.0 notes), so this just disallows the vulnerable lower range.
- `requirements-min.txt`:
  - `scikit-learn==1.5.0` (was `1.2.1`) for the same advisory.
  - `torch==2.8.0` (was `2.6.0`) to clear two PyTorch advisories: CVE-2025-3730 (improper resource shutdown in `torch.nn.functional.ctc_loss`, first patched in 2.8.0) and the local denial-of-service advisory (first patched in 2.7.1rc1).

Compatibility check for the `test-min-deps` matrix (Python 3.10 on Ubuntu/Windows/macOS-14):

- `scikit-learn 1.5.0` declares `requires_python>=3.9` and ships cp310 wheels.
- `torch 2.8.0` declares `requires_python>=3.9.0` and ships cp310 wheels for Linux (x86_64 and aarch64), Windows, and macOS arm64.

Note on alerts 13 and 14: Dependabot reports these under `requirements.txt`, but `requirements.txt` does not actually list `torch` (only `requirements-min.txt` and `requirements-dev.txt` do). They look like a Dependabot misclassification and should auto-resolve on the next scan once the `requirements-min.txt` bump lands. `requirements-dev.txt` leaves `torch` unpinned, so pip resolves to the latest patched release there already.

## Tests
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
- [ ] no documentation changes needed
- [x] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots

N/A