### PR TITLE
MNT bump version to 0.14.0 for release

### DIFF
--- a/fairlearn/__init__.py
+++ b/fairlearn/__init__.py
@@ -6,5 +6,5 @@
 from .show_versions import show_versions  # noqa: F401
 
 __name__ = "fairlearn"
-__version__ = "0.14.0.dev0"
+__version__ = "0.14.0"
 _base_version = __version__  # To enable the v0.4.6 docs


### PR DESCRIPTION
Step 4 of the v0.14.0 release process per `docs/contributor_guide/release.rst`.

Bumps `__version__` in `fairlearn/__init__.py` from `0.14.0.dev0` to `0.14.0` on the `release/v0.14.X` branch ahead of running the Release Wheel workflow and tagging `v0.14.0`.