### PR TITLE
MNT post-release bump to 0.15.0.dev0

### DIFF
--- a/docs/_static/versions.json
+++ b/docs/_static/versions.json
@@ -1,6 +1,11 @@
 [
     {
-        "name": "v0.13.0 (stable)",
+        "name": "v0.14.0 (stable)",
+        "version": "0.14.0",
+        "url": "https://fairlearn.org/v0.14/"
+    },
+    {
+        "name": "v0.13.0",
         "version": "0.13.0",
         "url": "https://fairlearn.org/v0.13/"
     },
@@ -35,8 +40,8 @@
         "url": "https://fairlearn.org/v0.7.0/"
     },
     {
-        "name": "v0.14.0 (dev)",
-        "version": "0.14.0",
+        "name": "v0.15.0 (dev)",
+        "version": "0.15.0",
         "url": "https://fairlearn.org/main/"
     }
 ]

--- a/docs/static_landing_page/js/landing_page.js
+++ b/docs/static_landing_page/js/landing_page.js
@@ -175,7 +175,7 @@ $(document).ready(function () {
 
 async function setLinks() {
   // update this version with every release
-  const latestVersion = 'v0.13'; // Do not include the patch
+  const latestVersion = 'v0.14'; // Do not include the patch
   const prefix = "./" + latestVersion;
 
   const contribGuideLink = prefix + "/contributor_guide/index.html";

--- a/docs/user_guide/installation_and_version_guide/v0.15.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.15.0.rst
@@ -1,0 +1,7 @@
+v0.15.0
+=======
+
+.. note::
+
+   v0.15.0 is not yet released. This page reflects changes on the current
+   :code:`main` branch that will eventually be a part of v0.15.0.

--- a/fairlearn/__init__.py
+++ b/fairlearn/__init__.py
@@ -6,5 +6,5 @@
 from .show_versions import show_versions  # noqa: F401
 
 __name__ = "fairlearn"
-__version__ = "0.14.0.dev0"
+__version__ = "0.15.0.dev0"
 _base_version = __version__  # To enable the v0.4.6 docs


### PR DESCRIPTION
⚠️ **Do not merge until the v0.14.0 release is completed.** Otherwise a new website will be published that points to the new version which doesn't exist yet.

## Description

Post-release bookkeeping for v0.14.0 (release step 9 of `docs/contributor_guide/release.rst`). Bumps `main` to the next development cycle and points the docs landing page and version switcher at the freshly released v0.14.0.

- Bump `fairlearn.__version__` from `0.14.0.dev0` to `0.15.0.dev0`.
- Update `docs/static_landing_page/js/landing_page.js` so the landing-page nav links resolve under the `v0.14` docs (`latestVersion = 'v0.14'`).
- Update `docs/_static/versions.json`: add `v0.14.0 (stable)` at the top, demote `v0.13.0` from stable, and rename the dev entry to `v0.15.0 (dev)` / `0.15.0`.
- Add a stub `docs/user_guide/installation_and_version_guide/v0.15.0.rst` for the next development cycle.

Mirrors the pattern from #1590 (the equivalent post-v0.13.0 PR).

## Tests
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
- [ ] no documentation changes needed
- [x] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
N/A (no rendered changes; landing page link target swaps from `v0.13/...` to `v0.14/...` once `v0.14` docs are live).