### PR TITLE
Add Python 3.14 support

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-14]
-        python: ["3.10", "3.11", "3.12", "3.13"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     uses: ./.github/workflows/test-all-deps.yml
     with:
       os: ${{ matrix.os }}
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-14]
-        python: ["3.10", "3.11", "3.12", "3.13"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     uses: ./.github/workflows/test-minimal-deps.yml
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/release-wheel.yml
+++ b/.github/workflows/release-wheel.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-14]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}

--- a/docs/contributor_guide/development_process.rst
+++ b/docs/contributor_guide/development_process.rst
@@ -80,7 +80,7 @@ To verify that the code works as expected run:
 .. note::
 
    If there is a :code:`torch` related error during the installation,
-   please downgrade keep your :code:`python` version between 3.10-3.13.
+   please downgrade keep your :code:`python` version between 3.10-3.14.
 
 Fairlearn currently includes plotting functionality provided by
 :code:`matplotlib`. This is for a niche use case, so it isn't a default requirement. To install run:

--- a/docs/user_guide/installation_and_version_guide/v0.15.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.15.0.rst
@@ -10,3 +10,8 @@ Bug fixes
 ---------
 
 * Fixed :code:`fetch_diabetes_hospital` so that :code:`as_frame=False` returns numpy arrays instead of raising. The data is now always fetched as a pandas DataFrame internally and converted to numpy when needed. The skipped tests and the obsolete :code:`test_fetch_diabetes_hospital_as_ndarray_raises_value_error` test were removed: :pr:`1636` by :user:`Richard Ogundele <richardogundele>`.
+
+Other improvements
+------------------
+
+* Added support for Python 3.14: :pr:`1649` by :user:`Roman Lutz <romanlutz>`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 99
-target_version = ['py39', 'py310', 'py311', 'py312']
+target_version = ['py39', 'py310', 'py311', 'py312', 'py313', 'py314']
 preview = true
 extend-exclude = '''
 (

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
## Description

Adds Python 3.14 to the supported Python range now that wheels for all required and dev dependencies are available on CPython 3.14.

Concretely:
- Added `"3.14"` to the `all-deps` and `minimal-deps` matrices in `.github/workflows/build-test.yml` and to the wheel-test matrix in `.github/workflows/release-wheel.yml`. The `other-ml` job stays pinned to 3.13 because TensorFlow 2.21 does not yet ship cp314 wheels; everything else (numpy, pandas, scikit-learn, scipy, narwhals, matplotlib, torch, lightgbm, xgboost, polars, pyarrow, sphinx, etc.) resolves cleanly on 3.14.
- Added the `Programming Language :: Python :: 3.14` classifier in `setup.py`.
- Extended Black's `target_version` in `pyproject.toml` to include `py313` and `py314` (py313 was previously missing too).
- Bumped the supported Python range in the contributor guide from `3.10-3.13` to `3.10-3.14`.

Verified locally on Windows with a fresh Python 3.14.4 venv: `requirements.txt` and `requirements-dev.txt` install cleanly, an editable install of `fairlearn` builds, all top-level subpackages import, and `pytest --mpl test/` reports `6806 passed, 328 skipped, 1080 deselected, 9 xfailed, 6 xpassed`.

## Tests
- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

The CI matrix change is itself the test: the existing `all-deps` and `minimal-deps` suites will now run on 3.14 across Linux, Windows, and macOS.

## Documentation
- [x] no documentation changes needed
- [x] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

Changelog entry added in `docs/user_guide/installation_and_version_guide/v0.15.0.rst`, and the supported-versions note in the development guide updated.

## Screenshots

N/A