### PR TITLE
[DOC] add Examples sections to base fairness metrics

### DIFF
--- a/fairlearn/metrics/_base_metrics.py
+++ b/fairlearn/metrics/_base_metrics.py
@@ -108,6 +108,14 @@ def true_positive_rate(y_true, y_pred, sample_weight=None, pos_label=None) -> fl
     -------
     float
         The true positive rate for the data
+
+    Examples
+    --------
+    >>> from fairlearn.metrics import true_positive_rate
+    >>> y_true = [0, 1, 1, 0, 1, 1, 0, 1]
+    >>> y_pred = [0, 1, 0, 0, 1, 1, 1, 1]
+    >>> true_positive_rate(y_true, y_pred).item()
+    0.8
     """
     unique_labels = _get_labels_for_confusion_matrix(np.vstack((y_true, y_pred)), pos_label)
     tnr, fpr, fnr, tpr = skm.confusion_matrix(
@@ -147,6 +155,14 @@ def true_negative_rate(y_true, y_pred, sample_weight=None, pos_label=None) -> fl
     -------
     float
         The true negative rate for the data
+
+    Examples
+    --------
+    >>> from fairlearn.metrics import true_negative_rate
+    >>> y_true = [0, 1, 1, 0, 1, 1, 0, 1]
+    >>> y_pred = [0, 1, 0, 0, 1, 1, 1, 1]
+    >>> true_negative_rate(y_true, y_pred).item()
+    0.6666666666666666
     """
     unique_labels = _get_labels_for_confusion_matrix(np.vstack((y_true, y_pred)), pos_label)
     tnr, fpr, fnr, tpr = skm.confusion_matrix(
@@ -186,6 +202,14 @@ def false_positive_rate(y_true, y_pred, sample_weight=None, pos_label=None) -> f
     -------
     float
         The false positive rate for the data
+
+    Examples
+    --------
+    >>> from fairlearn.metrics import false_positive_rate
+    >>> y_true = [0, 1, 1, 0, 1, 1, 0, 1]
+    >>> y_pred = [0, 1, 0, 0, 1, 1, 1, 1]
+    >>> false_positive_rate(y_true, y_pred).item()
+    0.3333333333333333
     """
     unique_labels = _get_labels_for_confusion_matrix(np.vstack((y_true, y_pred)), pos_label)
     tnr, fpr, fnr, tpr = skm.confusion_matrix(
@@ -225,6 +249,14 @@ def false_negative_rate(y_true, y_pred, sample_weight=None, pos_label=None) -> f
     -------
     float
         The false negative rate for the data
+
+    Examples
+    --------
+    >>> from fairlearn.metrics import false_negative_rate
+    >>> y_true = [0, 1, 1, 0, 1, 1, 0, 1]
+    >>> y_pred = [0, 1, 0, 0, 1, 1, 1, 1]
+    >>> false_negative_rate(y_true, y_pred).item()
+    0.2
     """
     unique_labels = _get_labels_for_confusion_matrix(np.vstack((y_true, y_pred)), pos_label)
     tnr, fpr, fnr, tpr = skm.confusion_matrix(
@@ -259,6 +291,14 @@ def count(y_true, y_pred) -> int:
     -------
     int
         The number of data points in each group.
+
+    Examples
+    --------
+    >>> from fairlearn.metrics import count
+    >>> y_true = [0, 1, 1, 0, 1, 1, 0, 1]
+    >>> y_pred = [0, 1, 0, 0, 1, 1, 1, 1]
+    >>> count(y_true, y_pred)
+    8
     """
     check_consistent_length(y_true, y_pred)
     return len(y_true)
@@ -287,6 +327,14 @@ def mean_prediction(y_true, y_pred, sample_weight=None) -> float:
     -------
     float
         The (weighted) mean prediction
+
+    Examples
+    --------
+    >>> from fairlearn.metrics import mean_prediction
+    >>> y_true = [0, 1, 1, 0, 1, 1, 0, 1]
+    >>> y_pred = [0, 1, 0, 0, 1, 1, 1, 1]
+    >>> mean_prediction(y_true, y_pred).item()
+    0.625
     """
     y_p = _convert_to_ndarray_and_squeeze(y_pred)
     s_w = np.ones(len(y_p))
@@ -324,6 +372,14 @@ def selection_rate(y_true, y_pred, *, pos_label: Any = 1, sample_weight=None) ->
     -------
     float
         The selection rate
+
+    Examples
+    --------
+    >>> from fairlearn.metrics import selection_rate
+    >>> y_true = [0, 1, 1, 0, 1, 1, 0, 1]
+    >>> y_pred = [0, 1, 0, 0, 1, 1, 1, 1]
+    >>> selection_rate(y_true, y_pred).item()
+    0.625
     """
     selected = _convert_to_ndarray_and_squeeze(y_pred) == pos_label
     if len(selected) == 0:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The base metric functions in `fairlearn/metrics/_base_metrics.py` did not have
`Examples` docstring sections. This PR adds short, runnable `Examples` to all
seven public functions so users can see how each one is called and what it
returns directly from the API reference:

- `true_positive_rate`
- `true_negative_rate`
- `false_positive_rate`
- `false_negative_rate`
- `count`
- `mean_prediction`
- `selection_rate`

Each example uses the same small binary `y_true`/`y_pred` pair for consistency,
and follows the existing doctest style (using `.item()` for scalar results, as
in the `MetricFrame` docstring and the quickstart guide). All examples were run
and their outputs verified (doctests pass).

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Any other comments?

Docstring-only change; no behaviour is modified and no test files are touched,
so no changelog entry is required by the changelog check. Happy to add one (or
to extend the same treatment to the higher-level fairness metrics in
`_fairness_metrics.py` in a follow-up) if reviewers prefer.

### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors. (Will use the @all-contributors bot after merge.)
- [x] The PR title starts with [DOC].
