### PR TITLE
MNT raise a clear error when X passed to BackendEngine is not 2D

### DIFF
--- a/docs/user_guide/installation_and_version_guide/v0.15.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.15.0.rst
@@ -27,7 +27,7 @@ Bug fixes
   attribute :code:`constraints_`: :pr:`1632` by
   :user:`BALOGUN DAVID TAIWO <BALOGUN-DAVID>`.
 * Fixed :code:`fetch_diabetes_hospital` so that :code:`as_frame=False` returns numpy arrays instead of raising. The data is now always fetched as a pandas DataFrame internally and converted to numpy when needed. The skipped tests and the obsolete :code:`test_fetch_diabetes_hospital_as_ndarray_raises_value_error` test were removed: :pr:`1636` by :user:`Richard Ogundele <richardogundele>`.
-* :code:`BackendEngine` used to read :code:`X.shape[1]` without checking how many dimensions :code:`X` had, so passing data with more than two dimensions (for example an array of images) would silently build a predictor model with the wrong input size instead of failing. It now raises a :code:`ValueError` up front when :code:`X` is not two-dimensional: :pr:`TBD` by :user:`Arnav <NotArnav03>`.
+* :code:`BackendEngine` used to read :code:`X.shape[1]` without checking how many dimensions :code:`X` had, so passing data with more than two dimensions (for example an array of images) would silently build a predictor model with the wrong input size instead of failing. It now raises a :code:`ValueError` up front when :code:`X` is not two-dimensional: :pr:`1671` by :user:`Arnav <NotArnav03>`.
 
 Documentation
 -------------

--- a/docs/user_guide/installation_and_version_guide/v0.15.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.15.0.rst
@@ -27,6 +27,7 @@ Bug fixes
   attribute :code:`constraints_`: :pr:`1632` by
   :user:`BALOGUN DAVID TAIWO <BALOGUN-DAVID>`.
 * Fixed :code:`fetch_diabetes_hospital` so that :code:`as_frame=False` returns numpy arrays instead of raising. The data is now always fetched as a pandas DataFrame internally and converted to numpy when needed. The skipped tests and the obsolete :code:`test_fetch_diabetes_hospital_as_ndarray_raises_value_error` test were removed: :pr:`1636` by :user:`Richard Ogundele <richardogundele>`.
+* :code:`BackendEngine` used to read :code:`X.shape[1]` without checking how many dimensions :code:`X` had, so passing data with more than two dimensions (for example an array of images) would silently build a predictor model with the wrong input size instead of failing. It now raises a :code:`ValueError` up front when :code:`X` is not two-dimensional: :pr:`TBD` by :user:`Arnav <NotArnav03>`.
 
 Documentation
 -------------

--- a/fairlearn/adversarial/_backend_engine.py
+++ b/fairlearn/adversarial/_backend_engine.py
@@ -10,6 +10,7 @@ from ._constants import (
     _LIST_MODEL_UNSUPPORTED,
     _NO_LOSS,
     _NOT_IMPLEMENTED,
+    _X_NOT_2D,
 )
 
 
@@ -33,7 +34,9 @@ class BackendEngine:
         """
         self.base = base
 
-        n_X_features = X.shape[1]  # FIXME: what if X.ndim > 2?
+        if X.ndim != 2:
+            raise ValueError(_X_NOT_2D.format(X.ndim))
+        n_X_features = X.shape[1]
         n_Y_features = base._y_transform.n_features_out_
         n_A_features = base._sf_transform.n_features_out_
 

--- a/fairlearn/adversarial/_constants.py
+++ b/fairlearn/adversarial/_constants.py
@@ -41,3 +41,4 @@ _LIST_MODEL_UNSUPPORTED = (
     + "supported when the accompanying {}_loss is not a keyword."
 )
 _CALLBACK_RETURNS_ERROR = "Callback function returned a non-boolean value"
+_X_NOT_2D = "Expected 'X' to be a two-dimensional array, but got an array with {} dimensions."

--- a/fairlearn/adversarial/_constants.py
+++ b/fairlearn/adversarial/_constants.py
@@ -41,4 +41,4 @@ _LIST_MODEL_UNSUPPORTED = (
     + "supported when the accompanying {}_loss is not a keyword."
 )
 _CALLBACK_RETURNS_ERROR = "Callback function returned a non-boolean value"
-_X_NOT_2D = "Expected 'X' to be a two-dimensional array, but got an array with {} dimensions."
+_X_NOT_2D = "Expected 'X' to be a two-dimensional array, but got an array with {} dimension(s)."

--- a/test/unit/adversarial/test_adversarial_mitigation.py
+++ b/test/unit/adversarial/test_adversarial_mitigation.py
@@ -378,6 +378,22 @@ def test_fake_models_df_inputs(fake_backend_env):
         mitigator.fit(pd.DataFrame(X), pd.Series(Y), sensitive_features=pd.DataFrame(Z))
 
 
+@pytest.mark.parametrize("fake_backend_env", ["torch", "tensorflow"], indirect=True)
+def test_backend_engine_rejects_non_2d_X(fake_backend_env):
+    """BackendEngine should raise a clear error instead of silently mis-sizing layers."""
+    rng = np.random.default_rng(0)
+    X = rng.random((20, 3, 4))
+    Y = rng.integers(0, 2, size=20)
+    Z = rng.integers(0, 2, size=20)
+    mitigator = get_instance(
+        fake_backend=fake_backend_env,
+        fake_training=True,
+        predictor_model=[10, "Sigmoid"],
+    )
+    with pytest.raises(ValueError, match="two-dimensional"):
+        mitigator.fit(X, Y, sensitive_features=Z)
+
+
 @pytest.mark.parametrize(
     "data, valid_choice",
     [


### PR DESCRIPTION
## Description
Closes #1656.

`BackendEngine.__init__` reads `X.shape[1]` to figure out how many input features the predictor model needs, but it never checked how many dimensions `X` actually had. If someone passed in data with more than two dimensions, for example a batch of images shaped `(n_samples, height, width, channels)`, the code would still run and just take `shape[1]` as the feature count. That's the wrong number, so the predictor's input layer ends up the wrong size and the model trains on garbage without any warning.

I added a check right before that line that raises a `ValueError` with a clear message if `X.ndim != 2`. This matches how the rest of the adversarial module already documents `X` (the docstrings for `_raw_predict`/`predict` both say "two-dimensional numpy array"), and every existing test already only exercises 2D `X`, so this doesn't change behavior for any currently supported input, it just fails loudly instead of quietly doing the wrong thing.

## Tests
- [x] new tests added

Added `test_backend_engine_rejects_non_2d_X` in `test/unit/adversarial/test_adversarial_mitigation.py`, parametrized over both the torch and tensorflow fake backends, which fits a mitigator with a 3D `X` and checks that a `ValueError` mentioning "two-dimensional" is raised.

Ran the full adversarial test suite locally (`pytest test/unit/adversarial`): 295 passed.

## Documentation
- [x] user guide added or updated

Added a changelog entry under "Bug fixes" in `docs/user_guide/installation_and_version_guide/v0.15.0.rst`. I left the PR number as `TBD` in that entry since I didn't know it before opening this PR, happy to update it once the PR number is assigned, or if a maintainer prefers to fill it in during merge.

## Screenshots
Not applicable, no visualization changes.