### PR TITLE
Modernize Ruff linting: bump to 0.15.20 and enable UP/B/SIM/C4 rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ docs/api_reference/generated/
 
 # Doc build generated files
 *.pkl
+
+# impeccable (UI design tooling)
+.impeccable/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     hooks:
     -   id: isort
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.5
+    rev: v0.15.20
     hooks:
     -   id: ruff
         args: [ --fix ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,10 +41,7 @@ author = "Fairlearn contributors"
 
 # The full version, including alpha/beta/rc tags
 release = fairlearn.__version__
-if "dev" in fairlearn.__version__:
-    tag_or_branch = "main"
-else:
-    tag_or_branch = fairlearn.__version__
+tag_or_branch = "main" if "dev" in fairlearn.__version__ else fairlearn.__version__
 
 
 # -- General configuration ---------------------------------------------------
@@ -307,10 +304,7 @@ def linkcode_resolve(domain, info):
     except OSError:
         lineno = None
 
-    if lineno:
-        linespec = f"#L{lineno}-L{lineno + len(source) - 1}"
-    else:
-        linespec = ""
+    linespec = f"#L{lineno}-L{lineno + len(source) - 1}" if lineno else ""
 
     fn = os.path.relpath(fn, start=os.path.dirname(fairlearn.__file__)).replace(os.sep, "/")
     if tag_or_branch == "main":

--- a/docs/user_guide/installation_and_version_guide/v0.15.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.15.0.rst
@@ -47,3 +47,4 @@ Other improvements
 * Removed the :code:`fairlearn.utils._compatibility` shim, which only existed to bridge the :code:`OneHotEncoder(sparse=...)` → :code:`sparse_output=...` rename completed in :code:`scikit-learn` 1.4. No longer needed now that the minimum supported :code:`scikit-learn` is ≥ 1.6: :pr:`1664` by :user:`Roman Lutz <romanlutz>`.
 * Enabled the :code:`pydocstyle` (:code:`D`) ruff rule set with the numpy convention. Added docstrings where missing for public APIs and per-file ignores for tests, examples, and scripts.
 * Enabled the :code:`flake8-logging-format` (:code:`G`) ruff rule set and converted existing logging calls to use lazy :code:`%s` formatting.
+* Updated Ruff to :code:`0.15.20`, enabled the :code:`UP`, :code:`B`, :code:`SIM`, and :code:`C4` rule families, and applied the resulting lint cleanups across the codebase: :pr:`1675` by :user:`Roman Lutz <romanlutz>`.

--- a/examples/plot_adversarial_fine_tuning.py
+++ b/examples/plot_adversarial_fine_tuning.py
@@ -92,7 +92,7 @@ import torch
 
 class PredictorModel(torch.nn.Module):
     def __init__(self):
-        super(PredictorModel, self).__init__()
+        super().__init__()
         self.layers = torch.nn.Sequential(
             # in_features is the number of features coming out of the above
             # ColumnTransformer
@@ -134,9 +134,7 @@ def validate(pipeline, X, y, z, pos_label):
     accuracy = mean(predictions == y)
     selection_rate = mean(predictions == pos_label)
     print(
-        "DP diff: {:.4f}, accuracy: {:.4f}, selection_rate: {:.4f}".format(
-            dp_diff, accuracy, selection_rate
-        )
+        f"DP diff: {dp_diff:.4f}, accuracy: {accuracy:.4f}, selection_rate: {selection_rate:.4f}"
     )
     return dp_diff, accuracy, selection_rate
 

--- a/examples/plot_credit_loan_decisions.py
+++ b/examples/plot_credit_loan_decisions.py
@@ -993,7 +993,7 @@ performance_df_masked = performance_df.loc[mask, :]
 # %%
 # Now, let's plot the performance trade-offs between all of our models.
 
-for index, row in performance_df_masked.iterrows():
+for _index, row in performance_df_masked.iterrows():
     bal_error, eq_odds_diff = row["balanced_error"], row["equalized_odds"]
     epsilon_, index_ = row["epsilon"], row["index"]
     plt.scatter(bal_error, eq_odds_diff, color="green", label="ExponentiatedGradient")

--- a/examples/plot_grid_search_census.py
+++ b/examples/plot_grid_search_census.py
@@ -183,7 +183,7 @@ predictors = sweep.predictors_
 errors, disparities = [], []
 for m in predictors:
 
-    def classifier(X):
+    def classifier(X, m=m):
         return m.predict(X)
 
     error = ErrorRate()
@@ -210,7 +210,7 @@ for row in all_results.itertuples():
 predictions = {"unmitigated": unmitigated_predictor.predict(X_test)}
 metric_frames = {"unmitigated": metric_frame}
 for i in range(len(non_dominated)):
-    key = "dominant_model_{0}".format(i)
+    key = f"dominant_model_{i}"
     predictions[key] = non_dominated[i].predict(X_test)
 
     metric_frames[key] = MetricFrame(

--- a/examples/plot_metricframe_beyond_binary_classification.py
+++ b/examples/plot_metricframe_beyond_binary_classification.py
@@ -179,7 +179,7 @@ def mean_iou(true_boxes, predicted_boxes):
         raise ValueError("Array size mismatch")
 
     all_iou = [
-        bounding_box_iou(y_true, y_pred) for y_true, y_pred in zip(true_boxes, predicted_boxes)
+        bounding_box_iou(y_true, y_pred) for y_true, y_pred in zip(true_boxes, predicted_boxes, strict=False)
     ]
 
     return np.mean(all_iou)

--- a/examples/plot_metricframe_beyond_binary_classification.py
+++ b/examples/plot_metricframe_beyond_binary_classification.py
@@ -179,7 +179,8 @@ def mean_iou(true_boxes, predicted_boxes):
         raise ValueError("Array size mismatch")
 
     all_iou = [
-        bounding_box_iou(y_true, y_pred) for y_true, y_pred in zip(true_boxes, predicted_boxes, strict=False)
+        bounding_box_iou(y_true, y_pred)
+        for y_true, y_pred in zip(true_boxes, predicted_boxes, strict=False)
     ]
 
     return np.mean(all_iou)

--- a/examples/plot_plotting_metrics_with_error.py
+++ b/examples/plot_plotting_metrics_with_error.py
@@ -111,7 +111,7 @@ def general_wilson(p, n, digits=4, z=1.959964):
     """
     denominator = 1 + z**2 / n
     centre_adjusted_probability = p + z * z / (2 * n)
-    adjusted_standard_deviation = np.sqrt((p * (1 - p) + z * z / (4 * n))) / np.sqrt(n)
+    adjusted_standard_deviation = np.sqrt(p * (1 - p) + z * z / (4 * n)) / np.sqrt(n)
     lower_bound = (centre_adjusted_probability - z * adjusted_standard_deviation) / denominator
     upper_bound = (centre_adjusted_probability + z * adjusted_standard_deviation) / denominator
     return np.array([round(lower_bound, digits), round(upper_bound, digits)])

--- a/fairlearn/adversarial/_adversarial_mitigation.py
+++ b/fairlearn/adversarial/_adversarial_mitigation.py
@@ -435,26 +435,22 @@ class _AdversarialFairness(BaseEstimator):
                 )
             )
 
-        if self.predictor_model is not None:
+        # Kept as if/else: the `[]` branch carries an F841 waiver and note that
+        # a one-line ternary would not preserve cleanly.
+        if self.predictor_model is not None:  # noqa: SIM108
             predictor_model = self.predictor_model
         else:
             predictor_model = []  # [] is a NN with no hidden layers # noqa: F841
 
-        if self.adversary_model is not None:
+        if self.adversary_model is not None:  # noqa: SIM108
             adversary_model = self.adversary_model
         else:
             adversary_model = []  # noqa: F841
 
-        if self.batch_size == -1:
-            batch_size = X.shape[0]
-        else:
-            batch_size = self.batch_size
+        batch_size = X.shape[0] if self.batch_size == -1 else self.batch_size
         batches = ceil(X.shape[0] / batch_size)
 
-        if self.epochs == -1:
-            epochs = ceil(self.max_iter / batches)
-        else:
-            epochs = self.epochs
+        epochs = ceil(self.max_iter / batches) if self.epochs == -1 else self.epochs
 
         start_time = time()
         last_update_time = start_time
@@ -467,32 +463,26 @@ class _AdversarialFairness(BaseEstimator):
             if self.shuffle:
                 X, y, A = self.backendEngine_.shuffle(X, y, A)
             for batch in range(batches):
-                if self.progress_updates:
-                    if (time() - last_update_time) > self.progress_updates:
-                        last_update_time = time()
-                        progress = (epoch / epochs) + (batch / (batches * epochs))
-                        if (
-                            progress > 0
-                            and len(predictor_losses) >= 1
-                            and len(adversary_losses) >= 1
-                        ):
-                            ETA = ((last_update_time - start_time + 1e-6) / (progress + 1e-6)) * (
-                                1 - progress
-                            )
-                            # + 1e-6 for numerical stability
-                            logger.info(
-                                _PROGRESS_UPDATE,
-                                "=" * round(20 * progress),
-                                " " * round(20 * (1 - progress)),
-                                epoch + 1,
-                                epochs,
-                                " " * (len(str(batch + 1)) - len(str(batches))),
-                                batch + 1,
-                                batches,
-                                ETA,
-                                predictor_losses[-1],
-                                adversary_losses[-1],
-                            )
+                if self.progress_updates and (time() - last_update_time) > self.progress_updates:
+                    last_update_time = time()
+                    progress = (epoch / epochs) + (batch / (batches * epochs))
+                    if progress > 0 and len(predictor_losses) >= 1 and len(adversary_losses) >= 1:
+                        ETA = ((last_update_time - start_time + 1e-6) / (progress + 1e-6)) * (
+                            1 - progress
+                        )  # + 1e-6 for numerical stability
+                        logger.info(
+                            _PROGRESS_UPDATE,
+                            "=" * round(20 * progress),
+                            " " * round(20 * (1 - progress)),
+                            epoch + 1,
+                            epochs,
+                            " " * (len(str(batch + 1)) - len(str(batches))),
+                            batch + 1,
+                            batches,
+                            ETA,
+                            predictor_losses[-1],
+                            adversary_losses[-1],
+                        )
                 batch_slice = slice(
                     batch * batch_size,
                     min((batch + 1) * batch_size, X.shape[0]),
@@ -561,12 +551,11 @@ class _AdversarialFairness(BaseEstimator):
 
         if first_call and classes is not None:
             self.classes_ = classes
-        if not first_call:
-            if self.n_features_in_ != X.shape[1]:
-                raise ValueError(
-                    "X has %d features, but %s is expecting %d features as input"
-                    % (X.shape[1], self.__class__.__name__, self.n_features_in_)
-                )
+        if not first_call and self.n_features_in_ != X.shape[1]:
+            raise ValueError(
+                f"X has {X.shape[1]} features, but {self.__class__.__name__} "
+                f"is expecting {self.n_features_in_} features as input"
+            )
 
         X, y, A = self._validate_input(X, y, sensitive_features, first_call)
         self.backendEngine_.train_step(X, y, A)
@@ -753,7 +742,7 @@ class _AdversarialFairness(BaseEstimator):
                     )
             except ImportError:
                 if self.backend == "torch":
-                    raise RuntimeError(_IMPORT_ERROR_MESSAGE.format("torch"))
+                    raise RuntimeError(_IMPORT_ERROR_MESSAGE.format("torch")) from None
             if select:
                 self.backend_ = PytorchEngine
                 return
@@ -776,7 +765,7 @@ class _AdversarialFairness(BaseEstimator):
                     )
             except ImportError:
                 if self.backend == "tensorflow":
-                    raise RuntimeError(_IMPORT_ERROR_MESSAGE.format("tensorflow"))
+                    raise RuntimeError(_IMPORT_ERROR_MESSAGE.format("tensorflow")) from None
             if select:
                 self.backend_ = TensorflowEngine
                 return
@@ -1015,7 +1004,7 @@ class AdversarialFairnessClassifier(ClassifierMixin, _AdversarialFairness):
         random_state=None,
     ):
         """Initialize model by setting the predictor loss and function."""
-        super(AdversarialFairnessClassifier, self).__init__(
+        super().__init__(
             backend=backend,
             predictor_model=predictor_model,
             adversary_model=adversary_model,
@@ -1207,7 +1196,7 @@ class AdversarialFairnessRegressor(RegressorMixin, _AdversarialFairness):
         random_state=None,
     ):
         """Initialize model by setting the predictor loss and function."""
-        super(AdversarialFairnessRegressor, self).__init__(
+        super().__init__(
             backend=backend,
             predictor_model=predictor_model,
             adversary_model=adversary_model,

--- a/fairlearn/adversarial/_pytorch_engine.py
+++ b/fairlearn/adversarial/_pytorch_engine.py
@@ -25,7 +25,7 @@ class PytorchEngine(BackendEngine):
 
         self.model_class = torch.nn.Module
         self.optim_class = torch.optim.Optimizer
-        super(PytorchEngine, self).__init__(base, X, Y, A)
+        super().__init__(base, X, Y, A)
 
     def __move_model__(self):
         """Move model to CUDA."""
@@ -63,10 +63,7 @@ class PytorchEngine(BackendEngine):
             X = X.to(self.device)
         with torch.no_grad():
             Y_pred = self.predictor_model(X)
-        if self.cuda:
-            Y_pred = Y_pred.detach().cpu().numpy()
-        else:
-            Y_pred = Y_pred.numpy()
+        Y_pred = Y_pred.detach().cpu().numpy() if self.cuda else Y_pred.numpy()
         return Y_pred
 
     def train_step(self, X, Y, A):
@@ -138,7 +135,7 @@ class PytorchEngine(BackendEngine):
             return torch.nn.CrossEntropyLoss(reduction="mean")
         elif dist_type in ["continuous", "continuous-multioutput"]:
             return torch.nn.MSELoss(reduction="mean")
-        super(PytorchEngine, self).get_loss(dist_type)
+        super().get_loss(dist_type)
 
     def get_model(self, list_nodes):
         """

--- a/fairlearn/adversarial/_tensorflow_engine.py
+++ b/fairlearn/adversarial/_tensorflow_engine.py
@@ -30,7 +30,7 @@ class TensorflowEngine(BackendEngine):
 
         self.model_class = keras.Model
         self.optim_class = keras.optimizers.Optimizer
-        super(TensorflowEngine, self).__init__(base, X, Y, A)
+        super().__init__(base, X, Y, A)
 
     def evaluate(self, X):
         """
@@ -82,10 +82,10 @@ class TensorflowEngine(BackendEngine):
             dW_LP[i] = dW_LP[i] - (proj * unit_dW_LA) - (self.base.alpha * dW_LA[i])
 
         self.predictor_optimizer.apply_gradients(
-            zip(dW_LP, self.predictor_model.trainable_variables)
+            zip(dW_LP, self.predictor_model.trainable_variables, strict=False)
         )
         self.adversary_optimizer.apply_gradients(
-            zip(dU_LA, self.adversary_model.trainable_variables)
+            zip(dU_LA, self.adversary_model.trainable_variables, strict=False)
         )
 
         return (LP.numpy().item(), LA.numpy().item())
@@ -111,7 +111,7 @@ class TensorflowEngine(BackendEngine):
             return keras.losses.CategoricalCrossentropy(from_logits=False)
         elif dist_type in ["continuous", "continuous-multioutput"]:
             return keras.losses.MeanSquaredError()
-        super(TensorflowEngine, self).get_loss(dist_type)
+        super().get_loss(dist_type)
 
     def get_model(self, list_nodes):
         """

--- a/fairlearn/datasets/_fetch_acs_income.py
+++ b/fairlearn/datasets/_fetch_acs_income.py
@@ -157,7 +157,7 @@ def fetch_acs_income(
     # check that user-provided state abbreviations are valid
     if states is not None:
         states = [state.upper() for state in states]
-        not_valid_states = [state for state in states if state not in _STATE_CODES.keys()]
+        not_valid_states = [state for state in states if state not in _STATE_CODES]
         if len(not_valid_states) > 0:
             raise ValueError(
                 f"Error with states: {not_valid_states}\n"

--- a/fairlearn/datasets/_fetch_boston.py
+++ b/fairlearn/datasets/_fetch_boston.py
@@ -125,7 +125,7 @@ def fetch_boston(*, cache=True, data_home=None, as_frame=True, return_X_y=False,
     """
     if warn:
         msg = "You are about to use a dataset with known fairness issues."
-        warnings.warn(DataFairnessWarning(msg))
+        warnings.warn(DataFairnessWarning(msg), stacklevel=2)
     if not data_home:
         data_home = pathlib.Path().home() / _DOWNLOAD_DIRECTORY_NAME
 

--- a/fairlearn/metrics/__init__.py
+++ b/fairlearn/metrics/__init__.py
@@ -74,4 +74,4 @@ _base_metrics = [
     "count",
 ]
 
-__all__ = _core + _fairness + _base_metrics + list(sorted(_generated_metric_dict.keys()))
+__all__ = _core + _fairness + _base_metrics + sorted(_generated_metric_dict.keys())

--- a/fairlearn/metrics/_annotated_metric_function.py
+++ b/fairlearn/metrics/_annotated_metric_function.py
@@ -66,7 +66,7 @@ class AnnotatedMetricFunction(Generic[R]):
             if hasattr(func, "__name__"):
                 self.name = func.__name__
             else:
-                warnings.warn("Supplied 'func' had no __name__ attribute")
+                warnings.warn("Supplied 'func' had no __name__ attribute", stacklevel=2)
                 self.name = _DEFAULT_NAME
         else:
             self.name = name
@@ -74,7 +74,7 @@ class AnnotatedMetricFunction(Generic[R]):
         self.postional_argument_names = ["y_true", "y_pred"]
         if positional_argument_names is not None:
             self.postional_argument_names = positional_argument_names
-        self.kw_argument_mapping = dict()
+        self.kw_argument_mapping = {}
         if kw_argument_mapping is not None:
             self.kw_argument_mapping = kw_argument_mapping
 

--- a/fairlearn/metrics/_bootstrap.py
+++ b/fairlearn/metrics/_bootstrap.py
@@ -168,5 +168,5 @@ def calculate_pandas_quantiles(
     elif isinstance(bootstrap_samples[0], pd.DataFrame):
         result = _calc_dataframe_quantiles(quantiles=quantiles, samples=bootstrap_samples)
     else:
-        assert False, "Should not be possible to get here"
+        raise AssertionError("Should not be possible to get here")
     return result

--- a/fairlearn/metrics/_disaggregated_result.py
+++ b/fairlearn/metrics/_disaggregated_result.py
@@ -15,11 +15,11 @@ logger = logging.getLogger(__name__)
 _VALID_ERROR_STRING = ["raise", "coerce"]
 _VALID_GROUPING_FUNCTION = ["min", "max"]
 
-_INVALID_ERRORS_VALUE_ERROR_MESSAGE = "Invalid error value specified. Valid values are {0}".format(
-    _VALID_ERROR_STRING
+_INVALID_ERRORS_VALUE_ERROR_MESSAGE = (
+    f"Invalid error value specified. Valid values are {_VALID_ERROR_STRING}"
 )
 _INVALID_GROUPING_FUNCTION_ERROR_MESSAGE = (
-    "Invalid grouping function specified. Valid values are {0}".format(_VALID_GROUPING_FUNCTION)
+    f"Invalid grouping function specified. Valid values are {_VALID_GROUPING_FUNCTION}"
 )
 _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE = (
     "Metric frame contains non-scalar cells. Please remove non-scalar columns from your"
@@ -45,14 +45,11 @@ def apply_to_dataframe(
     We don't use this argument, and only include it so that we can be
     compatible with pandas<2.2
     """
-    values = dict()
+    values = {}
     for function_name, metric_function in metric_functions.items():
         values[function_name] = metric_function(data)
     # correctly handle zero provided metrics
-    if len(values) == 0:
-        result = pd.Series(dtype=float)
-    else:
-        result = pd.Series(values)
+    result = pd.Series(dtype=float) if len(values) == 0 else pd.Series(values)
     return result
 
 
@@ -152,7 +149,7 @@ class DisaggregatedResult:
                 )
                 result = mf.groupby(level=control_feature_names).agg(grouping_function)
 
-        assert isinstance(result, pd.Series) or isinstance(result, pd.DataFrame)
+        assert isinstance(result, (pd.Series, pd.DataFrame))
 
         return result
 
@@ -200,7 +197,7 @@ class DisaggregatedResult:
         elif method == "to_overall":
             subtrahend = self.overall
         else:
-            raise ValueError("Unrecognised method '{0}' in difference() call".format(method))
+            raise ValueError(f"Unrecognised method '{method}' in difference() call")
 
         # Can assume errors='coerce', else error would already have been raised in .group_min
         # Fill all non-scalar values with NaN
@@ -211,7 +208,7 @@ class DisaggregatedResult:
         else:
             result = (mf - subtrahend).abs().groupby(level=control_feature_names).max()
 
-        assert isinstance(result, pd.Series) or isinstance(result, pd.DataFrame)
+        assert isinstance(result, (pd.Series, pd.DataFrame))
 
         return result
 
@@ -279,14 +276,11 @@ class DisaggregatedResult:
                 ratios = self.by_group / self.overall
 
             ratios = ratios.apply(lambda x: x.transform(ratio_sub_one))
-            if not control_feature_names:
-                result = ratios.min()
-            else:
-                result = ratios.min().unstack(0)
+            result = ratios.min() if not control_feature_names else ratios.min().unstack(0)
         else:
-            raise ValueError("Unrecognised method '{0}' in ratio() call".format(method))
+            raise ValueError(f"Unrecognised method '{method}' in ratio() call")
 
-        assert isinstance(result, pd.Series) or isinstance(result, pd.DataFrame)
+        assert isinstance(result, (pd.Series, pd.DataFrame))
 
         return result
 
@@ -297,7 +291,7 @@ class DisaggregatedResult:
         annotated_functions: dict[str, AnnotatedMetricFunction],
         sensitive_feature_names: list[str],
         control_feature_names: list[str] | None = None,
-    ) -> "DisaggregatedResult":
+    ) -> DisaggregatedResult:
         """Manufacture a DisaggregatedResult.
 
         This is essentially a more restricted version of the MetricFrame

--- a/fairlearn/metrics/_generated_metrics.py
+++ b/fairlearn/metrics/_generated_metrics.py
@@ -33,10 +33,10 @@ METRICS_SPEC = [
     (skm.log_loss, ["group_max"]),
 ]
 
-_generated_metric_dict = dict()
+_generated_metric_dict = {}
 for base_metric, variants in METRICS_SPEC:
     for variant in variants:
-        name = "{0}_{1}".format(base_metric.__name__, variant)
+        name = f"{base_metric.__name__}_{variant}"
         fn = make_derived_metric(
             metric=base_metric, transform=variant, sample_param_names=["sample_weight"]
         )

--- a/fairlearn/metrics/_make_derived_metric.py
+++ b/fairlearn/metrics/_make_derived_metric.py
@@ -22,7 +22,7 @@ _METHOD_ARG_ERROR = (
     "Callables which accept a '{0}' argument "
     "may not be passed to make_derived_metric(). Please use functools.partial()"
 )
-_INVALID_TRANSFORM = "Transform must be one of {0}".format(transform_options)
+_INVALID_TRANSFORM = f"Transform must be one of {transform_options}"
 
 
 class _DerivedMetric:
@@ -51,9 +51,9 @@ class _DerivedMetric:
             self._sample_param_names = sample_param_names
 
     def __call__(self, y_true, y_pred, *, sensitive_features, **other_params) -> float | int:
-        sample_params = dict()
-        params = dict()
-        transform_parameters = dict()
+        sample_params = {}
+        params = {}
+        transform_parameters = {}
         for k, v in other_params.items():
             if k in self._sample_param_names:
                 sample_params[k] = v
@@ -96,7 +96,7 @@ def make_derived_metric(
     *,
     metric: Callable[..., float | int],
     transform: str,
-    sample_param_names: list[str] = ["sample_weight"],
+    sample_param_names: list[str] | None = None,
 ) -> Callable[..., float | int]:
     """Create a scalar returning metric function based on aggregation of a disaggregated metric.
 
@@ -155,5 +155,7 @@ def make_derived_metric(
         :code:`sensitive_features=` and :code:`method=` arguments, to enable the
         required computation
     """
+    if sample_param_names is None:
+        sample_param_names = ["sample_weight"]
     dm = _DerivedMetric(metric=metric, transform=transform, sample_param_names=sample_param_names)
     return dm

--- a/fairlearn/metrics/_metric_frame.py
+++ b/fairlearn/metrics/_metric_frame.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, Literal
+from collections.abc import Callable
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -280,7 +281,7 @@ class MetricFrame:
                 raise ValueError(_DUPLICATE_FEATURE_NAME.format(name))
             nameset.add(name)
 
-        self._result_cache = dict()
+        self._result_cache = {}
 
         # Create the basic results
         result = DisaggregatedResult.create(
@@ -362,7 +363,7 @@ class MetricFrame:
         # Next up, group_min and group_max
         group_functions = {"group_min": "min", "group_max": "max"}
         for k, v in group_functions.items():
-            self._result_cache[k] = dict()
+            self._result_cache[k] = {}
             for err_string in _VALID_ERROR_STRING:
                 try:
                     self._result_cache[k][err_string] = self._group(raw_result, v, err_string)
@@ -372,9 +373,9 @@ class MetricFrame:
 
         # Differences and ratios
         for c_t in ["difference", "ratio"]:
-            self._result_cache[c_t] = dict()
+            self._result_cache[c_t] = {}
             for c_m in _COMPARE_METHODS:
-                self._result_cache[c_t][c_m] = dict()
+                self._result_cache[c_t][c_m] = {}
                 for err_string in _VALID_ERROR_STRING:
                     try:
                         if c_t == "difference":
@@ -426,7 +427,7 @@ class MetricFrame:
 
         # Differences and ratios
         for c_t in ["difference_ci", "ratio_ci"]:
-            self._result_cache[c_t] = dict()
+            self._result_cache[c_t] = {}
             for c_m in _COMPARE_METHODS:
                 if c_t == "difference_ci":
                     raw_samples = [

--- a/fairlearn/metrics/_plot_model_comparison.py
+++ b/fairlearn/metrics/_plot_model_comparison.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Callable
+from collections.abc import Callable
 
 from numpy import array, zeros
 from sklearn.utils.validation import check_array
@@ -115,7 +115,7 @@ def plot_model_comparison(
     try:
         import matplotlib.pyplot as plt
     except ImportError:
-        raise RuntimeError(_MATPLOTLIB_IMPORT_ERROR_MESSAGE)
+        raise RuntimeError(_MATPLOTLIB_IMPORT_ERROR_MESSAGE) from None
 
     _, y_true, sensitive_features, _ = _validate_and_reformat_input(
         zeros((len(y_true), 1)),  # Dummy values for X
@@ -173,10 +173,7 @@ def plot_model_comparison(
         if not len(point_labels) == y_preds.shape[0]:
             raise ValueError(_INCONSISTENT_ARRAY_LENGTH.format("point_labels and y_preds"))
     elif isinstance(point_labels, bool):
-        if point_labels:
-            point_labels = inferred_point_labels
-        else:
-            point_labels = None
+        point_labels = inferred_point_labels if point_labels else None
     else:
         raise ValueError(
             _INPUT_DATA_FORMAT_ERROR_MESSAGE.format(

--- a/fairlearn/metrics/_plotter.py
+++ b/fairlearn/metrics/_plotter.py
@@ -27,7 +27,7 @@ _CONF_INTERVALS_FLIPPED_BOUNDS_ERROR = (
 
 
 def _is_arraylike(input_):
-    return isinstance(input_, np.ndarray) or isinstance(input_, list)
+    return isinstance(input_, (np.ndarray, list))
 
 
 def _build_legend(ax, kind, legend_label):
@@ -193,7 +193,7 @@ def plot_metric_frame(
     if not isinstance(metric_frame, MetricFrame):
         raise (ValueError(_METRIC_FRAME_INVALID_ERROR))
     # ensure metrics is either list, str, or None
-    if not (isinstance(metrics, list) or isinstance(metrics, str) or metrics is None):
+    if not (isinstance(metrics, (list, str)) or metrics is None):
         raise ValueError(_METRICS_NOT_LIST_OR_STR_ERROR.format(type(metrics)))
 
     metrics = [metrics] if isinstance(metrics, str) else metrics
@@ -229,10 +229,12 @@ def plot_metric_frame(
     df_all_errors = pd.DataFrame([])
     df_all_bounds = pd.DataFrame([])
     # plotting with confidence intervals:
-    for metric, conf_interval in zip(metrics, conf_intervals):
+    for metric, conf_interval in zip(metrics, conf_intervals, strict=False):
         df_temp = pd.DataFrame([])
         df_temp[["lower", "upper"]] = pd.DataFrame(df[conf_interval].tolist(), index=df.index)
-        df_temp["error"] = list(zip(df[metric] - df_temp["lower"], df_temp["upper"] - df[metric]))
+        df_temp["error"] = list(
+            zip(df[metric] - df_temp["lower"], df_temp["upper"] - df[metric], strict=False)
+        )
         df_all_errors[metric] = df_temp["error"]
 
         if plot_ci_labels:

--- a/fairlearn/metrics/_plotter.py
+++ b/fairlearn/metrics/_plotter.py
@@ -132,7 +132,7 @@ def _get_conf_intervals_from_metric_frame(metric_frame):
         return {}
 
     # Zip and sort by quantile value so lower < upper always
-    pairs = sorted(zip(ci_quantiles, ci_data), key=lambda x: x[0])
+    pairs = sorted(zip(ci_quantiles, ci_data, strict=True), key=lambda x: x[0])
 
     if len(pairs) > 2:
         import warnings
@@ -152,12 +152,12 @@ def _get_conf_intervals_from_metric_frame(metric_frame):
             lower = lo_data[col].values
             upper = hi_data[col].values
             ci_col = f"__metricframe_ci_{col}"
-            mapping[col] = (ci_col, list(zip(lower, upper)))
+            mapping[col] = (ci_col, list(zip(lower, upper, strict=True)))
     else:
         # Single metric: by_group_ci returns Series
         col = lo_data.name or "metric"
         ci_col = f"__metricframe_ci_{col}"
-        mapping[col] = (ci_col, list(zip(lo_data.values, hi_data.values)))
+        mapping[col] = (ci_col, list(zip(lo_data.values, hi_data.values, strict=True)))
 
     return mapping
 

--- a/fairlearn/metrics/_roc_auc.py
+++ b/fairlearn/metrics/_roc_auc.py
@@ -109,7 +109,7 @@ def plot_roc_curve_by_group(
     try:
         import matplotlib.pyplot as plt
     except ImportError:
-        raise RuntimeError(_MATPLOTLIB_IMPORT_ERROR_MESSAGE)
+        raise RuntimeError(_MATPLOTLIB_IMPORT_ERROR_MESSAGE) from None
 
     y_true = asarray(y_true)
     y_score = asarray(y_score)

--- a/fairlearn/postprocessing/_interpolated_thresholder.py
+++ b/fairlearn/postprocessing/_interpolated_thresholder.py
@@ -98,7 +98,7 @@ class InterpolatedThresholder(MetaEstimatorMixin, BaseEstimator):
             try:
                 check_is_fitted(self.estimator)
             except NotFittedError:
-                warn(BASE_ESTIMATOR_NOT_FITTED_WARNING.format(type(self).__name__))
+                warn(BASE_ESTIMATOR_NOT_FITTED_WARNING.format(type(self).__name__), stacklevel=2)
             self.estimator_ = self.estimator
         return self
 

--- a/fairlearn/postprocessing/_plotting.py
+++ b/fairlearn/postprocessing/_plotting.py
@@ -20,7 +20,7 @@ def _get_debug_color(key):
         import matplotlib.cm as cm
         import matplotlib.colors
     except ImportError:
-        raise RuntimeError(_MATPLOTLIB_IMPORT_ERROR_MESSAGE)
+        raise RuntimeError(_MATPLOTLIB_IMPORT_ERROR_MESSAGE) from None
     if _debug_colors is None:
         tab_norm = matplotlib.colors.Normalize(vmin=0, vmax=7)
         tab_scalarMap = cm.ScalarMappable(norm=tab_norm, cmap="Dark2")
@@ -78,7 +78,7 @@ def _plot_curve(ax, sensitive_feature, x_col, y_col, points):
 def _raise_if_not_threshold_optimizer(obj):
     if not isinstance(obj, ThresholdOptimizer):
         raise ValueError(
-            "Argument {} needs to be of type {}.".format(obj.__name__, ThresholdOptimizer.__name__)
+            f"Argument {obj.__name__} needs to be of type {ThresholdOptimizer.__name__}."
         )
 
 
@@ -104,7 +104,7 @@ def plot_threshold_optimizer(threshold_optimizer: ThresholdOptimizer, ax=None, s
     try:
         import matplotlib.pyplot as plt
     except ImportError:
-        raise RuntimeError(_MATPLOTLIB_IMPORT_ERROR_MESSAGE)
+        raise RuntimeError(_MATPLOTLIB_IMPORT_ERROR_MESSAGE) from None
 
     _raise_if_not_threshold_optimizer(threshold_optimizer)
     check_is_fitted(threshold_optimizer)
@@ -112,7 +112,7 @@ def plot_threshold_optimizer(threshold_optimizer: ThresholdOptimizer, ax=None, s
     if ax is None:
         ax = plt.axes()
 
-    for sensitive_feature_value in threshold_optimizer._tradeoff_curve.keys():
+    for sensitive_feature_value in threshold_optimizer._tradeoff_curve:
         _plot_curve(
             ax,
             sensitive_feature_value,

--- a/fairlearn/postprocessing/_relaxed_constraints.py
+++ b/fairlearn/postprocessing/_relaxed_constraints.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import deque
-from typing import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 import pandas as pd
@@ -50,7 +50,9 @@ def maximize_objective_with_tolerance(
     n = len(x_values)
 
     # Extract weighted `y` columns
-    y_columns = [df[y_col].values * weight for df, weight in zip(dataframes, weights)]
+    y_columns = [
+        df[y_col].values * weight for df, weight in zip(dataframes, weights, strict=False)
+    ]
     m = len(y_columns)
 
     # Initialize a deque for each DataFrame to store indices in descending order of y values.

--- a/fairlearn/postprocessing/_threshold_operation.py
+++ b/fairlearn/postprocessing/_threshold_operation.py
@@ -56,4 +56,4 @@ class ThresholdOperation:
             raise ValueError("Unrecognized operator: " + self._operator)
 
     def __repr__(self):
-        return "[{}{}]".format(self._operator, self._threshold)
+        return f"[{self._operator}{self._threshold}]"

--- a/fairlearn/postprocessing/_threshold_optimizer.py
+++ b/fairlearn/postprocessing/_threshold_optimizer.py
@@ -48,8 +48,8 @@ MULTIPLE_DATA_COLUMNS_ERROR_MESSAGE = (
     "Post processing currently only supports a single column in {}."
 )
 SENSITIVE_FEATURE_NAME_CONFLICT_DETECTED_ERROR_MESSAGE = (
-    "A sensitive feature named {} or {} "
-    "was detected. Please rename your column and try again.".format(SCORE_KEY, LABEL_KEY)
+    f"A sensitive feature named {SCORE_KEY} or {LABEL_KEY} "
+    "was detected. Please rename your column and try again."
 )
 SCORES_DATA_TOO_MANY_COLUMNS_ERROR_MESSAGE = "The provided scores data contains multiple columns."
 UNEXPECTED_DATA_TYPE_ERROR_MESSAGE = "Unexpected data type {} encountered."
@@ -327,7 +327,7 @@ class ThresholdOptimizer(MetaEstimatorMixin, BaseEstimator):
             try:
                 check_is_fitted(self.estimator)
             except NotFittedError:
-                warn(BASE_ESTIMATOR_NOT_FITTED_WARNING.format(type(self).__name__))
+                warn(BASE_ESTIMATOR_NOT_FITTED_WARNING.format(type(self).__name__), stacklevel=2)
             self.estimator_ = self.estimator
 
         scores = _get_soft_predictions(self.estimator_, X, self._predict_method)
@@ -474,9 +474,9 @@ class ThresholdOptimizer(MetaEstimatorMixin, BaseEstimator):
             # sensitive feature value is identical by design.
             i_best = overall_tradeoff_curve.idxmax()
             self._x_best = self._x_grid[i_best]
-            self._x_best_per_group = {
-                group: self._x_best for group in sensitive_feature_proportions.keys()
-            }
+            self._x_best_per_group = dict.fromkeys(
+                sensitive_feature_proportions.keys(), self._x_best
+            )
             self._y_best = overall_tradeoff_curve[i_best]
             optimal_indices = [i_best] * len(sensitive_feature_proportions)
 
@@ -493,14 +493,14 @@ class ThresholdOptimizer(MetaEstimatorMixin, BaseEstimator):
 
         else:
             optimal_indices, self._y_best = maximize_objective_with_tolerance(
-                dataframes=[tradeoff_curve for tradeoff_curve in self._tradeoff_curve.values()],
+                dataframes=list(self._tradeoff_curve.values()),
                 weights=sensitive_feature_proportions.values(),
                 tol=self.tol,
             )
 
             self._x_best_per_group = {
                 group: self._x_grid[idx]
-                for group, idx in zip(self._tradeoff_curve.keys(), optimal_indices)
+                for group, idx in zip(self._tradeoff_curve.keys(), optimal_indices, strict=False)
             }
 
         max_x = max(self._x_best_per_group.values())
@@ -511,7 +511,9 @@ class ThresholdOptimizer(MetaEstimatorMixin, BaseEstimator):
         # interpolation per sensitive feature value.
         interpolation_dict = {}
 
-        for sensitive_feature_value, idx_best in zip(self._tradeoff_curve, optimal_indices):
+        for sensitive_feature_value, idx_best in zip(
+            self._tradeoff_curve, optimal_indices, strict=False
+        ):
             best_interpolation = self._tradeoff_curve[sensitive_feature_value].iloc[idx_best]
             interpolation_dict[sensitive_feature_value] = Bunch(
                 p0=best_interpolation.p0,
@@ -556,10 +558,7 @@ class ThresholdOptimizer(MetaEstimatorMixin, BaseEstimator):
 
         n = len(labels)
 
-        if isinstance(labels, pd.DataFrame):
-            n_positive = labels.sum().loc[0]
-        else:
-            n_positive = sum(labels)
+        n_positive = labels.sum().loc[0] if isinstance(labels, pd.DataFrame) else sum(labels)
         n_negative = n - n_positive
         self._tradeoff_curve = {}
         self._x_grid = np.linspace(0, 1, self.grid_size + 1)
@@ -611,7 +610,7 @@ class ThresholdOptimizer(MetaEstimatorMixin, BaseEstimator):
         # create the solution as interpolation of multiple points with a separate
         # interpolation per sensitive feature
         interpolation_dict = {}
-        for sensitive_feature_value in self._tradeoff_curve.keys():
+        for sensitive_feature_value in self._tradeoff_curve:
             roc_result = self._tradeoff_curve[sensitive_feature_value].transpose()[i_best_EO]
             # p_ignore * x_best represent the diagonal of the ROC plot.
             if roc_result.y == roc_result.x:
@@ -739,7 +738,7 @@ def _reformat_data_into_dict(key, data_dict, additional_data):
             if len(additional_data[0]) > 1:
                 # TODO: extend to multiple columns for additional_data
                 raise ValueError(MULTIPLE_DATA_COLUMNS_ERROR_MESSAGE.format("sensitive_features"))
-            data_dict[key] = map(lambda a: a[0], additional_data)
+            data_dict[key] = (a[0] for a in additional_data)
         else:
             data_dict[key] = additional_data
     else:

--- a/fairlearn/preprocessing/_correlation_remover.py
+++ b/fairlearn/preprocessing/_correlation_remover.py
@@ -114,12 +114,11 @@ class CorrelationRemover(TransformerMixin, BaseEstimator):
         X = self._create_lookup(X)
         X = validate_data(self, X)
 
-        if not first_call:
-            if self._n_features_in_ != X.shape[1]:
-                raise ValueError(
-                    "X has %d features, but %s is expecting %d features as input"
-                    % (X.shape[1], self.__class__.__name__, self._n_features_in_)
-                )
+        if not first_call and self._n_features_in_ != X.shape[1]:
+            raise ValueError(
+                f"X has {X.shape[1]} features, but {self.__class__.__name__} "
+                f"is expecting {self._n_features_in_} features as input"
+            )
 
         X_use, X_sensitive = self._split_X(X)
 
@@ -143,8 +142,8 @@ class CorrelationRemover(TransformerMixin, BaseEstimator):
         X = validate_data(self, X)
         if self._n_features_in_ != X.shape[1]:
             raise ValueError(
-                "X has %d features, but %s is expecting %d features as input"
-                % (X.shape[1], self.__class__.__name__, self._n_features_in_)
+                f"X has {X.shape[1]} features, but {self.__class__.__name__} "
+                f"is expecting {self._n_features_in_} features as input"
             )
 
         X_use, X_sensitive = self._split_X(X)
@@ -167,7 +166,7 @@ class CorrelationRemover(TransformerMixin, BaseEstimator):
 
         if len(missing_columns) > 0:
             raise ValueError(
-                "0 feature(s) (shape=(%d, 0)) while a minimum of %d is required. "
-                "Columns %s not found in the input data."
-                % (len(missing_columns), len(missing_columns), missing_columns)
+                f"0 feature(s) (shape=({len(missing_columns)}, 0)) while a minimum of "
+                f"{len(missing_columns)} is required. "
+                f"Columns {missing_columns} not found in the input data."
             )

--- a/fairlearn/reductions/_grid_search/_grid_generator.py
+++ b/fairlearn/reductions/_grid_search/_grid_generator.py
@@ -64,10 +64,7 @@ class _GridGenerator:
             self.grid_offset = grid_offset
 
         # true dimensionality of the grid
-        if self.force_L1_norm:
-            true_dim = self.dim - 1
-        else:
-            true_dim = self.dim
+        true_dim = self.dim - 1 if self.force_L1_norm else self.dim
 
         if true_dim > GRID_DIMENSION_WARN_THRESHOLD:
             logger.warning(GRID_DIMENSION_WARN_TEMPLATE, true_dim, GRID_DIMENSION_WARN_THRESHOLD)

--- a/fairlearn/reductions/_grid_search/grid_search.py
+++ b/fairlearn/reductions/_grid_search/grid_search.py
@@ -207,7 +207,7 @@ class GridSearch(BaseEstimator, MetaEstimatorMixin):
             oracle_call_execution_time = time() - oracle_call_start_time
             logger.debug("Call to estimator complete")
 
-            def predict_fct(X):
+            def predict_fct(X, current_estimator=current_estimator):
                 return current_estimator.predict(X)
 
             self.predictors_.append(current_estimator)

--- a/fairlearn/reductions/_moments/bounded_group_loss.py
+++ b/fairlearn/reductions/_moments/bounded_group_loss.py
@@ -65,13 +65,11 @@ class ConditionalLossMoment(LossMoment):
         self.neg_basis = pd.DataFrame()
         self.neg_basis_present = pd.Series(dtype="float64")
         zero_vec = pd.Series(0.0, self.index)
-        i = 0
-        for attr in attr_vals:
+        for i, attr in enumerate(attr_vals):
             self.pos_basis[i] = 0 + zero_vec
             self.neg_basis[i] = 0 + zero_vec
             self.pos_basis.loc[attr, i] = 1
             self.neg_basis_present.at[i] = False
-            i += 1
 
     def gamma(self, predictor: Callable) -> pd.Series:
         """Calculate the degree to which constraints are currently violated by the predictor."""

--- a/fairlearn/reductions/_moments/error_rate.py
+++ b/fairlearn/reductions/_moments/error_rate.py
@@ -2,7 +2,8 @@
 # Licensed under the MIT License.
 from __future__ import annotations
 
-from typing import Callable, Literal
+from collections.abc import Callable
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -47,7 +48,7 @@ class ErrorRate(ClassificationMoment):
 
     def __init__(self, *, costs: dict[Literal["fp", "fn"], float] | None = None):
         """Initialize the costs."""
-        super(ErrorRate, self).__init__()
+        super().__init__()
         if costs is None:
             self.fp_cost = 1.0
             self.fn_cost = 1.0

--- a/fairlearn/reductions/_moments/utility_parity.py
+++ b/fairlearn/reductions/_moments/utility_parity.py
@@ -97,7 +97,7 @@ class UtilityParity(ClassificationMoment):
         ratio_bound_slack: float = 0.0,
     ):
         """Initialize with the ratio value."""
-        super(UtilityParity, self).__init__()
+        super().__init__()
         if (difference_bound is None) and (ratio_bound is None):
             self.eps = _DEFAULT_DIFFERENCE_BOUND
             self.ratio = 1.0

--- a/fairlearn/show_versions.py
+++ b/fairlearn/show_versions.py
@@ -77,8 +77,8 @@ def show_versions():
 
     print("\nSystem:")
     for k, stat in sys_info.items():
-        print("{k:>10}: {stat}".format(k=k, stat=stat))
+        print(f"{k:>10}: {stat}")
 
     print("\nPython dependencies:")
     for k, stat in deps_info.items():
-        print("{k:>13}: {stat}".format(k=k, stat=stat))
+        print(f"{k:>13}: {stat}")

--- a/fairlearn/utils/_input_validation.py
+++ b/fairlearn/utils/_input_validation.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 import logging
-from typing import Sequence
+from collections.abc import Sequence
 
 import numpy as np
 import pandas as pd
@@ -15,7 +15,7 @@ _KW_CONTROL_FEATURES = "control_features"
 
 _MESSAGE_X_NONE = "Must supply X"
 _MESSAGE_Y_NONE = "Must supply nonempty y"
-_MESSAGE_SENSITIVE_FEATURES_NONE = "Must specify {0} (for now)".format(_KW_SENSITIVE_FEATURES)
+_MESSAGE_SENSITIVE_FEATURES_NONE = f"Must specify {_KW_SENSITIVE_FEATURES} (for now)"
 _MESSAGE_X_Y_ROWS = "X and y must have same number of rows"
 _MESSAGE_X_SENSITIVE_ROWS = "X and the sensitive features must have same number of rows"
 _MESSAGE_RATIO_NOT_IN_RANGE = "ratio must lie between (0,1]"
@@ -84,7 +84,7 @@ def _validate_and_reformat_input(
             raise ValueError(_MESSAGE_Y_NONE + f", got y={y}.")
         if not (y.ndim == 1 or (y.ndim == 2 and y.shape[1] == 1)):
             raise ValueError(f"`y` must be of shape (n,) or (n,1), got y of shape=({y.shape}).")
-        if enforce_binary_labels and not set(np.unique(y)).issubset(set([0, 1])):
+        if enforce_binary_labels and not set(np.unique(y)).issubset({0, 1}):
             raise ValueError(_LABELS_NOT_0_1_ERROR_MESSAGE)
         y = check_array(y.reshape(-1), ensure_2d=False, dtype="numeric", ensure_all_finite=False)
 
@@ -122,10 +122,7 @@ def _validate_and_reformat_input(
 
     # If we don't have a y, then need to fiddle with return type to
     # avoid a warning from pandas
-    if y is not None:
-        result_y = pd.Series(y)
-    else:
-        result_y = pd.Series(dtype="float64")
+    result_y = pd.Series(y) if y is not None else pd.Series(dtype="float64")
 
     return (result_X, result_y, sensitive_features, control_features)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,11 @@ notice-rgx = "# (?i)Copyright \\(C\\) (Microsoft Corporation and )?Fairlearn con
 # Enable flake8-logging-format (`G`) to enforce lazy %s logging.
 # Enable pydocstyle (`D`); the numpy convention is configured below to match
 # the project's use of numpydoc.
-select = ["E4", "E7", "E9", "F", "G", "NPY201", "D"]
+# Enable pyupgrade (`UP`) to modernize syntax for the minimum supported Python.
+# Enable flake8-bugbear (`B`) to catch likely bugs and design problems.
+# Enable flake8-simplify (`SIM`) to simplify verbose or redundant code.
+# Enable flake8-comprehensions (`C4`) for more idiomatic comprehensions.
+select = ["E4", "E7", "E9", "F", "G", "NPY201", "D", "UP", "B", "SIM", "C4"]
 ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
@@ -183,8 +187,9 @@ docstring-code-line-length = "dynamic"
 [tool.ruff.lint.per-file-ignores]
 # It's fine not to put the import at the top of the file in the examples
 # folder. Docstrings (`D`) are not required for tests, examples, scripts,
-# or the docs build configuration.
-"examples/*" = ["E402", "D"]
+# or the docs build configuration. Bare expressions (`B018`) in the examples
+# are intentional: sphinx-gallery renders their repr as cell output.
+"examples/*" = ["E402", "D", "B018"]
 "test/**" = ["D"]
 "test_othermlpackages/**" = ["D"]
 "scripts/**" = ["D"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@
 # Since that file does its own testing setup
 
 # Required for environment
-ruff==0.4.5
+ruff==0.15.20
 requirements-parser
 # Need to keep black version consistent in
 # requirements-dev.txt

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -5,7 +5,7 @@ scikit-learn==1.6.0
 scipy==1.9.3
 
 #requirements-dev
-ruff==0.4.5
+ruff==0.15.20
 requirements_parser==0.11.0
 black==26.3.1
 pytest==9.0.3

--- a/scripts/_utils.py
+++ b/scripts/_utils.py
@@ -17,9 +17,7 @@ def _ensure_cwd_is_fairlearn_root_dir():
         os.path.join(os.getcwd(), "README.rst")
     ):
         raise Exception(
-            "Please run this from the fairlearn root directory. Current directory: {}".format(
-                os.getcwd()
-            )
+            f"Please run this from the fairlearn root directory. Current directory: {os.getcwd()}"
         )
 
 
@@ -35,12 +33,14 @@ def _get_fairlearn_version():
     for node in tree.body:
         if isinstance(node, ast.Assign):
             for target in node.targets:
-                if isinstance(target, ast.Name) and target.id == "__version__":
-                    if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
-                        return node.value.value
-    raise RuntimeError(
-        "Could not find a string literal assignment to __version__ in {}".format(init_path)
-    )
+                if (
+                    isinstance(target, ast.Name)
+                    and target.id == "__version__"
+                    and isinstance(node.value, ast.Constant)
+                    and isinstance(node.value.value, str)
+                ):
+                    return node.value.value
+    raise RuntimeError(f"Could not find a string literal assignment to __version__ in {init_path}")
 
 
 class _LogWrapper:

--- a/scripts/build_wheels.py
+++ b/scripts/build_wheels.py
@@ -34,7 +34,7 @@ def main(argv):
     with _LogWrapper("processing README.rst"):
         process_readme("README.rst", "README.rst")
 
-    with _LogWrapper("storing fairlearn version in {}".format(args.version_filename)):
+    with _LogWrapper(f"storing fairlearn version in {args.version_filename}"):
         version = _get_fairlearn_version()
         with open(args.version_filename, "w") as version_file:
             version_file.write(version)

--- a/scripts/generate_maintainers_table.py
+++ b/scripts/generate_maintainers_table.py
@@ -36,10 +36,10 @@ def generate_table(maintainers):
     for alias, name in maintainers.items():
         lines.append("    <div>")
         lines.append(
-            "    <a href='%s'><img src='%s' class='avatar' /></a> <br />"
-            % (f"https://github.com/{alias}", f"https://github.com/{alias}.png")
+            f"    <a href='https://github.com/{alias}'>"
+            f"<img src='https://github.com/{alias}.png' class='avatar' /></a> <br />"
         )
-        lines.append("    <p>%s</p>" % (name,))
+        lines.append(f"    <p>{name}</p>")
         lines.append("    </div>")
     lines.append("    </div>")
     lines.append("")  # add empty line for linting compliance

--- a/scripts/install_requirements.py
+++ b/scripts/install_requirements.py
@@ -47,9 +47,9 @@ def _build_argument_parser():
 def _install_requirements_file(file_stem):
     _logger.info("Processing %s", file_stem)
 
-    requirements_file = "{0}.{1}".format(file_stem, _REQUIREMENTS_EXTENSION)
+    requirements_file = f"{file_stem}.{_REQUIREMENTS_EXTENSION}"
 
-    with _LogWrapper("Running pip on {0}".format(requirements_file)):
+    with _LogWrapper(f"Running pip on {requirements_file}"):
         command_args = ["pip", "install", "-r", requirements_file]
         subprocess.check_call(command_args)
 

--- a/scripts/process_readme.py
+++ b/scripts/process_readme.py
@@ -57,8 +57,8 @@ def _update_other_markdown_references(line, target_version):
     if match:
         _logger.info("Matched %s", match)
         for m in match.groups():
-            old_str = "./{0}".format(m)
-            new_str = "{0}/{1}".format(_get_base_path(target_version), m)
+            old_str = f"./{m}"
+            new_str = f"{_get_base_path(target_version)}/{m}"
             result = result.replace(old_str, new_str)
         _logger.info("Updated string: %s", result.rstrip())
 
@@ -74,7 +74,7 @@ def _update_same_page_references(line, target_version):
         _logger.info("Matched %s", match)
         for m in match.groups():
             old_str = m
-            new_str = "{0}{1}".format(_get_base_path(target_version), m)
+            new_str = f"{_get_base_path(target_version)}{m}"
             result = result.replace(old_str, new_str)
         _logger.info("Updated string: %s", result.rstrip())
 
@@ -95,15 +95,16 @@ def process_readme(input_file_name, output_file_name):
     _logger.info("fairlearn version: %s", target_version)
 
     text_lines = []
-    with _LogWrapper("reading file {}".format(input_file_name)):
-        with open(input_file_name, "r") as input_file:
-            text_lines = input_file.readlines()
+    with _LogWrapper(f"reading file {input_file_name}"), open(input_file_name) as input_file:
+        text_lines = input_file.readlines()
 
     result_lines = [_process_line(line, target_version) for line in text_lines]
 
-    with _LogWrapper("writing file {}".format(output_file_name)):
-        with open(output_file_name, "w") as output_file:
-            output_file.writelines(result_lines)
+    with (
+        _LogWrapper(f"writing file {output_file_name}"),
+        open(output_file_name, "w") as output_file,
+    ):
+        output_file.writelines(result_lines)
 
 
 def build_argument_parser():

--- a/test/unit/adversarial/helper.py
+++ b/test/unit/adversarial/helper.py
@@ -226,7 +226,7 @@ cols = 5
 Bin2d = np.random.choice([0.0, 1.0], size=(rows, cols))
 Bin1d = np.random.choice([0.0, 1.0], size=(rows,))
 Cat = np.zeros((rows, cols), dtype=float)
-Cat[np.arange(rows), np.random.choice([i for i in range(cols)], size=(rows,))] = 1.0
+Cat[np.arange(rows), np.random.choice(list(range(cols)), size=(rows,))] = 1.0
 Cat1d = Cat[:, 0]
 Cont2d = np.random.rand(rows, cols)
 Cont1d = np.random.rand(
@@ -262,7 +262,7 @@ def generate_data_combinations(n=10):
         Y = c % K
         c = (c - Y) // K
         Z = c % K
-        assert X + Y * K + Z * K * K == c_orig
+        assert c_orig == X + Y * K + Z * K * K
         X_type = dist_type[X]
         X = dataX[X]
         Y_type = dist_type[Y]
@@ -341,7 +341,7 @@ def get_instance(
     fake_backend : Literal["torch", "tensorflow"] | None
         which backend to use
     """
-    default_kwargs = dict()
+    default_kwargs = {}
 
     if fake_backend == "torch":
         default_kwargs["predictor_model"] = fake_torch.nn.Module()

--- a/test/unit/adversarial/test_adversarial_mitigation.py
+++ b/test/unit/adversarial/test_adversarial_mitigation.py
@@ -355,7 +355,7 @@ def test_estimators_with_torch(estimator, check, fake_backend_env):
 @pytest.mark.parametrize("fake_backend_env", ["torch"], indirect=True)
 def test_fake_models(fake_backend_env):
     """Test various data types and see if it is interpreted correctly."""
-    for (X, Y, Z), (X_type, Y_type, Z_type) in generate_data_combinations():
+    for (X, Y, Z), (_X_type, Y_type, Z_type) in generate_data_combinations():
         mitigator = get_instance(fake_training=True, fake_backend=fake_backend_env)
         mitigator.fit(X, Y, sensitive_features=Z)
         assert isinstance(mitigator.backendEngine_.predictor_loss, KeywordToClass(Y_type))
@@ -365,7 +365,7 @@ def test_fake_models(fake_backend_env):
 @pytest.mark.parametrize("fake_backend_env", ["torch"], indirect=True)
 def test_fake_models_list_inputs(fake_backend_env):
     """Test model with lists as input."""
-    for (X, Y, Z), types in generate_data_combinations():
+    for (X, Y, Z), _types in generate_data_combinations():
         mitigator = get_instance(fake_mixin=True)
         mitigator.fit(X.tolist(), Y.tolist(), sensitive_features=Z.tolist())
 
@@ -373,7 +373,7 @@ def test_fake_models_list_inputs(fake_backend_env):
 @pytest.mark.parametrize("fake_backend_env", ["torch"], indirect=True)
 def test_fake_models_df_inputs(fake_backend_env):
     """Test model with data frames as input."""
-    for (X, Y, Z), types in generate_data_combinations():
+    for (X, Y, Z), _types in generate_data_combinations():
         mitigator = get_instance(fake_mixin=True)
         mitigator.fit(pd.DataFrame(X), pd.Series(Y), sensitive_features=pd.DataFrame(Z))
 
@@ -406,7 +406,7 @@ def check_2dnp(X):
 @pytest.mark.parametrize("fake_backend_env", ["torch"], indirect=True)
 def test_validate_data(fake_backend_env):
     """Test if validate_data properly preprocesses datasets to ndarray."""
-    for (X, Y, Z), types in generate_data_combinations():
+    for (X, Y, Z), _types in generate_data_combinations():
         mitigator = get_instance(fake_mixin=True)
         X, Y, Z = mitigator._validate_input(X, Y, Z)
         for x in (X, Y, Z):
@@ -416,7 +416,7 @@ def test_validate_data(fake_backend_env):
 @pytest.mark.parametrize("fake_backend_env", ["torch"], indirect=True)
 def test_validate_data_list_inputs(fake_backend_env):
     """Test if validate_data properly preprocesses list datasets to ndarray."""
-    for (X, Y, Z), types in generate_data_combinations():
+    for (X, Y, Z), _types in generate_data_combinations():
         mitigator = get_instance(fake_mixin=True)
         X, Y, Z = mitigator._validate_input(X.tolist(), Y.tolist(), Z.tolist())
         for x in (X, Y, Z):
@@ -426,7 +426,7 @@ def test_validate_data_list_inputs(fake_backend_env):
 @pytest.mark.parametrize("fake_backend_env", ["torch"], indirect=True)
 def test_validate_data_df_inputs(fake_backend_env):
     """Test if validate_data properly preprocesses dataframes to ndarray."""
-    for (X, Y, Z), types in generate_data_combinations():
+    for (X, Y, Z), _types in generate_data_combinations():
         mitigator = get_instance(fake_mixin=True)
         X, Y, Z = mitigator._validate_input(pd.DataFrame(X), pd.Series(Y), pd.DataFrame(Z))
         for x in (X, Y, Z):
@@ -436,10 +436,7 @@ def test_validate_data_df_inputs(fake_backend_env):
 @pytest.mark.parametrize("fake_backend_env", ["torch", "tensorflow"], indirect=True)
 def test_not_correct_backend(fake_backend_env):
     """Test if validate_data properly preprocesses dataframes to ndarray."""
-    if fake_backend_env == "torch":
-        backend = "tensorflow"
-    else:
-        backend = "torch"
+    backend = "tensorflow" if fake_backend_env == "torch" else "torch"
 
     mitigator = get_instance(
         fake_backend=fake_backend_env,
@@ -461,13 +458,12 @@ def test_no_backend(backend, fake_backend_env):
 @pytest.mark.parametrize("fake_backend_env", ["torch"], indirect=True)
 def test_validate_data_ambiguous_rows(fake_backend_env):
     """Test if an ambiguous number of rows are caught."""
-    for (X, Y, Z), types in generate_data_combinations():
+    for (X, Y, Z), _types in generate_data_combinations():
         X = X[:5, :]
         mitigator = get_instance(fake_mixin=True)
         with pytest.raises(ValueError) as exc:
             mitigator._validate_input(X.tolist(), Y.tolist(), Z.tolist())
-            assert str(
-                exc.value
-            ) == "Input data has an ambiguous number of rows: {}, {}, {}.".format(
-                X.shape[0], Y.shape[0], Z.shape[0]
+            assert (
+                str(exc.value)
+                == f"Input data has an ambiguous number of rows: {X.shape[0]}, {Y.shape[0]}, {Z.shape[0]}."
             )

--- a/test/unit/input_convertors.py
+++ b/test/unit/input_convertors.py
@@ -11,11 +11,7 @@ def ensure_list(X):
     assert X is not None
     if isinstance(X, list):
         return X
-    elif isinstance(X, np.ndarray):
-        return X.tolist()
-    elif isinstance(X, pd.Series):
-        return X.tolist()
-    elif isinstance(X, pd.DataFrame):
+    elif isinstance(X, (np.ndarray, pd.Series, pd.DataFrame)):
         return X.tolist()
     raise ValueError("Failed to convert to list")
 
@@ -26,9 +22,7 @@ def ensure_list_1d(X):
         return X
     elif isinstance(X, np.ndarray):
         return X.squeeze().tolist()
-    elif isinstance(X, pd.Series):
-        return X.tolist()
-    elif isinstance(X, pd.DataFrame):
+    elif isinstance(X, (pd.Series, pd.DataFrame)):
         return X.tolist()
     raise ValueError("Failed to convert to list")
 
@@ -39,9 +33,7 @@ def ensure_ndarray(X):
         return np.asarray(X)
     elif isinstance(X, np.ndarray):
         return X
-    elif isinstance(X, pd.Series):
-        return np.asarray(X)
-    elif isinstance(X, pd.DataFrame):
+    elif isinstance(X, (pd.Series, pd.DataFrame)):
         return np.asarray(X)
     raise ValueError("Failed to convert to ndarray")
 
@@ -76,11 +68,7 @@ def ensure_series(X):
 
 def ensure_dataframe(X):
     assert X is not None
-    if isinstance(X, list):
-        return pd.DataFrame(X)
-    elif isinstance(X, np.ndarray):
-        return pd.DataFrame(X)
-    elif isinstance(X, pd.Series):
+    if isinstance(X, (list, np.ndarray, pd.Series)):
         return pd.DataFrame(X)
     elif isinstance(X, pd.DataFrame):
         return X

--- a/test/unit/metrics/test_base_metrics.py
+++ b/test/unit/metrics/test_base_metrics.py
@@ -704,13 +704,13 @@ class TestCount:
         y_true = []
         y_pred = []
 
-        assert 0 == metrics.count(y_true, y_pred)
+        assert metrics.count(y_true, y_pred) == 0
 
     def test_group_of_one(self):
         y_true = [1]
         y_pred = [0]
 
-        assert 1 == metrics.count(y_true, y_pred)
+        assert metrics.count(y_true, y_pred) == 1
 
     def test_multi_group(self):
         y_true = [
@@ -770,7 +770,7 @@ class TestCount:
             0,
         ]
 
-        assert 26 == metrics.count(y_true, y_pred)
+        assert metrics.count(y_true, y_pred) == 26
 
     def test_unequal_y_sizes(self):
         y_true = [0, 1, 0, 1, 0, 1, 1]

--- a/test/unit/metrics/test_bootstrap.py
+++ b/test/unit/metrics/test_bootstrap.py
@@ -142,5 +142,5 @@ from fairlearn.metrics._bootstrap import _align_sample_indices
 )
 def test_align_sample_indices(samples: list[pd.DataFrame], expected: list[pd.DataFrame]) -> None:
     aligned_samples = _align_sample_indices(samples=samples)
-    for aligned, exp in zip(aligned_samples, expected):
+    for aligned, exp in zip(aligned_samples, expected, strict=False):
         pd.testing.assert_frame_equal(aligned, exp)

--- a/test/unit/metrics/test_generated_metrics.py
+++ b/test/unit/metrics/test_generated_metrics.py
@@ -70,10 +70,7 @@ def test_dict_sizes():
 def test_generated_metrics_smoke(func_name):
     func = getattr(metrics, func_name)
     assert callable(func)
-    if func_name.startswith("log_loss"):
-        y_pred_test = y_pred_log_loss
-    else:
-        y_pred_test = y_pred
+    y_pred_test = y_pred_log_loss if func_name.startswith("log_loss") else y_pred
     result = func(
         y_true,
         y_pred_test,

--- a/test/unit/metrics/test_metricframe_aggregates.py
+++ b/test/unit/metrics/test_metricframe_aggregates.py
@@ -160,14 +160,14 @@ class Test1m1sf0cf:
 
         with pytest.raises(ValueError) as exc:
             self.target.difference(method="some_string")
-        assert "Unrecognised comparison method: some_string" == exc.value.args[0]
+        assert exc.value.args[0] == "Unrecognised comparison method: some_string"
 
     def test_ratio_bad_method(self):
         self._prepare(skm.accuracy_score)
 
         with pytest.raises(ValueError) as exc:
             self.target.ratio(method="some_other_string")
-        assert "Unrecognised comparison method: some_other_string" == exc.value.args[0]
+        assert exc.value.args[0] == "Unrecognised comparison method: some_other_string"
 
 
 class Test1m1sf0cfFnDict:
@@ -1351,7 +1351,7 @@ class Test2m1sf1cfErrorHandlingCM:
     def test_min_raise(self):
         with pytest.raises(ValueError) as exc:
             self.target.group_min(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_min_coerce(self):
         target_mins = self.target.group_min(errors="coerce")
@@ -1362,18 +1362,18 @@ class Test2m1sf1cfErrorHandlingCM:
     def test_min_wrong_input(self):
         with pytest.raises(ValueError) as exc:
             self.target.group_min(errors="WRONG")
-        assert _INVALID_ERRORS_VALUE_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _INVALID_ERRORS_VALUE_ERROR_MESSAGE
 
     def test_min_default(self):
         # default is 'raise'
         with pytest.raises(ValueError) as exc:
             self.target.group_min(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_max_raise(self):
         with pytest.raises(ValueError) as exc:
             self.target.group_max(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_max_coerce(self):
         target_maxs = self.target.group_max(errors="coerce")
@@ -1384,18 +1384,18 @@ class Test2m1sf1cfErrorHandlingCM:
     def test_max_wrong_input(self):
         with pytest.raises(ValueError) as exc:
             self.target.group_max(errors="WRONG")
-        assert _INVALID_ERRORS_VALUE_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _INVALID_ERRORS_VALUE_ERROR_MESSAGE
 
     def test_max_default(self):
         # default is 'raise'
         with pytest.raises(ValueError) as exc:
             self.target.group_max(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_difference_raise(self):
         with pytest.raises(ValueError) as exc:
             self.target.difference(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_difference_coerce(self):
         target_differences = self.target.difference(errors="coerce")
@@ -1406,7 +1406,7 @@ class Test2m1sf1cfErrorHandlingCM:
     def test_difference_wrong_input(self):
         with pytest.raises(ValueError) as exc:
             self.target.difference(errors="WRONG")
-        assert _INVALID_ERRORS_VALUE_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _INVALID_ERRORS_VALUE_ERROR_MESSAGE
 
     def test_difference_default(self):
         # default is 'coerce'
@@ -1418,7 +1418,7 @@ class Test2m1sf1cfErrorHandlingCM:
     def test_ratio_raise(self):
         with pytest.raises(ValueError) as exc:
             self.target.ratio(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_ratio_coerce(self):
         target_ratio = self.target.ratio(errors="coerce")
@@ -1429,7 +1429,7 @@ class Test2m1sf1cfErrorHandlingCM:
     def test_ratio_wrong_input(self):
         with pytest.raises(ValueError) as exc:
             self.target.ratio(errors="WRONG")
-        assert _INVALID_ERRORS_VALUE_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _INVALID_ERRORS_VALUE_ERROR_MESSAGE
 
     def test_ratio_default(self):
         # default is 'coerce'
@@ -1462,7 +1462,7 @@ class Test1m1sf1cfErrorHandlingCM:
     def test_min_raise(self):
         with pytest.raises(ValueError) as exc:
             self.target.group_min(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_min_coerce(self):
         target_mins = self.target.group_min(errors="coerce")
@@ -1473,18 +1473,18 @@ class Test1m1sf1cfErrorHandlingCM:
     def test_min_wrong_input(self):
         with pytest.raises(ValueError) as exc:
             self.target.group_min(errors="WRONG")
-        assert _INVALID_ERRORS_VALUE_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _INVALID_ERRORS_VALUE_ERROR_MESSAGE
 
     def test_min_default(self):
         # default is 'raise'
         with pytest.raises(ValueError) as exc:
             self.target.group_min(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_max_raise(self):
         with pytest.raises(ValueError) as exc:
             self.target.group_max(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_max_coerce(self):
         target_maxs = self.target.group_max(errors="coerce")
@@ -1495,18 +1495,18 @@ class Test1m1sf1cfErrorHandlingCM:
     def test_max_wrong_input(self):
         with pytest.raises(ValueError) as exc:
             self.target.group_max(errors="WRONG")
-        assert _INVALID_ERRORS_VALUE_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _INVALID_ERRORS_VALUE_ERROR_MESSAGE
 
     def test_max_default(self):
         # default is 'raise'
         with pytest.raises(ValueError) as exc:
             self.target.group_max(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_difference_raise(self):
         with pytest.raises(ValueError) as exc:
             self.target.difference(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_difference_coerce(self):
         target_differences = self.target.difference(errors="coerce")
@@ -1517,7 +1517,7 @@ class Test1m1sf1cfErrorHandlingCM:
     def test_difference_wrong_input(self):
         with pytest.raises(ValueError) as exc:
             self.target.difference(errors="WRONG")
-        assert _INVALID_ERRORS_VALUE_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _INVALID_ERRORS_VALUE_ERROR_MESSAGE
 
     def test_difference_default(self):
         # default is 'coerce'
@@ -1529,7 +1529,7 @@ class Test1m1sf1cfErrorHandlingCM:
     def test_ratio_raise(self):
         with pytest.raises(ValueError) as exc:
             self.target.ratio(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_ratio_coerce(self):
         target_ratio = self.target.ratio(errors="coerce")
@@ -1540,7 +1540,7 @@ class Test1m1sf1cfErrorHandlingCM:
     def test_ratio_wrong_input(self):
         with pytest.raises(ValueError) as exc:
             self.target.ratio(errors="WRONG")
-        assert _INVALID_ERRORS_VALUE_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _INVALID_ERRORS_VALUE_ERROR_MESSAGE
 
     def test_ratio_default(self):
         # default is 'coerce'
@@ -1568,7 +1568,7 @@ class Test2m1sf0cfErrorHandlingCM:
     def test_min_raise(self):
         with pytest.raises(ValueError) as exc:
             self.target.group_min(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_min_coerce(self):
         target_mins = self.target.group_min(errors="coerce")
@@ -1579,18 +1579,18 @@ class Test2m1sf0cfErrorHandlingCM:
     def test_min_wrong_input(self):
         with pytest.raises(ValueError) as exc:
             self.target.group_min(errors="WRONG")
-        assert _INVALID_ERRORS_VALUE_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _INVALID_ERRORS_VALUE_ERROR_MESSAGE
 
     def test_min_default(self):
         # default is 'raise'
         with pytest.raises(ValueError) as exc:
             self.target.group_min(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_max_raise(self):
         with pytest.raises(ValueError) as exc:
             self.target.group_max(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_max_coerce(self):
         target_maxs = self.target.group_max(errors="coerce")
@@ -1601,18 +1601,18 @@ class Test2m1sf0cfErrorHandlingCM:
     def test_max_wrong_input(self):
         with pytest.raises(ValueError) as exc:
             self.target.group_max(errors="WRONG")
-        assert _INVALID_ERRORS_VALUE_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _INVALID_ERRORS_VALUE_ERROR_MESSAGE
 
     def test_max_default(self):
         # default is 'raise'
         with pytest.raises(ValueError) as exc:
             self.target.group_max(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_difference_raise(self):
         with pytest.raises(ValueError) as exc:
             self.target.difference(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_difference_coerce(self):
         target_differences = self.target.difference(errors="coerce")
@@ -1623,7 +1623,7 @@ class Test2m1sf0cfErrorHandlingCM:
     def test_difference_wrong_input(self):
         with pytest.raises(ValueError) as exc:
             self.target.difference(errors="WRONG")
-        assert _INVALID_ERRORS_VALUE_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _INVALID_ERRORS_VALUE_ERROR_MESSAGE
 
     def test_difference_default(self):
         # default is 'coerce'
@@ -1635,7 +1635,7 @@ class Test2m1sf0cfErrorHandlingCM:
     def test_ratio_raise(self):
         with pytest.raises(ValueError) as exc:
             self.target.ratio(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_ratio_coerce(self):
         target_ratio = self.target.ratio(errors="coerce")
@@ -1646,7 +1646,7 @@ class Test2m1sf0cfErrorHandlingCM:
     def test_ratio_wrong_input(self):
         with pytest.raises(ValueError) as exc:
             self.target.ratio(errors="WRONG")
-        assert _INVALID_ERRORS_VALUE_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _INVALID_ERRORS_VALUE_ERROR_MESSAGE
 
     def test_ratio_default(self):
         # default is 'coerce'
@@ -1667,7 +1667,7 @@ class Test1m1sf0cfErrorHandlingCM:
     def test_min_raise(self):
         with pytest.raises(ValueError) as exc:
             self.target.group_min(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_min_coerce(self):
         target_mins = self.target.group_min(errors="coerce")
@@ -1676,18 +1676,18 @@ class Test1m1sf0cfErrorHandlingCM:
     def test_min_wrong_input(self):
         with pytest.raises(ValueError) as exc:
             self.target.group_min(errors="WRONG")
-        assert _INVALID_ERRORS_VALUE_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _INVALID_ERRORS_VALUE_ERROR_MESSAGE
 
     def test_min_default(self):
         # default is 'raise'
         with pytest.raises(ValueError) as exc:
             self.target.group_min(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_max_raise(self):
         with pytest.raises(ValueError) as exc:
             self.target.group_max(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_max_coerce(self):
         target_maxs = self.target.group_max(errors="coerce")
@@ -1696,18 +1696,18 @@ class Test1m1sf0cfErrorHandlingCM:
     def test_max_wrong_input(self):
         with pytest.raises(ValueError) as exc:
             self.target.group_max(errors="WRONG")
-        assert _INVALID_ERRORS_VALUE_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _INVALID_ERRORS_VALUE_ERROR_MESSAGE
 
     def test_max_default(self):
         # default is 'raise'
         with pytest.raises(ValueError) as exc:
             self.target.group_max(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_difference_raise(self):
         with pytest.raises(ValueError) as exc:
             self.target.difference(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_difference_coerce(self):
         target_differences = self.target.difference(errors="coerce")
@@ -1716,7 +1716,7 @@ class Test1m1sf0cfErrorHandlingCM:
     def test_difference_wrong_input(self):
         with pytest.raises(ValueError) as exc:
             self.target.difference(errors="WRONG")
-        assert _INVALID_ERRORS_VALUE_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _INVALID_ERRORS_VALUE_ERROR_MESSAGE
 
     def test_difference_default(self):
         # default is 'coerce'
@@ -1726,7 +1726,7 @@ class Test1m1sf0cfErrorHandlingCM:
     def test_ratio_raise(self):
         with pytest.raises(ValueError) as exc:
             self.target.ratio(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_ratio_coerce(self):
         target_ratio = self.target.ratio(errors="coerce")
@@ -1735,7 +1735,7 @@ class Test1m1sf0cfErrorHandlingCM:
     def test_ratio_wrong_input(self):
         with pytest.raises(ValueError) as exc:
             self.target.ratio(errors="WRONG")
-        assert _INVALID_ERRORS_VALUE_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _INVALID_ERRORS_VALUE_ERROR_MESSAGE
 
     def test_ratio_default(self):
         # default is 'coerce'
@@ -1758,7 +1758,7 @@ class Test2m1sf0cfErrorHandlingCM2:
     def test_min_raise(self):
         with pytest.raises(ValueError) as exc:
             self.target.group_min(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_min_coerce(self):
         target_mins = self.target.group_min(errors="coerce")
@@ -1767,18 +1767,18 @@ class Test2m1sf0cfErrorHandlingCM2:
     def test_min_wrong_input(self):
         with pytest.raises(ValueError) as exc:
             self.target.group_min(errors="WRONG")
-        assert _INVALID_ERRORS_VALUE_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _INVALID_ERRORS_VALUE_ERROR_MESSAGE
 
     def test_min_default(self):
         # default is 'raise'
         with pytest.raises(ValueError) as exc:
             self.target.group_min(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_max_raise(self):
         with pytest.raises(ValueError) as exc:
             self.target.group_max(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_max_coerce(self):
         target_maxs = self.target.group_max(errors="coerce")
@@ -1787,18 +1787,18 @@ class Test2m1sf0cfErrorHandlingCM2:
     def test_max_wrong_input(self):
         with pytest.raises(ValueError) as exc:
             self.target.group_max(errors="WRONG")
-        assert _INVALID_ERRORS_VALUE_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _INVALID_ERRORS_VALUE_ERROR_MESSAGE
 
     def test_max_default(self):
         # default is 'raise'
         with pytest.raises(ValueError) as exc:
             self.target.group_max(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_difference_raise(self):
         with pytest.raises(ValueError) as exc:
             self.target.difference(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_difference_coerce(self):
         target_differences = self.target.difference(errors="coerce")
@@ -1807,7 +1807,7 @@ class Test2m1sf0cfErrorHandlingCM2:
     def test_difference_wrong_input(self):
         with pytest.raises(ValueError) as exc:
             self.target.difference(errors="WRONG")
-        assert _INVALID_ERRORS_VALUE_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _INVALID_ERRORS_VALUE_ERROR_MESSAGE
 
     def test_difference_default(self):
         # default is 'coerce'
@@ -1817,7 +1817,7 @@ class Test2m1sf0cfErrorHandlingCM2:
     def test_ratio_raise(self):
         with pytest.raises(ValueError) as exc:
             self.target.ratio(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_ratio_coerce(self):
         target_ratio = self.target.ratio(errors="coerce")
@@ -1826,7 +1826,7 @@ class Test2m1sf0cfErrorHandlingCM2:
     def test_ratio_wrong_input(self):
         with pytest.raises(ValueError) as exc:
             self.target.ratio(errors="WRONG")
-        assert _INVALID_ERRORS_VALUE_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _INVALID_ERRORS_VALUE_ERROR_MESSAGE
 
     def test_ratio_default(self):
         # default is 'coerce'
@@ -1845,7 +1845,7 @@ class Test1m1sf0cfErrorHandlingSeries:
     def test_min_raise(self):
         with pytest.raises(ValueError) as exc:
             self.target.group_min(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_min_coerce(self):
         target_mins = self.target.group_min(errors="coerce")
@@ -1854,18 +1854,18 @@ class Test1m1sf0cfErrorHandlingSeries:
     def test_min_wrong_input(self):
         with pytest.raises(ValueError) as exc:
             self.target.group_min(errors="WRONG")
-        assert _INVALID_ERRORS_VALUE_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _INVALID_ERRORS_VALUE_ERROR_MESSAGE
 
     def test_min_default(self):
         # default is 'raise'
         with pytest.raises(ValueError) as exc:
             self.target.group_min(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_max_raise(self):
         with pytest.raises(ValueError) as exc:
             self.target.group_max(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_max_coerce(self):
         target_maxs = self.target.group_max(errors="coerce")
@@ -1874,18 +1874,18 @@ class Test1m1sf0cfErrorHandlingSeries:
     def test_max_wrong_input(self):
         with pytest.raises(ValueError) as exc:
             self.target.group_max(errors="WRONG")
-        assert _INVALID_ERRORS_VALUE_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _INVALID_ERRORS_VALUE_ERROR_MESSAGE
 
     def test_max_default(self):
         # default is 'raise'
         with pytest.raises(ValueError) as exc:
             self.target.group_max(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_difference_raise(self):
         with pytest.raises(ValueError) as exc:
             self.target.difference(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_difference_coerce(self):
         target_differences = self.target.difference(errors="coerce")
@@ -1894,7 +1894,7 @@ class Test1m1sf0cfErrorHandlingSeries:
     def test_difference_wrong_input(self):
         with pytest.raises(ValueError) as exc:
             self.target.difference(errors="WRONG")
-        assert _INVALID_ERRORS_VALUE_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _INVALID_ERRORS_VALUE_ERROR_MESSAGE
 
     def test_difference_default(self):
         # default is 'coerce'
@@ -1904,7 +1904,7 @@ class Test1m1sf0cfErrorHandlingSeries:
     def test_ratio_raise(self):
         with pytest.raises(ValueError) as exc:
             self.target.ratio(errors="raise")
-        assert _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _MF_CONTAINS_NON_SCALAR_ERROR_MESSAGE
 
     def test_ratio_coerce(self):
         target_ratio = self.target.ratio(errors="coerce")
@@ -1913,7 +1913,7 @@ class Test1m1sf0cfErrorHandlingSeries:
     def test_ratio_wrong_input(self):
         with pytest.raises(ValueError) as exc:
             self.target.ratio(errors="WRONG")
-        assert _INVALID_ERRORS_VALUE_ERROR_MESSAGE == exc.value.args[0]
+        assert exc.value.args[0] == _INVALID_ERRORS_VALUE_ERROR_MESSAGE
 
     def test_ratio_default(self):
         # default is 'coerce'

--- a/test/unit/metrics/test_metricframe_missing.py
+++ b/test/unit/metrics/test_metricframe_missing.py
@@ -42,9 +42,9 @@ def test_missing_sensitive_feature_combinations(metric_fn):
         mask_B = g_B == idx[1]
         mask = np.logical_and(mask_A, mask_B)
         if idx == ("bb", "x"):
-            assert sum(mask) == 0, "idx={0}".format(idx)
+            assert sum(mask) == 0, f"idx={idx}"
         else:
-            assert sum(mask) != 0, "idx={0}".format(idx)
+            assert sum(mask) != 0, f"idx={idx}"
             nxt = metric_fn(y_t[mask], y_p[mask])
             direct_eval.append(nxt)
     assert len(direct_eval) == 5
@@ -75,13 +75,13 @@ def test_missing_conditional_feature_combinations(metric_fn):
     )
 
     # Build all the expected values
-    overall = dict()
-    by_groups = dict()
+    overall = {}
+    by_groups = {}
     for i_A in np.unique(g_A):
         mask_A = g_A == i_A
 
-        overall_B = dict()
-        by_groups_B = dict()
+        overall_B = {}
+        by_groups_B = {}
         for i_B in np.unique(g_B):
             mask_B = g_B == i_B
 
@@ -91,7 +91,7 @@ def test_missing_conditional_feature_combinations(metric_fn):
             else:
                 assert sum(mask_A_B) != 0
                 overall_B[i_B] = metric_fn(y_t[mask_A_B], y_p[mask_A_B])
-                b_g = dict()
+                b_g = {}
                 for i_1 in np.unique(g_1):
                     mask = np.logical_and(mask_A_B, g_1 == i_1)
                     if sum(mask) != 0:

--- a/test/unit/metrics/test_metricframe_process_features.py
+++ b/test/unit/metrics/test_metricframe_process_features.py
@@ -141,7 +141,7 @@ class TestTwoFeatures:
         cols = ["Col Alpha", "Col Num"]
         a, b, y_true = self._get_raw_data()
 
-        rf = pd.DataFrame(data=zip(a, b), columns=cols)
+        rf = pd.DataFrame(data=zip(a, b, strict=False), columns=cols)
 
         target = _get_raw_MetricFrame()
         result = target._process_features("Ignored", rf, y_true)
@@ -150,7 +150,7 @@ class TestTwoFeatures:
     def test_unnamed_dataframe(self):
         a, b, y_true = self._get_raw_data()
 
-        rf = pd.DataFrame(data=zip(a, b))
+        rf = pd.DataFrame(data=zip(a, b, strict=False))
 
         target = _get_raw_MetricFrame()
         msg = "DataFrame column names must be strings. Name '0' is of type <class 'int'>"

--- a/test/unit/metrics/test_plot_metricframe.py
+++ b/test/unit/metrics/test_plot_metricframe.py
@@ -44,7 +44,7 @@ def general_wilson(p, n, digits=digits_of_precision, z=z_score):
     """
     denominator = 1 + z**2 / n
     centre_adjusted_probability = p + z * z / (2 * n)
-    adjusted_standard_deviation = np.sqrt((p * (1 - p) + z * z / (4 * n))) / np.sqrt(n)
+    adjusted_standard_deviation = np.sqrt(p * (1 - p) + z * z / (4 * n)) / np.sqrt(n)
     lower_bound = (centre_adjusted_probability - z * adjusted_standard_deviation) / denominator
     upper_bound = (centre_adjusted_probability + z * adjusted_standard_deviation) / denominator
     return np.array([round(lower_bound, digits), round(upper_bound, digits)])

--- a/test/unit/metrics/test_plot_metricframe.py
+++ b/test/unit/metrics/test_plot_metricframe.py
@@ -1,6 +1,8 @@
 # Copyright (c) Fairlearn contributors.
 # Licensed under the MIT License.
 
+from contextlib import suppress
+
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
@@ -430,8 +432,6 @@ def test_explicit_conf_intervals_not_overridden_by_auto(monkeypatch):
         return {}
 
     monkeypatch.setattr("fairlearn.metrics._plotter._get_conf_intervals_from_metric_frame", spy)
-    try:
+    with suppress(KeyError, AttributeError):
         plot_metric_frame(mf, metrics=["accuracy_score"], conf_intervals=["custom_ci"])
-    except (KeyError, AttributeError):
-        pass
     assert len(calls) == 0, "auto-detect must not fire when conf_intervals is explicitly passed"

--- a/test/unit/metrics/test_plot_roc_curve_by_group.py
+++ b/test/unit/metrics/test_plot_roc_curve_by_group.py
@@ -65,7 +65,7 @@ class TestPlotRocCurveByGroup:
 
     def test_draws_curve_per_group_plus_overall_and_chance(self, two_sensitive_features):
         ax = plot_roc_curve_by_group(y_t, y_score, sensitive_features=two_sensitive_features)
-        n_groups = len(set(zip(g_1, g_2)))
+        n_groups = len(set(zip(g_1, g_2, strict=False)))
         # One ROC curve per subgroup, plus the overall curve and the chance line.
         assert len(ax.get_lines()) == n_groups + 2
 
@@ -77,7 +77,7 @@ class TestPlotRocCurveByGroup:
             plot_overall=False,
             plot_chance_level=False,
         )
-        assert len(ax.get_lines()) == len(set(zip(g_1, g_2)))
+        assert len(ax.get_lines()) == len(set(zip(g_1, g_2, strict=False)))
 
     def test_chance_level_label(self):
         ax = plot_roc_curve_by_group(y_t, y_score, sensitive_features=g_1)
@@ -125,7 +125,7 @@ class TestPlotRocCurveByGroup:
             plot_overall=False,
             plot_chance_level=False,
         )
-        assert len(ax.get_lines()) == len(set(zip(g_1, g_2)))
+        assert len(ax.get_lines()) == len(set(zip(g_1, g_2, strict=False)))
 
     def test_sets_title(self):
         ax = plot_roc_curve_by_group(y_t, y_score, sensitive_features=g_1, title="My ROC")
@@ -165,7 +165,7 @@ class TestPlotRocCurveByGroup:
             plot_overall=False,
             plot_chance_level=False,
         )
-        assert len(ax.get_lines()) == len(set(zip(g_1, g_2)))
+        assert len(ax.get_lines()) == len(set(zip(g_1, g_2, strict=False)))
 
     def test_single_subgroup(self):
         sensitive_features = np.zeros_like(y_t)

--- a/test/unit/metrics/test_selection_rate.py
+++ b/test/unit/metrics/test_selection_rate.py
@@ -10,7 +10,7 @@ from fairlearn.metrics._base_metrics import _EMPTY_INPUT_PREDICTIONS_ERROR_MESSA
 def test_selection_rate_empty():
     with pytest.raises(ValueError) as exc:
         _ = metrics.selection_rate([], [])
-    assert _EMPTY_INPUT_PREDICTIONS_ERROR_MESSAGE == exc.value.args[0]
+    assert exc.value.args[0] == _EMPTY_INPUT_PREDICTIONS_ERROR_MESSAGE
 
 
 @pytest.mark.parametrize(

--- a/test/unit/postprocessing/conftest.py
+++ b/test/unit/postprocessing/conftest.py
@@ -33,10 +33,10 @@ X_ex = np.stack(
 )
 
 sensitive_feature_names_ex1 = ["A", "B", "C"]
-sensitive_features_ex1 = np.array([x for x in "AAAAAAABBBBBBBCCCCCC"]).reshape(-1, 1)
+sensitive_features_ex1 = np.array(list("AAAAAAABBBBBBBCCCCCC")).reshape(-1, 1)
 
 sensitive_feature_names_ex2 = ["x", "Y"]
-sensitive_features_ex2 = np.array([x for x in "xxxYYYYxYYYYYxYYYYYY"]).reshape(-1, 1)
+sensitive_features_ex2 = np.array(list("xxxYYYYxYYYYYxYYYYYY")).reshape(-1, 1)
 
 labels_ex = np.array([int(x) for x in "01101000010111000111"])
 degenerate_labels_ex = np.array([int(x) for x in "00000000000000000000"])
@@ -104,12 +104,10 @@ def is_invalid_transformation(**kwargs):
 
     # Skip combinations where the multi-column sensitive features would have to be compressed
     # into a one-dimensional data structure.
-    if (sensitive_features == sensitive_features_ex3).all() and sensitive_feature_transform in [
-        ensure_list_1d,
-        ensure_series,
-    ]:
-        return True
-    return False
+    return bool(
+        (sensitive_features == sensitive_features_ex3).all()
+        and sensitive_feature_transform in [ensure_list_1d, ensure_series]
+    )
 
 
 @pytest.fixture(params=candidate_A_transforms)

--- a/test/unit/postprocessing/test_threshold_optimization.py
+++ b/test/unit/postprocessing/test_threshold_optimization.py
@@ -243,21 +243,21 @@ def test_threshold_optimization_demographic_parity(
     assert np.isclose(
         value_for_less_than_2_5, prob_pred([sensitive_feature_names_ex1[0]], [2.499])
     )
-    assert 0 == prob_pred([sensitive_feature_names_ex1[0]], [2.5])
-    assert 0 == prob_pred([sensitive_feature_names_ex1[0]], [100])
+    assert prob_pred([sensitive_feature_names_ex1[0]], [2.5]) == 0
+    assert prob_pred([sensitive_feature_names_ex1[0]], [100]) == 0
 
     # sensitive feature value B
     value_for_less_than_0_5 = 0.00133333333333
     assert np.isclose(value_for_less_than_0_5, prob_pred([sensitive_feature_names_ex1[1]], [0]))
     assert np.isclose(value_for_less_than_0_5, prob_pred([sensitive_feature_names_ex1[1]], [0.5]))
-    assert 1 == prob_pred([sensitive_feature_names_ex1[1]], [0.51])
-    assert 1 == prob_pred([sensitive_feature_names_ex1[1]], [1])
-    assert 1 == prob_pred([sensitive_feature_names_ex1[1]], [100])
+    assert prob_pred([sensitive_feature_names_ex1[1]], [0.51]) == 1
+    assert prob_pred([sensitive_feature_names_ex1[1]], [1]) == 1
+    assert prob_pred([sensitive_feature_names_ex1[1]], [100]) == 1
 
     # sensitive feature value C
     value_between_0_5_and_1_5 = 0.608
-    assert 0 == prob_pred([sensitive_feature_names_ex1[2]], [0])
-    assert 0 == prob_pred([sensitive_feature_names_ex1[2]], [0.5])
+    assert prob_pred([sensitive_feature_names_ex1[2]], [0]) == 0
+    assert prob_pred([sensitive_feature_names_ex1[2]], [0.5]) == 0
     assert np.isclose(
         value_between_0_5_and_1_5, prob_pred([sensitive_feature_names_ex1[2]], [0.51])
     )
@@ -265,8 +265,8 @@ def test_threshold_optimization_demographic_parity(
     assert np.isclose(
         value_between_0_5_and_1_5, prob_pred([sensitive_feature_names_ex1[2]], [1.5])
     )
-    assert 1 == prob_pred([sensitive_feature_names_ex1[2]], [1.51])
-    assert 1 == prob_pred([sensitive_feature_names_ex1[2]], [100])
+    assert prob_pred([sensitive_feature_names_ex1[2]], [1.51]) == 1
+    assert prob_pred([sensitive_feature_names_ex1[2]], [100]) == 1
 
     # Assert Demographic Parity actually holds
     predictions_by_sensitive_feature = _get_predictions_by_sensitive_feature(

--- a/test/unit/preprocessing/test_preprocessing_fairness.py
+++ b/test/unit/preprocessing/test_preprocessing_fairness.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from test.utils import DATA_HOME
-from typing import Callable, Union
 
 import numpy as np
 import pandas as pd
@@ -20,7 +20,7 @@ from fairlearn.metrics import (
 )
 from fairlearn.preprocessing import CorrelationRemover, PrototypeRepresentationLearner
 
-PreprocessingAlgorithm = Union[CorrelationRemover, PrototypeRepresentationLearner]
+PreprocessingAlgorithm = CorrelationRemover | PrototypeRepresentationLearner
 
 
 @dataclass(frozen=True)

--- a/test/unit/reductions/conftest.py
+++ b/test/unit/reductions/conftest.py
@@ -7,6 +7,4 @@ from test.unit.input_convertors import ensure_list, ensure_series
 def is_invalid_transformation(**kwargs):
     A_two_dim = kwargs["A_two_dim"]
     transform = kwargs["transformA"]
-    if A_two_dim and transform in [ensure_list, ensure_series]:
-        return True
-    return False
+    return bool(A_two_dim and transform in [ensure_list, ensure_series])

--- a/test/unit/reductions/data_generators.py
+++ b/test/unit/reductions/data_generators.py
@@ -25,7 +25,7 @@ def loan_scenario_generator(
             n_curr = class_sizes[ib][sf]
             f_curr = success_fractions[ib][sf]
 
-            for i in range(n_curr):
+            for _i in range(n_curr):
                 IB.append(ib)
                 SF.append(sf)
                 flip = random.random()

--- a/test/unit/reductions/exponentiated_gradient/test_exponentiatedgradient_arguments.py
+++ b/test/unit/reductions/exponentiated_gradient/test_exponentiatedgradient_arguments.py
@@ -197,7 +197,7 @@ class TestExponentiatedGradientArguments:
         )
         with pytest.raises(ValueError) as execInfo:
             expgrad.fit(X, y, sensitive_features=(A))
-        assert _LABELS_NOT_0_1_ERROR_MESSAGE == execInfo.value.args[0]
+        assert execInfo.value.args[0] == _LABELS_NOT_0_1_ERROR_MESSAGE
 
     def test_sample_weights_argument(self):
         estimator = Pipeline(

--- a/test/unit/reductions/exponentiated_gradient/test_exponentiatedgradient_smoke.py
+++ b/test/unit/reductions/exponentiated_gradient/test_exponentiatedgradient_smoke.py
@@ -827,16 +827,13 @@ class TestExponentiatedGradientSmoke:
 
     def run_smoke_test_binary_classification(self, data, flipped=False):
         learner = LeastSquaresBinaryClassifierLearner()
-        if "ratio" in data.keys():
+        if "ratio" in data:
             disparity_moment = data["constraint_class"](
                 ratio_bound_slack=data["eps"], ratio_bound=data["ratio"]
             )
         else:
             disparity_moment = data["constraint_class"](difference_bound=data["eps"])
-        if "objective" in data.keys():
-            objective_moment = deepcopy(data["objective"])
-        else:
-            objective_moment = ErrorRate()
+        objective_moment = deepcopy(data["objective"]) if "objective" in data else ErrorRate()
 
         # Create Exponentiated Gradient object with a copy of the constraint.
         # The original disparity_moment object is used for validation, so the
@@ -901,7 +898,7 @@ class TestExponentiatedGradientSmoke:
         disparity_moment.load_data(X, y, sensitive_features=A)
         for i in range(len(expgrad.predictors_)):
 
-            def Q(X):
+            def Q(X, i=i):
                 return expgrad._pmf_predict(X)[i]
 
             default_objective = MeanLoss(data["loss"])
@@ -1016,7 +1013,7 @@ class TestExponentiatedGradientSmoke:
             expgrad.fit(X, y, sensitive_features=A)
 
             # select probability of predicting 1
-            def Q(X):
+            def Q(X, expgrad=expgrad):
                 return expgrad._pmf_predict(X)[:, 1]
 
             constraints_eval = deepcopy(constraints_moment)

--- a/test/unit/reductions/exponentiated_gradient/test_lagrangian.py
+++ b/test/unit/reductions/exponentiated_gradient/test_lagrangian.py
@@ -118,7 +118,7 @@ def test_lagrangian_eval(eps, Constraints, use_Q_callable, opt_lambda):
         )
     ).all()
 
-    assert L == pytest.approx(L_expected, abs=_PRECISION)
+    assert pytest.approx(L_expected, abs=_PRECISION) == L
     assert L_high == pytest.approx(L_high_expected, abs=_PRECISION)
     assert error == 0.25
     assert (gamma == best_h_gamma).all()
@@ -225,10 +225,7 @@ def test_objective_constraints_compatibility(Constraints, Objective):
     else:
         constraints = Constraints()
 
-    if issubclass(Objective, LossMoment):
-        objective = Objective(ZeroOneLoss())
-    else:
-        objective = Objective()
+    objective = Objective(ZeroOneLoss()) if issubclass(Objective, LossMoment) else Objective()
 
     if objective._moment_type() != constraints._moment_type():
         with pytest.raises(ValueError) as execInfo:
@@ -274,10 +271,7 @@ def get_lambda_new_weights_and_labels(constraints, X, y, A):
     objective.load_data(X, y, sensitive_features=A)
     signed_weights = objective.signed_weights() + constraints.signed_weights(lambda_vec)
 
-    if isinstance(constraints, LossMoment):
-        redY = y
-    else:  # classification
-        redY = 1 * (signed_weights > 0)
+    redY = y if isinstance(constraints, LossMoment) else 1 * (signed_weights > 0)
     redW = signed_weights.abs()
     redW = y.shape[0] * redW / redW.sum()
     return lambda_vec, redW, redY

--- a/test/unit/reductions/grid_search/test_grid_search_arguments.py
+++ b/test/unit/reductions/grid_search/test_grid_search_arguments.py
@@ -225,7 +225,9 @@ class ArgumentTests:
         log_records = caplog.get_records("call")
         dimension_log_record = log_records[0]
         size_log_record = log_records[1]
-        if isinstance(self.disparity_criterion, EqualizedOdds):
+        # Kept as if/else: each branch has an explanatory comment that a ternary
+        # would drop.
+        if isinstance(self.disparity_criterion, EqualizedOdds):  # noqa: SIM108
             # not every label occurs with every group
             grid_dimensions = 10
         else:
@@ -423,7 +425,7 @@ class ConditionalOpportunityTests(ArgumentTests):
         with pytest.raises(ValueError) as execInfo:
             gs.fit(transformX(X), transformY(Y), sensitive_features=transformA(A))
 
-        assert _LABELS_NOT_0_1_ERROR_MESSAGE == execInfo.value.args[0]
+        assert execInfo.value.args[0] == _LABELS_NOT_0_1_ERROR_MESSAGE
 
     @pytest.mark.parametrize("transformA", candidate_A_transforms)
     @pytest.mark.parametrize("transformY", candidate_Y_transforms)
@@ -443,7 +445,7 @@ class ConditionalOpportunityTests(ArgumentTests):
         with pytest.raises(ValueError) as execInfo:
             gs.fit(transformX(X), transformY(Y), sensitive_features=transformA(A))
 
-        assert _LABELS_NOT_0_1_ERROR_MESSAGE == execInfo.value.args[0]
+        assert execInfo.value.args[0] == _LABELS_NOT_0_1_ERROR_MESSAGE
 
 
 # Set up Pipeline estimator

--- a/test/unit/reductions/moments/test_moments_equalized_odds.py
+++ b/test/unit/reductions/moments/test_moments_equalized_odds.py
@@ -37,7 +37,7 @@ def test_construct_and_load():
     # Examine the tags DF
     assert eqo.tags["label"].equals(pd.Series(Y))
     assert eqo.tags["group_id"].equals(pd.Series(A))
-    expected_tags_event = ["label={0}".format(a) for a in Y]
+    expected_tags_event = [f"label={a}" for a in Y]
     assert np.array_equal(expected_tags_event, eqo.tags["event"])
 
     # Examine the index MultiIndex

--- a/test_othermlpackages/adversarial_fairness.py
+++ b/test_othermlpackages/adversarial_fairness.py
@@ -85,7 +85,7 @@ def test_examples():
     # EXAMPLE 2
     class PredictorModel(torch.nn.Module):
         def __init__(self):
-            super(PredictorModel, self).__init__()
+            super().__init__()
             self.layers = torch.nn.Sequential(
                 torch.nn.Linear(X_prep_train.shape[1], 200),
                 torch.nn.LeakyReLU(),

--- a/test_othermlpackages/package_test_common.py
+++ b/test_othermlpackages/package_test_common.py
@@ -70,7 +70,7 @@ def run_expgrad_classification(estimator, moment):
     gamma_mitigated = verification_moment.gamma(lambda x: expgrad.predict(x))
 
     for idx in gamma_mitigated.index:
-        assert abs(gamma_mitigated[idx]) <= abs(gamma_unmitigated[idx]), "Checking {0}".format(idx)
+        assert abs(gamma_mitigated[idx]) <= abs(gamma_unmitigated[idx]), f"Checking {idx}"
 
 
 def run_gridsearch_classification(estimator, moment):
@@ -92,7 +92,7 @@ def run_gridsearch_classification(estimator, moment):
     gamma_mitigated = verification_moment.gamma(lambda x: gs.predict(x))
 
     for idx in gamma_mitigated.index:
-        assert abs(gamma_mitigated[idx]) <= abs(gamma_unmitigated[idx]), "Checking {0}".format(idx)
+        assert abs(gamma_mitigated[idx]) <= abs(gamma_unmitigated[idx]), f"Checking {idx}"
 
 
 def run_thresholdoptimizer_classification(estimator):

--- a/test_othermlpackages/test_tensorflow.py
+++ b/test_othermlpackages/test_tensorflow.py
@@ -14,8 +14,10 @@ from . import package_test_common as ptc
 tf = pytest.importorskip("tensorflow")
 
 
-def create_model(X, y, loss="binary_crossentropy", layers=[12, 8]):
+def create_model(X, y, loss="binary_crossentropy", layers=None):
     # create model
+    if layers is None:
+        layers = [12, 8]
     n_features_in = X.shape[1]
     inp = Input(shape=(n_features_in,))
 


### PR DESCRIPTION
## Description

Modernizes the Ruff linting setup.

- Bump Ruff from `0.4.5` to `0.15.20`, kept in sync across `requirements-dev.txt`, `requirements-min.txt`, and the `astral-sh/ruff-pre-commit` hook.
- Enable four additional lint rule families in `[tool.ruff.lint].select`: `UP` (pyupgrade), `B` (flake8-bugbear), `SIM` (flake8-simplify), and `C4` (flake8-comprehensions), alongside the existing `E4`/`E7`/`E9`/`F`/`G`/`NPY201`/`D`. Import sorting (`I`) is intentionally **not** enabled — isort still owns imports.
- Apply the resulting Ruff autofixes plus a small number of manual fixes where no safe autofix exists: modernized syntax/f-strings, `collections.abc` imports, comprehension simplifications, `zip(strict=False)`, `raise ... from None` on optional-dependency re-raises, `warnings.warn(..., stacklevel=2)`, and mutable-default / loop-closure fixes.
- Add a `B018` per-file-ignore for `examples/*` (bare expressions there are intentional sphinx-gallery cell output) and a few targeted `# noqa: SIM108` where an `if`/`else` preserves an explanatory comment or an `F841` waiver.
- Also ignore the local `.impeccable/` tooling directory in `.gitignore`.

Black and isort configuration and pins are unchanged, and no formatter was run — formatting stays owned by Black/isort. `ruff check` is clean and `./test/unit` passes (6837 passed, 328 skipped, 9 xfailed, 6 xpassed).

## Tests
- [x] no new tests required
- [ ] new tests added
- [x] existing tests adjusted <!-- lint autofixes touched a few test files; behavior unchanged -->

## Documentation
- [x] no documentation changes needed
- [ ] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
N/A — no visualization or website changes.
