### PR TITLE
MNT modernize GitHub Actions to current stable major versions

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
           echo "TAGGED_MILESTONE=${{ github.event.pull_request.milestone.title }}" >> $GITHUB_ENV
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: '0'
       - name: Check the changelog entry

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -18,19 +18,19 @@ jobs:
     # .pre-commit-config.yaml
     runs-on: ${{ inputs.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: psf/black@26.3.1
   ruff:
     runs-on: ${{ inputs.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
+      - uses: actions/checkout@v7
+      - uses: astral-sh/ruff-action@v4
   build-wheel:
     runs-on: ${{ inputs.os }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
     - name: Install build

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/ruff-action@v4
+      - uses: astral-sh/ruff-action@v4.1.0
   build-wheel:
     runs-on: ${{ inputs.os }}
     steps:

--- a/.github/workflows/release-wheel.yml
+++ b/.github/workflows/release-wheel.yml
@@ -19,9 +19,9 @@ jobs:
   build-wheel:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
     - name: Update pip and build
@@ -31,7 +31,7 @@ jobs:
     - name: Build wheels
       run: python ./scripts/build_wheels.py --version-filename $VERSION_FILE_NAME
     - name: Save wheels to artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: env.WHEEL_ARTIFACT
         path: dist/
@@ -44,9 +44,9 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-14]
         python-version: ['3.11', '3.12', '3.13', '3.14']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Remove Fairlearn source directory
@@ -54,7 +54,7 @@ jobs:
       with:
         path: fairlearn
     - name: Download wheel artifact
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v8
       with:
         name: env.WHEEL_ARTIFACT
     - name: Install Fairlearn from wheel
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download wheel artifact
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v8
       with:
         name: env.WHEEL_ARTIFACT
         path: dist

--- a/.github/workflows/test-all-deps.yml
+++ b/.github/workflows/test-all-deps.yml
@@ -26,7 +26,7 @@ jobs:
     env:
       MPLBACKEND: Agg
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Get commit date
         id: get_date
         shell: bash
@@ -36,11 +36,11 @@ jobs:
           AGE=$((CURRENT_DATE - COMMIT_DATE))
           echo "AGE=$AGE" >> $GITHUB_OUTPUT
           echo "AGE in seconds: $AGE"
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python }}
       - name: Cache openml datasets
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ env.DATA_HOME }}
           key: ${{ runner.os }}-openml-datasets-v1
@@ -55,7 +55,7 @@ jobs:
           --ignore=test/install --cov=fairlearn --cov-report=xml -vl test/
       - name: Upload coverage reports to Codecov with GitHub Action
         if: ${{ (inputs.codeCovPython == inputs.python) && (steps.get_date.outputs.AGE < 172800) }} # 172800 = 48 * 3600
-        uses: codecov/codecov-action@v4.2.0
+        uses: codecov/codecov-action@v7
         with:
           env_vars: OS,PYTHON
           fail_ci_if_error: true

--- a/.github/workflows/test-min-deps.yml
+++ b/.github/workflows/test-min-deps.yml
@@ -25,7 +25,7 @@ jobs:
     env:
       MPLBACKEND: Agg
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Get commit date
         id: get_date
         shell: bash
@@ -35,11 +35,11 @@ jobs:
           AGE=$((CURRENT_DATE - COMMIT_DATE))
           echo "AGE=$AGE" >> $GITHUB_OUTPUT
           echo "AGE in seconds: $AGE"
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python }}
       - name: Cache openml datasets
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ env.DATA_HOME }}
           key: ${{ runner.os }}-openml-datasets-v1
@@ -54,7 +54,7 @@ jobs:
           --ignore=test/install --cov=fairlearn --cov-report=xml -vl test/
       - name: Upload coverage reports to Codecov with GitHub Action
         if: ${{ (inputs.codeCovPython == inputs.python) && (steps.get_date.outputs.AGE < 172800) }} # 172800 = 48 * 3600
-        uses: codecov/codecov-action@v4.2.0
+        uses: codecov/codecov-action@v7
         with:
           env_vars: OS,PYTHON
           fail_ci_if_error: true

--- a/.github/workflows/test-minimal-deps.yml
+++ b/.github/workflows/test-minimal-deps.yml
@@ -26,7 +26,7 @@ jobs:
     # we only upload results if the current commit is under 48 hours old
     runs-on: ${{ inputs.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Get commit date
         id: get_date
         shell: bash
@@ -36,11 +36,11 @@ jobs:
           AGE=$((CURRENT_DATE - COMMIT_DATE))
           echo "AGE=$AGE" >> $GITHUB_OUTPUT
           echo "AGE in seconds: $AGE"
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python }}
       - name: Cache openml datasets
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ env.DATA_HOME }}
           key: ${{ runner.os }}-openml-datasets-v1
@@ -51,7 +51,7 @@ jobs:
       - run: pytest --cov=fairlearn --cov-report=xml test/install
       - name: Upload coverage reports to Codecov with GitHub Action
         if: ${{ (inputs.codeCovPython == inputs.python) && (steps.get_date.outputs.AGE < 172800) }} # 172800 = 48 * 3600
-        uses: codecov/codecov-action@v4.2.0
+        uses: codecov/codecov-action@v7
         with:
           env_vars: OS,PYTHON
           fail_ci_if_error: true

--- a/.github/workflows/test-other-ml.yml
+++ b/.github/workflows/test-other-ml.yml
@@ -23,12 +23,12 @@ jobs:
       baseDir: test_othermlpackages
       condaEnv: test-conda-env
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python }}
       - name: Cache openml datasets
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ env.DATA_HOME }}
           key: ${{ runner.os }}-openml-datasets-v1
@@ -68,7 +68,7 @@ jobs:
         name: Run ${{matrix.mlpackage}} tests
       - name: Upload coverage reports to Codecov with GitHub Action
         if: ${{ (inputs.codeCovPython == inputs.python) && (steps.get_date.outputs.AGE < 172800) }} # 172800 = 48 * 3600
-        uses: codecov/codecov-action@v4.2.0
+        uses: codecov/codecov-action@v7
         with:
           env_vars: OS,PYTHON
           fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,9 @@ docbuild/
 # IntelliJ
 /.idea
 
+# Impeccable (GitHub Copilot skill) cache
+.impeccable/
+
 # OSX directory info files
 .DS_Store
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes. -->
Modernize the GitHub Actions used across `.github/workflows/`. Every action is bumped to its current stable major, and the archived Ruff action is replaced with the official one.

**Actions bumped:**
- `chartboost/ruff-action@v1` (archived) → `astral-sh/ruff-action@v4` — v4 still runs `ruff check` by default, so it is a drop-in replacement.
- `codecov/codecov-action@v4.2.0` → `@v7`
- `actions/checkout@v4` → `@v7`
- `actions/setup-python@v5` → `@v6`
- `actions/cache@v4` → `@v6`
- `actions/upload-artifact@v4` → `@v7`
- `actions/download-artifact@v4.1.7` → `@v8`

**Notes:**
- The major jumps are primarily Node.js 24 runtime updates that require an Actions runner >= 2.327.1, which GitHub-hosted runners satisfy.
- Codecov v5+ deprecated `file`/`plugin` in favor of `files`/`plugins`. The workflows already use `files`, and `env_vars`/`flags`/`name`/`fail_ci_if_error`/`verbose` remain valid, so no input changes were required.
- `psf/black`, `JesseTG/rm`, and `pypa/gh-action-pypi-publish@release/v1` are intentionally left unchanged.
- Also adds `.impeccable/` (a local GitHub Copilot skill cache) to `.gitignore`.

## Tests
- [x] no new tests required

## Documentation
- [x] no documentation changes needed