### PR TITLE
DOC add versionadded for postprocessing API

### DIFF
--- a/fairlearn/postprocessing/_interpolated_thresholder.py
+++ b/fairlearn/postprocessing/_interpolated_thresholder.py
@@ -27,6 +27,8 @@ class InterpolatedThresholder(MetaEstimatorMixin, BaseEstimator):
 
     Read more in the :ref:`User Guide <postprocessing>`.
 
+    .. versionadded:: 0.5.0
+
     Parameters
     ----------
     estimator :

--- a/fairlearn/postprocessing/_plotting.py
+++ b/fairlearn/postprocessing/_plotting.py
@@ -91,6 +91,8 @@ def plot_threshold_optimizer(threshold_optimizer: ThresholdOptimizer, ax=None, s
     objects that have their constraint set to :code:`equalized_odds` this will
     result in a ROC curve plot.
 
+    .. versionadded:: 0.4.5
+
     Parameters
     ----------
     threshold_optimizer : :class:`.ThresholdOptimizer`

--- a/fairlearn/postprocessing/_threshold_optimizer.py
+++ b/fairlearn/postprocessing/_threshold_optimizer.py
@@ -202,6 +202,8 @@ class ThresholdOptimizer(MetaEstimatorMixin, BaseEstimator):
         all the sensitive groups is at most `tol`. If `None`, the constraint is not relaxed.
         Relaxation is not supported for `equalized_odds`.
 
+        .. versionadded:: 0.13.0
+
 
     Notes
     -----


### PR DESCRIPTION
## Summary
- Add missing `.. versionadded::` directives for postprocessing public API

## Changes
- `plot_threshold_optimizer` → 0.4.5
- `InterpolatedThresholder` → 0.5.0
- `ThresholdOptimizer.tol` → 0.13.0

## Why
Continues #855 / #950. Versions taken from first release tags that contain each API.

## Tests
- Docs only, no code changes