### PR TITLE
MNT: Raise ValueError when X is not 2D in BackendEngine

### DIFF
--- a/fairlearn/adversarial/_backend_engine.py
+++ b/fairlearn/adversarial/_backend_engine.py
@@ -33,7 +33,15 @@ class BackendEngine:
         """
         self.base = base
 
-        n_X_features = X.shape[1]  # FIXME: what if X.ndim > 2?
+        if X.ndim != 2:
+            raise ValueError(
+                "Expected X to be 2-dimensional (n_samples, n_features), "
+                f"but got an array with X.ndim={X.ndim}. Higher-dimensional "
+                "inputs (e.g. image batches) are not currently supported "
+                "and would otherwise silently mis-size the predictor/"
+                "adversary input layers."
+            )
+        n_X_features = X.shape[1]
         n_Y_features = base._y_transform.n_features_out_
         n_A_features = base._sf_transform.n_features_out_
 


### PR DESCRIPTION
## Description
`BackendEngine.__init__` used `X.shape[1]` to compute `n_X_features` without
checking `X.ndim` first (see the `# FIXME: what if X.ndim > 2?` comment).
If `X` had more than 2 dimensions (e.g. an image batch shaped
`(n_samples, height, width, channels)`), the code did not error — it just
computed the wrong `n_X_features`, which silently mis-sized the
predictor/adversary input layers downstream.

This PR adds an explicit `X.ndim != 2` check that raises a clear `ValueError`
instead, so the failure is loud and immediate rather than a silent
mis-sizing bug.

Related to fairlearn/fairlearn#1656.