### PR TITLE
MNT: Enforce 2D input contract in AdversarialFairness predict()

### DIFF
--- a/fairlearn/adversarial/_adversarial_mitigation.py
+++ b/fairlearn/adversarial/_adversarial_mitigation.py
@@ -594,7 +594,6 @@ class _AdversarialFairness(BaseEstimator):
             accept_sparse=False,
             accept_large_sparse=False,
             dtype=float,
-            allow_nd=True,
             reset=False,
         )
         y_pred = self.backendEngine_.evaluate(X)


### PR DESCRIPTION
_raw_predict's docstring documents X as a "Two-dimensional numpy array",
but validate_data was called with allow_nd=True, silently permitting
higher-dimensional input to reach the trained backend after fit(). This
removes the override so validate_data enforces the documented 2D
contract, consistent with the fit-time check added for #1656.

Related to fairlearn/fairlearn#1672.