### PR TITLE
DOC fix double-space typos in prose across docs and docstrings

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -23,7 +23,7 @@ Why not just ignore the sensitive features?
     Even if the model is not provided with race as a feature, the model will
     pick up on it implicitly via the ZIP code (and other features).
     Worse, without having the race available in the dataset, it is hard to
-    assess the  model's impact across different groups defined by race or by
+    assess the model's impact across different groups defined by race or by
     race intersected with other demographic features.
 
 The model is unfair because the data are biased. Isn't it better to get better data?
@@ -57,7 +57,7 @@ The model is unfair because the data are biased. Isn't it better to get better d
 
 Why am I seeing fairness issues, even though my data are reflective of the general population?
     Machine learning models often perform poorly for subgroups which are
-    poorly  represented.
+    poorly represented.
     What constitutes poor representation is context specific, and may well be
     affected by historical misrepresentation (consider the example above, of a
     company which had previously hired few women).

--- a/docs/user_guide/datasets/diabetes_hospital_data.rst
+++ b/docs/user_guide/datasets/diabetes_hospital_data.rst
@@ -12,7 +12,7 @@ Each record represents the hospital admission record for a patient diagnosed wit
 diabetes whose stay lasted between one to fourteen days. Also, laboratory tests were
 performed and medications were administered during the encounter. The features
 describing each encounter include demographics, diagnoses, diabetic medications, number
-of visits in the year preceding  the encounter, and payer information, as well as
+of visits in the year preceding the encounter, and payer information, as well as
 whether the patient was readmitted after release, and whether the readmission occurred
 within 30 days of the release.
 

--- a/docs/user_guide/fairness_in_machine_learning.rst
+++ b/docs/user_guide/fairness_in_machine_learning.rst
@@ -125,7 +125,7 @@ exploration below on construct validity.
 We note that both play an important role in understanding fairness in sociotechnical contexts.
 With that said, :footcite:cts:`jacobs2021measurement` offers a fairness-oriented conceptualization of construct validity, that
 is helpful in thinking about fairness in sociotechnical contexts.
-We capture the idea in seven key parts that when combined  can serve as a framework for analyzing an AI task and attempting to establish construct validity:
+We capture the idea in seven key parts that when combined can serve as a framework for analyzing an AI task and attempting to establish construct validity:
 
 1. **Face validity** – On the surface, how plausible do the measurements produced by the measurement model look?
 

--- a/fairlearn/datasets/_fetch_boston.py
+++ b/fairlearn/datasets/_fetch_boston.py
@@ -38,7 +38,7 @@ def fetch_boston(*, cache=True, data_home=None, as_frame=True, return_X_y=False,
     to look out for and a column that is a derived from the proportion of
     people with a black skin color that live in a neighborhood (B)
     :footcite:`carlisle2019racist`.
-    See the references at the bottom for  more detailed information.
+    See the references at the bottom for more detailed information.
 
     Here's a table of all the variables in order:
 


### PR DESCRIPTION
## Summary

Fixes 5 accidental double spaces in prose sentences across docs and source docstrings.
Found by automated scan of all `.rst` and `.py` files, filtering out RST table
alignment lines.

- docs/faq.rst: "assess the  model's" → "assess the model's"
- docs/faq.rst: "poorly  represented" → "poorly represented"
- docs/user_guide/fairness_in_machine_learning.rst: "combined  can serve" → "combined can serve"
- docs/user_guide/datasets/diabetes_hospital_data.rst: "preceding  the encounter" → "preceding the encounter"
- fairlearn/datasets/_fetch_boston.py: "for  more detailed" → "for more detailed"

No behavior change, prose only.

## Type of change
Documentation fix

## Related issues/PRs
Fixes #ΑΡΙΘΜΟΣ_ISSUE