### PR TITLE
DOC British spellings in source and docs should use American English

### DIFF
--- a/docs/user_guide/installation_and_version_guide/v0.4.4.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.4.4.rst
@@ -1,7 +1,7 @@
 v0.4.4
 ======
 
-* Remove :code:`GroupMetricSet` in favour of a :code:`create_group_metric_set`
+* Remove :code:`GroupMetricSet` in favor of a :code:`create_group_metric_set`
   method
 * Add basic support for multiple sensitive features
 * Refactor :class:`.ThresholdOptimizer` to use mixins from scikit-learn

--- a/fairlearn/metrics/_plotter.py
+++ b/fairlearn/metrics/_plotter.py
@@ -253,7 +253,7 @@ def plot_metric_frame(
 
     df = metric_frame.by_group
 
-    # Normalise to DataFrame so column iteration works for single-metric
+    # Normalize to DataFrame so column iteration works for single-metric
     # frames where by_group is a Series.
     if isinstance(df, pd.Series):
         df = df.to_frame()


### PR DESCRIPTION
Two places use British spellings inconsistently with the rest of the
codebase (which uses American English throughout):

- fairlearn/metrics/_plotter.py line 256: "Normalise" → "Normalize"
- docs/user_guide/installation_and_version_guide/v0.4.4.rst line 4: "favour" → "favor"

Found by automated scan of all .py and .rst files for British/American
spelling inconsistencies. No behavior change. I have a fix ready and
would like to open a PR once assigned.