### PR TITLE
MNT FloatTransformer.transform raises AttributeError instead of NotFittedError when called before fit

### DIFF
--- a/fairlearn/adversarial/_preprocessor.py
+++ b/fairlearn/adversarial/_preprocessor.py
@@ -5,6 +5,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.preprocessing import OneHotEncoder
 from sklearn.utils import check_array
 from sklearn.utils.multiclass import type_of_target
+from sklearn.utils.validation import check_is_fitted
 
 
 class FloatTransformer(TransformerMixin, BaseEstimator):
@@ -96,6 +97,7 @@ class FloatTransformer(TransformerMixin, BaseEstimator):
 
     def transform(self, X):
         """Transform X using the fitted encoder or passthrough."""
+        check_is_fitted(self)
         if isinstance(self.transformer, str) or self.transformer is None:
             return (
                 self.transform_.transform(self._check(X)).astype(float)


### PR DESCRIPTION
`FloatTransformer.transform()` does not call `check_is_fitted` before
accessing fitted attributes. Calling it before `fit()` raises an
unhelpful `AttributeError` instead of the sklearn-standard
`NotFittedError`:

    from fairlearn.adversarial._preprocessor import FloatTransformer
    import numpy as np
    ft = FloatTransformer(transformer="binary")
    ft.transform(np.array([0, 1, 0]))
    # AttributeError: 'FloatTransformer' object has no attribute 'inferred_type_'

The fix is to add `check_is_fitted(self)` at the top of `transform()`,
consistent with how other sklearn-compatible transformers handle this.
Two-line change. I have a fix ready and would like to open a PR.