### PR TITLE
fix: enforce X.ndim == 2 in _AdversarialFairness.predict and repeated fit/partial_fit

### DIFF
--- a/docs/user_guide/installation_and_version_guide/v0.15.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.15.0.rst
@@ -37,6 +37,12 @@ Bug fixes
   :code:`FloatTransformer.inverse_transform` so that they raise
   :code:`NotFittedError` instead of :code:`AttributeError` when called before
   :code:`fit`: :pr:`1709` by :user:`SpiliosDimakopoulos`.
+* Extended the :code:`X` dimensionality check added in :pr:`1671` to
+  :code:`_AdversarialFairness.predict` and to repeated/:code:`partial_fit`
+  calls, which previously bypassed :code:`BackendEngine.__init__` (and
+  therefore the check) entirely and could silently mis-size predictions or
+  hand non-2D data straight to the backend model: :pr:`REPLACE_WITH_PR_NUMBER`
+  by :user:`REPLACE_WITH_YOUR_GITHUB_USERNAME`.
 
 Documentation
 -------------

--- a/fairlearn/adversarial/_adversarial_mitigation.py
+++ b/fairlearn/adversarial/_adversarial_mitigation.py
@@ -31,6 +31,7 @@ from ._constants import (
     _KWARG_ERROR_MESSAGE,
     _PREDICTION_FUNCTION_AMBIGUOUS,
     _PROGRESS_UPDATE,
+    _X_NOT_2D,
 )
 from ._preprocessor import FloatTransformer
 from ._pytorch_engine import PytorchEngine
@@ -586,6 +587,8 @@ class _AdversarialFairness(BaseEstimator):
             allow_nd=True,
             reset=False,
         )
+        if X.ndim != 2:
+            raise ValueError(_X_NOT_2D.format(X.ndim))
         y_pred = self.backendEngine_.evaluate(X)
         return y_pred
 
@@ -651,6 +654,8 @@ class _AdversarialFairness(BaseEstimator):
                 allow_nd=True,
                 ensure_2d=True,
             )
+            if X.ndim != 2:
+                raise ValueError(_X_NOT_2D.format(X.ndim))
             if y is not None:
                 y = validate_data(self, y, dtype=None, ensure_2d=False)
                 if y.ndim != 1:

--- a/test/unit/adversarial/test_adversarial_mitigation.py
+++ b/test/unit/adversarial/test_adversarial_mitigation.py
@@ -394,6 +394,49 @@ def test_backend_engine_rejects_non_2d_X(fake_backend_env):
         mitigator.fit(X, Y, sensitive_features=Z)
 
 
+@pytest.mark.parametrize("fake_backend_env", ["torch", "tensorflow"], indirect=True)
+def test_partial_fit_rejects_non_2d_X_on_second_call(fake_backend_env):
+    """partial_fit should reject non-2D X even after the backend engine exists.
+
+    The first call to partial_fit sets up the backend engine (which validates
+    ndim), but subsequent calls go straight to backendEngine_.train_step and
+    used to skip that check entirely.
+    """
+    rng = np.random.default_rng(0)
+    X = rng.random((20, 3))
+    Y = rng.integers(0, 2, size=20)
+    Z = rng.integers(0, 2, size=20)
+    mitigator = get_instance(
+        fake_backend=fake_backend_env,
+        fake_training=True,
+        predictor_model=[10, "Sigmoid"],
+    )
+    mitigator.partial_fit(X, Y, classes=[0, 1], sensitive_features=Z)
+
+    bad_X = rng.random((20, 3, 4))
+    with pytest.raises(ValueError, match="two-dimensional"):
+        mitigator.partial_fit(bad_X, Y, sensitive_features=Z)
+
+
+@pytest.mark.parametrize("fake_backend_env", ["torch", "tensorflow"], indirect=True)
+def test_predict_rejects_non_2d_X(fake_backend_env):
+    """predict() should reject non-2D X instead of passing it to the backend."""
+    rng = np.random.default_rng(0)
+    X = rng.random((20, 3))
+    Y = rng.integers(0, 2, size=20)
+    Z = rng.integers(0, 2, size=20)
+    mitigator = get_instance(
+        fake_backend=fake_backend_env,
+        fake_training=True,
+        predictor_model=[10, "Sigmoid"],
+    )
+    mitigator.fit(X, Y, sensitive_features=Z)
+
+    bad_X = rng.random((20, 3, 4))
+    with pytest.raises(ValueError, match="two-dimensional"):
+        mitigator.predict(bad_X)
+
+
 @pytest.mark.parametrize(
     "data, valid_choice",
     [


### PR DESCRIPTION
Fixes #1672

## Problem
#1656 / #1671 added a check in `BackendEngine.__init__` that raises a
clear `ValueError` when `X.ndim != 2` — but that check only runs when
the backend engine is *constructed*. Two paths bypass it entirely:

- `partial_fit()` on an already-fitted model (and a repeated, non
  warm-start call to `fit()`) reuse the existing `backendEngine_` and
  call `backendEngine_.train_step(X, y, A)` directly.
- `predict()` -> `_raw_predict()` validates `X` with `allow_nd=True`
  and passes it straight to `backendEngine_.evaluate(X)`.

In both cases a non-2D `X` (e.g. an image batch) either raises an
opaque backend-specific error, or — worse — is silently mis-applied if
the trailing dimension happens to match `n_features_in_`.

## Fix
Reuse the existing `_X_NOT_2D` message from #1671 and add the same
`ndim` check at the two remaining choke points:
- `_AdversarialFairness._validate_input` (shared by `fit`/`partial_fit`)
- `_AdversarialFairness._raw_predict` (used by `predict`)

## Tests
- Added `test_partial_fit_rejects_non_2d_X_on_second_call`
- Added `test_predict_rejects_non_2d_X`
- Full adversarial test suite passes locally (274 passed, 5 skipped,
  6 xfailed, 6 xpassed); `ruff check` / `ruff format --check` clean.

## Changelog
Added an entry to `docs/user_guide/installation_and_version_guide/v0.15.0.rst`
following the existing convention.