### PR TITLE
FIX: plot_roc_curve_by_group crashes on missing sensitive feature values

### DIFF
--- a/docs/user_guide/installation_and_version_guide/v0.15.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.15.0.rst
@@ -37,6 +37,15 @@ Bug fixes
   :code:`FloatTransformer.inverse_transform` so that they raise
   :code:`NotFittedError` instead of :code:`AttributeError` when called before
   :code:`fit`: :pr:`1709` by :user:`SpiliosDimakopoulos`.
+* :func:`~fairlearn.metrics.plot_roc_curve_by_group` raised
+  :code:`ValueError: Input contains NaN` for any row with a missing sensitive
+  feature value, even though its docstring says it follows the same
+  convention as :class:`~fairlearn.metrics.MetricFrame`, whose
+  :code:`by_group` results simply omit such rows. It now matches that
+  convention: rows with a missing sensitive feature value are included in
+  the overall curve but skipped when drawing per-group curves, instead of
+  raising: :pr:`REPLACE_WITH_PR_NUMBER` by
+  :user:`REPLACE_WITH_YOUR_GITHUB_USERNAME`.
 
 Documentation
 -------------

--- a/docs/user_guide/installation_and_version_guide/v0.15.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.15.0.rst
@@ -37,15 +37,10 @@ Bug fixes
   :code:`FloatTransformer.inverse_transform` so that they raise
   :code:`NotFittedError` instead of :code:`AttributeError` when called before
   :code:`fit`: :pr:`1709` by :user:`SpiliosDimakopoulos`.
-* :func:`~fairlearn.metrics.plot_roc_curve_by_group` raised
-  :code:`ValueError: Input contains NaN` for any row with a missing sensitive
-  feature value, even though its docstring says it follows the same
-  convention as :class:`~fairlearn.metrics.MetricFrame`, whose
-  :code:`by_group` results simply omit such rows. It now matches that
-  convention: rows with a missing sensitive feature value are included in
-  the overall curve but skipped when drawing per-group curves, instead of
-  raising: :pr:`REPLACE_WITH_PR_NUMBER` by
-  :user:`REPLACE_WITH_YOUR_GITHUB_USERNAME`.
+* Fixed :func:`~fairlearn.metrics.plot_roc_curve_by_group` so that rows with
+  missing sensitive feature values are included in the overall curve but
+  omitted from per-group curves, instead of raising a :code:`ValueError`:
+  :pr:`1713` by :user:`SpiliosDimakopoulos`.
 
 Documentation
 -------------

--- a/fairlearn/metrics/_roc_auc.py
+++ b/fairlearn/metrics/_roc_auc.py
@@ -4,13 +4,14 @@
 from __future__ import annotations
 
 import pandas as pd
-from numpy import asarray, zeros
+from numpy import asarray
 from sklearn.metrics import RocCurveDisplay
+from sklearn.utils import check_array, check_consistent_length
 
 from ..postprocessing._constants import _MATPLOTLIB_IMPORT_ERROR_MESSAGE
 from ..utils._input_validation import (
     _INCONSISTENT_ARRAY_LENGTH,
-    _validate_and_reformat_input,
+    _merge_columns,
 )
 
 _CHANCE_LEVEL_LABEL = "Chance level (AUC = 0.50)"
@@ -40,7 +41,11 @@ def plot_roc_curve_by_group(
 
     When more than one sensitive feature is provided, the unique combinations of
     their values define the subgroups (for example ``"Female,White"``), following
-    the same convention as :class:`~fairlearn.metrics.MetricFrame`.
+    the same convention as :class:`~fairlearn.metrics.MetricFrame`. Rows with a
+    missing (``NaN``) sensitive feature value are included in the overall curve
+    but are skipped when drawing per-group curves, since they cannot be assigned
+    to a subgroup -- again matching :class:`~fairlearn.metrics.MetricFrame`,
+    whose :code:`by_group` results omit such rows.
 
     .. versionadded:: 0.15.0
 
@@ -118,14 +123,20 @@ def plot_roc_curve_by_group(
 
     # Validate and merge the sensitive feature(s) into a single Series of group
     # names without coercing y_true, so that non-numeric class labels remain
-    # usable together with pos_label.
+    # usable together with pos_label. Unlike the shared
+    # `_validate_and_reformat_input` helper, this does not reject missing
+    # (NaN) values: a NaN sensitive feature value means "unknown group", not
+    # invalid input, and rows with such values are skipped below rather than
+    # raising -- matching how `MetricFrame.by_group` treats them.
     if isinstance(sensitive_features, dict):
         sensitive_features = pd.DataFrame(sensitive_features)
-    *_, sensitive_features, _ = _validate_and_reformat_input(
-        zeros((len(y_true), 1)),  # dummy X; only sensitive_features is needed
-        expect_y=False,
-        sensitive_features=sensitive_features,
+    check_consistent_length(y_true, sensitive_features)
+    sensitive_features = check_array(
+        sensitive_features, ensure_2d=False, dtype=None, ensure_all_finite=False
     )
+    if sensitive_features.ndim > 1 and sensitive_features.shape[1] > 1:
+        sensitive_features = _merge_columns(sensitive_features)
+    sensitive_features = pd.Series(sensitive_features.squeeze())
 
     if ax is None:
         _, ax = plt.subplots()
@@ -142,7 +153,7 @@ def plot_roc_curve_by_group(
             ax=ax,
         )
 
-    for group in sorted(sensitive_features.unique()):
+    for group in sorted(sensitive_features.dropna().unique()):
         mask = (sensitive_features == group).to_numpy()
         RocCurveDisplay.from_predictions(
             y_true[mask],

--- a/fairlearn/metrics/_roc_auc.py
+++ b/fairlearn/metrics/_roc_auc.py
@@ -135,8 +135,11 @@ def plot_roc_curve_by_group(
         sensitive_features, ensure_2d=False, dtype=None, ensure_all_finite=False
     )
     if sensitive_features.ndim > 1 and sensitive_features.shape[1] > 1:
-        sensitive_features = _merge_columns(sensitive_features)
-    sensitive_features = pd.Series(sensitive_features.squeeze())
+        missing_rows = pd.isna(sensitive_features).any(axis=1)
+        sensitive_features = pd.Series(_merge_columns(sensitive_features))
+        sensitive_features.loc[missing_rows] = pd.NA
+    else:
+        sensitive_features = pd.Series(sensitive_features.squeeze())
 
     if ax is None:
         _, ax = plt.subplots()

--- a/test/unit/metrics/test_plot_roc_curve_by_group.py
+++ b/test/unit/metrics/test_plot_roc_curve_by_group.py
@@ -215,3 +215,39 @@ class TestPlotRocCurveByGroup:
             mask = g_1 == group
             expected_auc = roc_auc_score((y_str[mask] == "yes").astype(int), y_score[mask])
             assert f"{group} (AUC = {expected_auc:0.2f})" in labels
+
+    def test_missing_sensitive_feature_value_is_skipped_not_raised(self):
+        """A NaN sensitive feature value should not crash the plot.
+
+        This mirrors how `MetricFrame.by_group` treats such rows: they are
+        excluded from any single subgroup's curve, but the overall curve
+        still uses every row.
+        """
+        sf = np.asarray(g_1, dtype=object).copy()
+        sf[0] = np.nan
+
+        ax = plot_roc_curve_by_group(y_t, y_score, sensitive_features=sf)
+
+        labels = [line.get_label() for line in ax.get_lines()]
+        assert not any("nan" in label.lower() for label in labels)
+
+        known_mask = np.array([not (isinstance(v, float) and np.isnan(v)) for v in sf])
+        for group in sorted(np.unique(sf[known_mask])):
+            mask = known_mask & (sf == group)
+            expected_auc = roc_auc_score(y_t[mask], y_score[mask])
+            assert f"{group} (AUC = {expected_auc:0.2f})" in labels
+
+        # The overall curve still reflects every row, including the one with
+        # the missing sensitive feature value.
+        expected_overall_auc = roc_auc_score(y_t, y_score)
+        assert f"Overall (AUC = {expected_overall_auc:0.2f})" in labels
+
+    def test_all_missing_sensitive_feature_values(self):
+        """No per-group curves are drawn if every value is missing."""
+        sf = np.full(len(y_t), np.nan, dtype=object)
+
+        ax = plot_roc_curve_by_group(y_t, y_score, sensitive_features=sf)
+
+        labels = [line.get_label() for line in ax.get_lines()]
+        assert not any("nan" in label.lower() for label in labels)
+        assert _expected_label("Overall", y_t, y_score) in labels

--- a/test/unit/metrics/test_plot_roc_curve_by_group.py
+++ b/test/unit/metrics/test_plot_roc_curve_by_group.py
@@ -251,3 +251,20 @@ class TestPlotRocCurveByGroup:
         labels = [line.get_label() for line in ax.get_lines()]
         assert not any("nan" in label.lower() for label in labels)
         assert _expected_label("Overall", y_t, y_score) in labels
+
+    def test_missing_value_in_multiple_sensitive_features_is_skipped(self, two_sensitive_features):
+        sf = two_sensitive_features.astype(object)
+        sf[0, 1] = np.nan
+
+        ax = plot_roc_curve_by_group(y_t, y_score, sensitive_features=sf)
+
+        labels = [line.get_label() for line in ax.get_lines()]
+        assert not any("nan" in label.lower() for label in labels)
+
+        missing_rows = np.zeros(len(sf), dtype=bool)
+        missing_rows[0] = True
+        expected_groups = {tuple(row) for row in sf[~missing_rows]}
+        for values in expected_groups:
+            group = ",".join(values)
+            mask = (~missing_rows) & np.all(sf == values, axis=1)
+            assert _expected_label(group, y_t[mask], y_score[mask]) in labels


### PR DESCRIPTION
## Problem
`plot_roc_curve_by_group`'s docstring says it "follows the same
convention as `MetricFrame`" for sensitive features. In practice it
didn't:

- `MetricFrame.by_group` silently omits rows with a missing (`NaN`)
  sensitive feature value from any single subgroup's result.
- `plot_roc_curve_by_group` raised `ValueError: Input contains NaN`
  for the exact same input, because it routes `sensitive_features`
  through `_validate_and_reformat_input`, whose internal `check_array`
  call (unlike the one used for `X`) doesn't pass
  `ensure_all_finite=False`.

## Fix
Validate and merge the sensitive feature(s) locally in `_roc_auc.py`
instead of going through the shared `_validate_and_reformat_input`
helper, using `check_array(..., ensure_all_finite=False)`. Rows with a
`NaN` sensitive feature value are skipped when drawing per-group
curves (`sensitive_features.dropna()` before `.unique()`), while the
"overall" curve is unaffected and still uses every row.

The shared `_input_validation.py` helper is left untouched, since it's
used broadly across the library — this fix is scoped to the new
`plot_roc_curve_by_group` function only.

## Tests
- Added `test_missing_sensitive_feature_value_is_skipped_not_raised`
- Added `test_all_missing_sensitive_feature_values`
- Full `test/unit/metrics/` suite passes locally (752 passed);
  `ruff check` / `ruff format --check` clean.

## Changelog
Added an entry to
`docs/user_guide/installation_and_version_guide/v0.15.0.rst` following
the existing convention.