### PR TITLE
MNT improve UtilityParity lambda projection

### DIFF
--- a/docs/user_guide/installation_and_version_guide/v0.15.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.15.0.rst
@@ -46,6 +46,9 @@ Documentation
 Other improvements
 ------------------
 
+* Tightened the internal projection of Lagrange multipliers for difference-based
+  reductions constraints by removing the redundant per-event group-membership
+  component while preserving the classifier-dependent Lagrangian term.
 * Preserved multi-column sensitive feature data in
   :class:`fairlearn.postprocessing.ThresholdOptimizer` data reformatting helpers:
   :pr:`1679` by :user:`BALOGUN-DAVID <BALOGUN-DAVID>`.

--- a/docs/user_guide/installation_and_version_guide/v0.15.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.15.0.rst
@@ -48,7 +48,8 @@ Other improvements
 
 * Tightened the internal projection of Lagrange multipliers for difference-based
   reductions constraints by removing the redundant per-event group-membership
-  component while preserving the classifier-dependent Lagrangian term.
+  component while preserving the classifier-dependent Lagrangian term: :pr:`1714`
+  by :user:`quinnarnold <quinnarnold>`.
 * Preserved multi-column sensitive feature data in
   :class:`fairlearn.postprocessing.ThresholdOptimizer` data reformatting helpers:
   :pr:`1679` by :user:`BALOGUN-DAVID <BALOGUN-DAVID>`.

--- a/fairlearn/reductions/_moments/utility_parity.py
+++ b/fairlearn/reductions/_moments/utility_parity.py
@@ -242,7 +242,6 @@ class UtilityParity(ClassificationMoment):
         """
         return pd.Series(self.eps, index=self.index)
 
-    # TODO: this can be further improved using the overcompleteness in group membership
     def project_lambda(self, lambda_vec: pd.Series) -> pd.Series:
         """Return the projected lambda values.
 
@@ -250,10 +249,23 @@ class UtilityParity(ClassificationMoment):
         Lagrangian compared with lambda_vec for all possible choices of the classifier, h.
         """
         if self.ratio == 1.0:
-            lambda_pos = lambda_vec["+"] - lambda_vec["-"]
-            lambda_neg = -lambda_pos
-            lambda_pos[lambda_pos < 0.0] = 0.0
-            lambda_neg[lambda_neg < 0.0] = 0.0
+            lambda_signed = (lambda_vec["+"] - lambda_vec["-"]).astype(np.float64)
+            group_prob = self.prob_group_event.div(self.prob_event, level=_EVENT)
+
+            # Within each event, sum_g P(g|e) * gamma_(+,e,g) = 0. Thus shifting
+            # lambda_signed by a multiple of P(g|e) preserves its inner product with
+            # gamma. A weighted median minimizes the L1 norm over all such shifts.
+            for _, event_lambda in lambda_signed.groupby(level=_EVENT, sort=False):
+                event_prob = group_prob.loc[event_lambda.index]
+                normalized_lambda = event_lambda / event_prob
+                order = np.argsort(normalized_lambda.to_numpy(), kind="stable")
+                cumulative_prob = event_prob.iloc[order].cumsum()
+                median_position = np.searchsorted(cumulative_prob.to_numpy(), event_prob.sum() / 2)
+                shift = normalized_lambda.iloc[order[median_position]]
+                lambda_signed.loc[event_lambda.index] = event_lambda - event_prob * shift
+
+            lambda_pos = lambda_signed.clip(lower=0.0)
+            lambda_neg = (-lambda_signed).clip(lower=0.0)
             lambda_projected = pd.concat(
                 [lambda_pos, lambda_neg],
                 keys=["+", "-"],

--- a/test/unit/reductions/moments/test_moments_demographic_parity.py
+++ b/test/unit/reductions/moments/test_moments_demographic_parity.py
@@ -85,6 +85,11 @@ def test_construct_and_load():
 
 def test_project_lambda_smoke_negatives():
     dp = DemographicParity()
+    dp.load_data(
+        np.zeros((4, 1)),
+        pd.Series([0, 0, 0, 0]),
+        sensitive_features=pd.Series(["a", "a", "b", "b"]),
+    )
 
     events = ["all"]
     signs = ["+", "-"]
@@ -99,7 +104,7 @@ def test_project_lambda_smoke_negatives():
     ls = dp.project_lambda(df)
 
     expected = pd.DataFrame()
-    expected = 0 + pd.Series([0, 0, 10, 17], index=midx, dtype=np.float64)
+    expected = 0 + pd.Series([7, 0, 0, 0], index=midx, dtype=np.float64)
     assert expected.equals(ls)
 
 
@@ -107,6 +112,11 @@ def test_project_lambda_smoke_positives():
     # This is a repeat of the _negatives method but with
     # the '+' indices larger
     dp = DemographicParity()
+    dp.load_data(
+        np.zeros((4, 1)),
+        pd.Series([0, 0, 0, 0]),
+        sensitive_features=pd.Series(["a", "a", "b", "b"]),
+    )
 
     events = ["all"]
     signs = ["+", "-"]
@@ -121,8 +131,30 @@ def test_project_lambda_smoke_positives():
     ls = dp.project_lambda(df)
 
     expected = pd.DataFrame()
-    expected = 0 + pd.Series([18, 12, 0, 0], index=midx, dtype=np.float64)
+    expected = 0 + pd.Series([6, 0, 0, 0], index=midx, dtype=np.float64)
     assert expected.equals(ls)
+
+
+def test_project_lambda_uses_group_membership_redundancy():
+    eps = 0.1
+    dp = DemographicParity(difference_bound=eps)
+    X = np.zeros((10, 1))
+    y = pd.Series(np.zeros(10, dtype=int))
+    sensitive_features = pd.Series(["a"] * 2 + ["b"] * 2 + ["c"] * 6)
+    dp.load_data(X, y, sensitive_features=sensitive_features)
+
+    lambda_vec = pd.Series([4, 2, 30, 1, 8, 0], index=dp.index, dtype=np.float64)
+    projected = dp.project_lambda(lambda_vec)
+
+    expected = pd.Series([0, 0, 0, 7, 16, 0], index=dp.index, dtype=np.float64)
+    assert expected.equals(projected)
+    assert projected.sum() < lambda_vec.sum()
+    assert np.allclose(dp.signed_weights(projected), dp.signed_weights(lambda_vec))
+
+    for predictions in [np.zeros(10), np.ones(10), np.arange(10) % 2]:
+        gamma = dp.gamma(lambda _, predictions=predictions: predictions)
+        assert np.isclose(projected.dot(gamma), lambda_vec.dot(gamma))
+        assert projected.dot(gamma - dp.bound()) >= lambda_vec.dot(gamma - dp.bound())
 
 
 def test_signed_weights():

--- a/test/unit/reductions/moments/test_moments_equalized_odds.py
+++ b/test/unit/reductions/moments/test_moments_equalized_odds.py
@@ -102,6 +102,11 @@ def test_construct_and_load():
 
 def test_project_lambda_smoke_negatives():
     eqo = EqualizedOdds()
+    eqo.load_data(
+        np.zeros((4, 1)),
+        pd.Series([False, False, True, True]),
+        sensitive_features=pd.Series(["a", "b", "a", "b"]),
+    )
 
     events = ["label=False", "label=True"]
     signs = ["+", "-"]
@@ -115,7 +120,7 @@ def test_project_lambda_smoke_negatives():
     ls = eqo.project_lambda(df)
 
     expected = pd.DataFrame()
-    expected = 0 + pd.Series([0, 0, 0, 0, 1000, 1108, 1219, 1331], index=midx, dtype=np.float64)
+    expected = 0 + pd.Series([108, 0, 112, 0, 0, 0, 0, 0], index=midx, dtype=np.float64)
     assert expected.equals(ls)
 
 
@@ -123,6 +128,11 @@ def test_project_lambda_smoke_positives():
     # This is a repeat of the _negatives method but with
     # the '+' indices larger
     eqo = EqualizedOdds()
+    eqo.load_data(
+        np.zeros((4, 1)),
+        pd.Series([False, False, True, True]),
+        sensitive_features=pd.Series(["a", "b", "a", "b"]),
+    )
 
     events = ["label=False", "label=True"]
     signs = ["+", "-"]
@@ -136,7 +146,7 @@ def test_project_lambda_smoke_positives():
     ls = eqo.project_lambda(df)
 
     expected = pd.DataFrame()
-    expected = 0 + pd.Series([196, 295, 94, 593, 0, 0, 0, 0], index=midx, dtype=np.float64)
+    expected = 0 + pd.Series([0, 99, 0, 499, 0, 0, 0, 0], index=midx, dtype=np.float64)
     assert expected.equals(ls)
 
 

--- a/test/unit/reductions/moments/test_moments_equalized_odds.py
+++ b/test/unit/reductions/moments/test_moments_equalized_odds.py
@@ -153,9 +153,7 @@ def test_project_lambda_smoke_positives():
 def test_project_lambda_handles_unequal_group_probabilities_by_event():
     eqo = EqualizedOdds()
     y = pd.Series([False] * 6 + [True] * 6)
-    sensitive_features = pd.Series(
-        ["a", "a", "b", "c", "c", "c", "a", "b", "b", "b", "b", "b"]
-    )
+    sensitive_features = pd.Series(["a", "a", "b", "c", "c", "c", "a", "b", "b", "b", "b", "b"])
     eqo.load_data(np.zeros((12, 1)), y, sensitive_features=sensitive_features)
 
     lambda_vec = pd.Series(

--- a/test/unit/reductions/moments/test_moments_equalized_odds.py
+++ b/test/unit/reductions/moments/test_moments_equalized_odds.py
@@ -150,6 +150,26 @@ def test_project_lambda_smoke_positives():
     assert expected.equals(ls)
 
 
+def test_project_lambda_handles_unequal_group_probabilities_by_event():
+    eqo = EqualizedOdds()
+    y = pd.Series([False] * 6 + [True] * 6)
+    sensitive_features = pd.Series(
+        ["a", "a", "b", "c", "c", "c", "a", "b", "b", "b", "b", "b"]
+    )
+    eqo.load_data(np.zeros((12, 1)), y, sensitive_features=sensitive_features)
+
+    lambda_vec = pd.Series(
+        [4, 2, 30, 8, 1, 1, 8, 0, 3, 7],
+        index=eqo.index,
+        dtype=np.float64,
+    )
+    projected = eqo.project_lambda(lambda_vec)
+
+    assert np.allclose(eqo.signed_weights(projected), eqo.signed_weights(lambda_vec))
+    assert projected.sum() <= lambda_vec.sum()
+    assert np.allclose(eqo.project_lambda(projected), projected)
+
+
 def test_signed_weights():
     eqo = EqualizedOdds()
     assert eqo.short_name == "EqualizedOdds"


### PR DESCRIPTION
## Description

Improve `UtilityParity.project_lambda` for difference-based constraints by removing the redundant per-event group-membership component. The projection uses a probability-weighted median, preserves the classifier-dependent Lagrangian term, and reduces the multiplier L1 norm.

Fixes #1655.

## Tests

- [ ] no new tests required
- [x] new tests added
- [x] existing tests adjusted

Focused validation: `python -m pytest test/unit/reductions/moments/test_moments_demographic_parity.py test/unit/reductions/moments/test_moments_equalized_odds.py -q` (9 passed).

## Documentation

- [ ] no documentation changes needed
- [x] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots

Not applicable.