### PR TITLE
FIX Handle linprog solver failures

### DIFF
--- a/docs/user_guide/installation_and_version_guide/v0.15.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.15.0.rst
@@ -41,6 +41,9 @@ Bug fixes
   missing sensitive feature values are included in the overall curve but
   omitted from per-group curves, instead of raising a :code:`ValueError`:
   :pr:`1713` by :user:`SpiliosDimakopoulos`.
+* Fixed :code:`solve_linprog` so that failures reported by SciPy's linear
+  programming solver raise a :code:`RuntimeError` instead of allowing invalid
+  solver output to propagate: :pr:`1715` by :user:`Roman Lutz <romanlutz>`.
 
 Documentation
 -------------

--- a/fairlearn/reductions/_exponentiated_gradient/_lagrangian.py
+++ b/fairlearn/reductions/_exponentiated_gradient/_lagrangian.py
@@ -26,6 +26,23 @@ logger = logging.getLogger(__name__)
 _MESSAGE_BAD_OBJECTIVE = (
     "Objective needs to be of the same type as constraints. Objective is {}, constraints are {}."
 )
+_MESSAGE_LINPROG_FAILED = (
+    "Linear programming failed while solving the {} problem with method {}. "
+    "Status: {}. Message: {}"
+)
+_LINPROG_METHOD = "highs-ds"
+
+
+def _raise_if_linprog_failed(result, problem):
+    if not result.success:
+        raise RuntimeError(
+            _MESSAGE_LINPROG_FAILED.format(
+                problem,
+                _LINPROG_METHOD,
+                result.status,
+                result.message,
+            )
+        )
 
 
 class _PredictorAsCallable:
@@ -186,7 +203,15 @@ class _Lagrangian:
         b_ub = np.zeros(n_constraints)
         A_eq = np.concatenate((np.ones((1, n_hs)), np.zeros((1, 1))), axis=1)
         b_eq = np.ones(1)
-        result = opt.linprog(c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, method="highs-ds")
+        result = opt.linprog(
+            c,
+            A_ub=A_ub,
+            b_ub=b_ub,
+            A_eq=A_eq,
+            b_eq=b_eq,
+            method=_LINPROG_METHOD,
+        )
+        _raise_if_linprog_failed(result, "primal")
         Q = pd.Series(result.x[:-1], self.hs.index)
         dual_c = np.concatenate((b_ub, -b_eq))
         dual_A_ub = np.concatenate((-A_ub.transpose(), A_eq.transpose()), axis=1)
@@ -199,8 +224,9 @@ class _Lagrangian:
             A_ub=dual_A_ub,
             b_ub=dual_b_ub,
             bounds=dual_bounds,
-            method="highs-ds",
+            method=_LINPROG_METHOD,
         )
+        _raise_if_linprog_failed(result_dual, "dual")
         lambda_vec = pd.Series(result_dual.x[:-1], self.constraints.index)
         self.last_linprog_n_hs = n_hs
         self.last_linprog_result = (

--- a/test/unit/reductions/exponentiated_gradient/test_lagrangian.py
+++ b/test/unit/reductions/exponentiated_gradient/test_lagrangian.py
@@ -6,9 +6,11 @@ from copy import deepcopy
 import numpy as np
 import pandas as pd
 import pytest
+from scipy.optimize import OptimizeResult
 from sklearn.base import BaseEstimator
 from sklearn.dummy import DummyClassifier
 
+import fairlearn.reductions._exponentiated_gradient._lagrangian as lagrangian_module
 from fairlearn.reductions import (
     BoundedGroupLoss,
     DemographicParity,
@@ -44,6 +46,40 @@ REGRESSION_CONSTRAINTS = [BoundedGroupLoss]
 ALL_CONSTRAINTS = CLASSIFICATION_CONSTRAINTS + REGRESSION_CONSTRAINTS
 
 ALL_OBJECTIVES = [ErrorRate, MeanLoss]
+
+
+def test_solve_linprog_raises_on_primal_failure(monkeypatch):
+    lagrangian = _get_lagrangian_for_linprog()
+
+    def mock_linprog(*args, **kwargs):
+        return OptimizeResult(success=False, status=2, message="primal failed")
+
+    monkeypatch.setattr(lagrangian_module.opt, "linprog", mock_linprog)
+
+    with pytest.raises(RuntimeError, match="primal.*highs-ds.*Status: 2.*primal failed"):
+        lagrangian.solve_linprog(nu=0.01)
+
+
+def test_solve_linprog_raises_on_dual_failure(monkeypatch):
+    lagrangian = _get_lagrangian_for_linprog()
+    n_constraints = len(lagrangian.constraints.index)
+    linprog_results = [
+        OptimizeResult(success=True, status=0, message="success", x=np.array([1.0, 0.0])),
+        OptimizeResult(
+            success=False,
+            status=4,
+            message="dual failed",
+            x=np.zeros(n_constraints + 1),
+        ),
+    ]
+
+    def mock_linprog(*args, **kwargs):
+        return linprog_results.pop(0)
+
+    monkeypatch.setattr(lagrangian_module.opt, "linprog", mock_linprog)
+
+    with pytest.raises(RuntimeError, match="dual.*highs-ds.*Status: 4.*dual failed"):
+        lagrangian.solve_linprog(nu=0.01)
 
 
 @pytest.mark.parametrize("eps", [0.001, 0.01, 0.1])
@@ -263,6 +299,23 @@ def get_lambda_vec(constraints, X, y, A):
     theta = pd.Series(0, constraints.index)
     lambda_vec = np.exp(theta) / (1 + np.exp(theta).sum())
     return lambda_vec
+
+
+def _get_lagrangian_for_linprog():
+    X, y, A = _get_data(A_two_dim=False)
+    constraints = DemographicParity(difference_bound=0.01)
+    lagrangian = _Lagrangian(
+        X=X,
+        y=y,
+        estimator=LeastSquaresBinaryClassifierLearner(),
+        constraints=constraints,
+        B=100.0,
+        sensitive_features=A,
+    )
+    lagrangian.hs.at[0] = lambda X: np.zeros(len(X))
+    lagrangian.errors.at[0] = 0.25
+    lagrangian.gammas[0] = pd.Series(0.0, index=lagrangian.constraints.index)
+    return lagrangian
 
 
 def get_lambda_new_weights_and_labels(constraints, X, y, A):


### PR DESCRIPTION
`solve_linprog` previously read `linprog` outputs without checking whether SciPy reported a successful solve. If either LP failed, invalid solver output could silently propagate into the reduction.

This change adds explicit success checks for both the primal and dual `linprog(method="highs-ds")` calls. On failure, `solve_linprog` now raises a `RuntimeError` that includes the problem type, method, solver status, and solver message. Successful solves keep the existing behavior.

Targeted tests monkeypatch `linprog` to return unsuccessful `OptimizeResult` values for both primal and dual failure paths.

Tested with:

```bash
uv run pytest test\unit\reductions\exponentiated_gradient\test_lagrangian.py -q
```