### PR TITLE
DOC Add links to additional adversarial fairness experiments

### DIFF
--- a/docs/user_guide/mitigation/adversarial.rst
+++ b/docs/user_guide/mitigation/adversarial.rst
@@ -211,6 +211,34 @@ Refer to the following examples for more details:
 - :ref:`sphx_glr_auto_examples_plot_adversarial_basics.py`
 - :ref:`sphx_glr_auto_examples_plot_adversarial_fine_tuning.py`
 
+Additional experiments
+----------------------
+
+Sean McCarren's `adversarial debiasing experiments
+<https://github.com/SeanMcCarren/adversarial-debiasing>`_ explore applications from
+:footcite:t:`zhang2018mitigating` beyond the Adult dataset:
+
+- The `toy classification example
+  <https://github.com/SeanMcCarren/adversarial-debiasing/blob/main/reproduce_toy.py>`_
+  generates a binary sensitive feature and correlated input features. It uses
+  :class:`AdversarialFairnessClassifier` and reports accuracy and selection rates
+  by group with :class:`fairlearn.metrics.MetricFrame`.
+- The `word embedding example
+  <https://github.com/SeanMcCarren/adversarial-debiasing/blob/main/reproduce_embeddings.py>`_
+  uses :class:`AdversarialFairnessRegressor` to predict a word embedding in an analogy
+  task. The sensitive feature is the embedding's projection onto a direction derived
+  from pairs of words associated with binary gender categories. This projection is a
+  continuous value, not a category. Both the embedding target and the sensitive feature
+  therefore use squared-error losses, rather than the cross-entropy losses used for
+  classification. See :ref:`adversarial_data_types` for how these losses are inferred.
+
+These external experiments were written for an earlier Fairlearn implementation and
+require adaptation to the current API. For example, their ``max_iter`` argument is no
+longer available; the current estimators use ``epochs`` to limit training.
+The word embedding experiment illustrates a modeling choice about gender associations
+in text; its binary framing does not represent the full range of gender identities or
+establish fairness in downstream uses.
+
 .. topic:: References
 
    .. footbibliography::


### PR DESCRIPTION
## Description

Adds links to the issue author's toy-classification and word-embedding adversarial debiasing experiments, with explanations of their inputs, outputs, and loss choices. Notes the adaptations needed for the current API and the limitations of the embedding experiment's gender framing.

Closes #1081.

## Tests

- [x] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

Checked the linked scripts against the descriptions and current estimator API. Sphinx HTML build and pre-commit checks pass; existing unrelated documentation warnings remain.

## Documentation

- [ ] no documentation changes needed
- [x] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated
