### PR TITLE
FIX: handle vacuous TPR/FPR parity constraints

### DIFF
--- a/docs/user_guide/installation_and_version_guide/v0.15.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.15.0.rst
@@ -23,6 +23,14 @@ New features
 Bug fixes
 ---------
 
+* Fixed :class:`~fairlearn.reductions.TruePositiveRateParity` and
+  :class:`~fairlearn.reductions.FalsePositiveRateParity` so that data in which the
+  conditioning event never occurs (all-negative labels for true positive rate parity,
+  all-positive labels for false positive rate parity) produces a vacuous, empty set of
+  constraints instead of raising from zero-dimensional intermediates.
+  :class:`~fairlearn.reductions.ExponentiatedGradient` and
+  :class:`~fairlearn.reductions.GridSearch` now fit and predict on such data,
+  returning the unconstrained best hypothesis: by :user:`breken-ai`.
 * :class:`~fairlearn.metrics.MetricFrame` now raises a :code:`ValueError` when a
   sensitive or control feature contains missing values, naming the offending
   feature. Previously a missing value was silently dropped from

--- a/fairlearn/reductions/_exponentiated_gradient/_lagrangian.py
+++ b/fairlearn/reductions/_exponentiated_gradient/_lagrangian.py
@@ -137,12 +137,17 @@ class _Lagrangian:
             response of the lambda player, `gamma` is the vector of constraint
             violations, and `error` is the empirical error
         """
+        if lambda_vec.empty and self.constraints.index.empty:
+            lambda_vec = pd.Series(dtype=float, index=self.constraints.index)
         if callable(Q):
             error = self.obj.gamma(Q).iloc[0]
             gamma = self.constraints.gamma(Q)
         else:
             error = self.errors[Q.index].dot(Q)
             gamma = self.gammas[Q.index].dot(Q)
+
+        if self.constraints.index.empty:
+            gamma = pd.Series(dtype=float, index=self.constraints.index)
 
         if self.opt_lambda:
             lambda_vec = self.constraints.project_lambda(lambda_vec)
@@ -174,6 +179,15 @@ class _Lagrangian:
         n_hs = len(self.hs)
         n_constraints = len(self.constraints.index)
         if self.last_linprog_n_hs == n_hs:
+            return self.last_linprog_result
+        if n_constraints == 0:
+            best_h_idx = self.errors.idxmin()
+            Q = pd.Series(0.0, index=self.hs.index)
+            Q.loc[best_h_idx] = 1.0
+            lambda_vec = pd.Series(dtype=float, index=self.constraints.index)
+            result = self.eval_gap(Q, lambda_vec, nu)
+            self.last_linprog_n_hs = n_hs
+            self.last_linprog_result = (Q, lambda_vec, result)
             return self.last_linprog_result
         c = np.concatenate((self.errors, [self.B]))
         A_ub = np.concatenate(

--- a/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
+++ b/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
@@ -200,6 +200,8 @@ class ExponentiatedGradient(BaseEstimator, MetaEstimatorMixin):
                 Qsum.at[h_idx] = 0.0
             Qsum[h_idx] += 1.0
             gamma = lagrangian.gammas[h_idx]
+            if lagrangian.constraints.index.empty:
+                gamma = pd.Series(dtype=float, index=lagrangian.constraints.index)
             Q_EG = Qsum / Qsum.sum()
             result_EG = lagrangian.eval_gap(Q_EG, lambda_EG, self.nu)
             gap_EG = result_EG.gap()

--- a/fairlearn/reductions/_grid_search/_grid_generator.py
+++ b/fairlearn/reductions/_grid_search/_grid_generator.py
@@ -63,6 +63,10 @@ class _GridGenerator:
         else:
             self.grid_offset = grid_offset
 
+        if self.dim == 0:
+            self.grid = pd.DataFrame({0: self.grid_offset})
+            return
+
         # true dimensionality of the grid
         true_dim = self.dim - 1 if self.force_L1_norm else self.dim
 

--- a/fairlearn/reductions/_moments/utility_parity.py
+++ b/fairlearn/reductions/_moments/utility_parity.py
@@ -222,6 +222,8 @@ class UtilityParity(ClassificationMoment):
 
     def gamma(self, predictor: Callable) -> pd.Series:
         """Calculate the degree to which constraints are currently violated by the predictor."""
+        if self.index.empty:
+            return pd.Series(dtype=float, index=self.index)
         predictions = predictor(self.X)
         if isinstance(predictions, np.ndarray):
             # TensorFlow seems to return an (n,1) array instead of an (n) array
@@ -248,6 +250,8 @@ class UtilityParity(ClassificationMoment):
         i.e., returns lambda which is guaranteed to lead to the same or higher value of the
         Lagrangian compared with lambda_vec for all possible choices of the classifier, h.
         """
+        if lambda_vec.empty:
+            return lambda_vec
         if self.ratio == 1.0:
             lambda_signed = (lambda_vec["+"] - lambda_vec["-"]).astype(np.float64)
             group_prob = self.prob_group_event.div(self.prob_event, level=_EVENT)

--- a/test/unit/reductions/moments/test_vacuous_utility_parity.py
+++ b/test/unit/reductions/moments/test_vacuous_utility_parity.py
@@ -1,0 +1,55 @@
+"""Regression tests for vacuous utility-parity constraints."""
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.base import BaseEstimator, ClassifierMixin
+
+from fairlearn.reductions import (
+    ExponentiatedGradient,
+    FalsePositiveRateParity,
+    GridSearch,
+    TruePositiveRateParity,
+)
+
+
+class ConstantClassifier(ClassifierMixin, BaseEstimator):
+    """Clone-compatible one-class estimator accepting sample weights."""
+
+    def fit(self, X, y, sample_weight=None):
+        self.classes_ = np.unique(y)
+        self.constant_ = self.classes_[0]
+        return self
+
+    def predict(self, X):
+        return np.full(len(X), self.constant_)
+
+
+@pytest.mark.parametrize(
+    ("constraint", "y"),
+    [(TruePositiveRateParity(), np.zeros(4)), (FalsePositiveRateParity(), np.ones(4))],
+)
+def test_global_absent_event_has_vacuous_zero_constraints(constraint, y):
+    """An absent conditioning event produces empty, safe constraint vectors."""
+    X = np.arange(8).reshape(4, 2)
+    sensitive = np.array([0, 0, 1, 1])
+    constraint.load_data(X, y, sensitive_features=sensitive)
+
+    assert constraint.index.empty
+    assert constraint.gamma(lambda _: y).empty
+    assert constraint.bound().empty
+    assert constraint.project_lambda(pd.Series(dtype=float)).empty
+
+
+@pytest.mark.parametrize("reduction", [ExponentiatedGradient, GridSearch])
+@pytest.mark.parametrize(
+    ("constraint", "y"),
+    [(TruePositiveRateParity(), np.zeros(4)), (FalsePositiveRateParity(), np.ones(4))],
+)
+def test_vacuous_events_fit_reductions_end_to_end(reduction, constraint, y):
+    """One-class absent events fit reductions and predict without constraints."""
+    X = np.arange(8).reshape(4, 2)
+    sensitive = np.array([0, 0, 1, 1])
+    estimator = reduction(ConstantClassifier(), constraint)
+    estimator.fit(X, y, sensitive_features=sensitive)
+    assert estimator.predict(X).shape == y.shape


### PR DESCRIPTION
## Description

### Symptom

If you fit `ExponentiatedGradient` or `GridSearch` with `TruePositiveRateParity` on data
that happens to contain no positive labels — or with `FalsePositiveRateParity` on data
with no negative labels — fairlearn does not fit, and it does not tell you why. It fails
deep inside the reductions machinery with either `KeyError: '+'` or
`ZeroDivisionError: float division by zero`.

This is easy to hit without doing anything unusual: cross-validating on a heavily
imbalanced dataset, or slicing a dataset by a sensitive feature, will eventually hand a
fold to `fit` in which the rare class is simply absent. The mathematically correct answer
in that case is that the constraint is *vacuous* — there is no conditioning event to
equalise across groups, so there is nothing to constrain, and the reduction should return
the unconstrained best hypothesis. Instead it raises.

Copy-pasteable reproducer:

```python
import numpy as np
from sklearn.base import BaseEstimator, ClassifierMixin

from fairlearn.reductions import ExponentiatedGradient, GridSearch, TruePositiveRateParity


class ConstantClassifier(ClassifierMixin, BaseEstimator):
    def fit(self, X, y, sample_weight=None):
        self.classes_ = np.unique(y)
        self.constant_ = self.classes_[0]
        return self

    def predict(self, X):
        return np.full(len(X), self.constant_)


X = np.arange(8).reshape(4, 2)
y = np.zeros(4)                 # no positives at all
sensitive = np.array([0, 0, 1, 1])

for reduction in (ExponentiatedGradient, GridSearch):
    try:
        reduction(ConstantClassifier(), TruePositiveRateParity()).fit(
            X, y, sensitive_features=sensitive
        )
        print(f"{reduction.__name__}: fitted")
    except Exception as exc:
        print(f"{reduction.__name__}: {type(exc).__name__}: {exc}")
```

Run against the merge base (`dd4b1ed2c13206041527e0dbb8f59de282af6e79`), in a detached
worktree with `PYTHONPATH` pinned to it so the base code is what actually gets imported:

```
ExponentiatedGradient: KeyError: '+'
GridSearch: ZeroDivisionError: float division by zero
```

The tails of the two tracebacks, captured in the same run:

```
=== ExponentiatedGradient
  File ".../pandas/core/indexes/multi.py", line 3912, in _get_level_indexer
    raise KeyError(key)
KeyError: '+'
=== GridSearch
    grid = _GridGenerator(
           ^^^^^^^^^^^^^^^
  File ".../fairlearn/reductions/_grid_search/_grid_generator.py", line 77, in __init__
    n_units = (float(grid_size) / (2.0 ** neg_allowed.sum())) ** (1.0 / true_dim) - 1
                                                                  ~~~~^~~~~~~~~~
ZeroDivisionError: float division by zero
```

With this branch applied, the same script prints:

```
ExponentiatedGradient: fitted
GridSearch: fitted
```

### Verified root cause

`UtilityParity.load_data` tags each sample with its conditioning event and then derives
the constraint index from the observed events
(`fairlearn/reductions/_moments/utility_parity.py:159-166` at the merge base):

```python
self.prob_event = self.tags.groupby(_EVENT).size() / self.total_samples
self.prob_group_event = self.tags.groupby([_EVENT, _GROUP_ID]).size() / self.total_samples
signed = pd.concat([self.prob_group_event, self.prob_group_event], keys=["+", "-"], ...)
self._index = signed.index
```

When the conditioning event never occurs, every row's event tag is `NaN`, `groupby` drops
it, and the constraint index is legitimately empty. Probed at the merge base:

```
index: []
index empty: True
prob_event: {}
```

That empty index is a correct description of a vacuous constraint. The problem is that
the code downstream of it was written assuming at least one constraint exists. Three
files each break in their own way, and I confirmed each one independently by reverting
only that file and re-running this PR's tests (see Testing):

* `fairlearn/reductions/_moments/utility_parity.py:223` (`gamma`) and `:245`
  (`project_lambda`). `project_lambda` unconditionally does `lambda_vec["+"]`, which is
  the `KeyError: '+'` above. `gamma` returns a Series derived from an empty `self.U`,
  whose index does not line up with what callers expect.
* `fairlearn/reductions/_grid_search/_grid_generator.py:77`. The grid's true
  dimensionality is `0`, and the scaling parameter is computed as
  `... ** (1.0 / true_dim)`, which is the `ZeroDivisionError` above.
* `fairlearn/reductions/_exponentiated_gradient/_lagrangian.py:117` (`_eval`, reached from
  `eval_gap` at `:159`) and `:173` (`solve_linprog`, whose LP matrices are sized by
  `n_constraints = len(self.constraints.index)` at `:175`), plus `fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py:202`,
  which takes `gamma` from `lagrangian.gammas[h_idx]`. With the other two files fixed and
  only this directory reverted, the two `ExponentiatedGradient` cases fail with
  `ValueError: cannot join with no overlapping index names`.

### What the change does

It gives the empty-constraint case a defined meaning — "no constraints, so return the
unconstrained best hypothesis" — and then makes each of those five call sites honour it:

* `UtilityParity.gamma` returns an empty `float` Series on the constraint index, and
  `UtilityParity.project_lambda` returns the (empty) lambda vector unchanged, instead of
  indexing into it.
* `_GridGenerator.__init__` returns a single-column grid built from `grid_offset` when
  the dimensionality is zero, before reaching the exponent.
* `_Lagrangian.solve_linprog` short-circuits when there are no constraints: it puts all
  weight on the single lowest-error hypothesis and evaluates the gap there, rather than
  handing an empty LP to `scipy`. `_Lagrangian._eval` and `ExponentiatedGradient._fit`
  reindex `lambda_vec` / `gamma` onto the empty constraint index so the joins line up.

87 added lines across 6 files, no deletions; no existing behaviour path is touched, since
every new branch is gated on `index.empty` / `dim == 0` / `n_constraints == 0`.

### Trade-offs a reviewer should weigh

1. **Is silence the right answer?** This makes a vacuous constraint fit quietly and return
   the unconstrained model. The alternative design is to raise a clear, named error
   ("this constraint is vacuous on the data you passed") instead of a `KeyError`. I chose
   the silent-vacuous route because it is what the maths says and because it is what makes
   cross-validation on imbalanced data work without special-casing, but "warn" or "raise a
   good error" are both defensible and I will change it if you prefer either.
2. **Guard placement.** The guards are spread across five call sites rather than
   concentrated in one place. Concentrating them would mean giving `UtilityParity` a
   public "is vacuous" notion that `_Lagrangian` and `_GridGenerator` branch on; that is a
   larger API surface change than seemed warranted for a bug fix. Happy to restructure.
3. **On the Narwhals migration.** `code_style.rst` recommends `narwhals` over `pandas` for
   new code. This change adds `pd.Series(dtype=float, index=...)` in `utility_parity.py`,
   `_lagrangian.py` and `exponentiated_gradient.py`, and `pd.DataFrame({0: self.grid_offset})`
   in `_grid_generator.py`. I deliberately kept pandas here: each of these lines has to
   produce an object that is index-joined against surrounding pandas objects
   (`self.constraints.index`, `self.errors`, `self.hs.index`) in code that is entirely
   pandas today, and having the degenerate path use a different library from the
   non-degenerate path next to it seemed worse than the migration debt. If you would rather
   these lines land as narwhals now, say so and I will redo them.

## Tests

- [ ] no new tests required
- [x] new tests added
- [ ] existing tests adjusted

New file `test/unit/reductions/moments/test_vacuous_utility_parity.py`, 6 cases:
two moment-level cases asserting the index, `gamma`, `bound` and `project_lambda` are all
empty, and four end-to-end cases covering
`{ExponentiatedGradient, GridSearch} x {TruePositiveRateParity, FalsePositiveRateParity}`.

### Commands run and their output

Environment: Python 3.12.12, macOS, scikit-learn 1.9.0, pandas 3.0.5, numpy 2.5.3,
scipy 1.18.1, ruff 0.16.6.

```
$ python -m pytest test/unit/reductions/moments/test_vacuous_utility_parity.py -q -p no:randomly
6 passed in 1.49s

$ python -m pytest test/unit/reductions -q -p no:randomly
3890 passed, 320 skipped, 888 deselected in 129.23s (0:02:09)

$ ruff check fairlearn/reductions test/unit/reductions/moments/test_vacuous_utility_parity.py docs
All checks passed!

$ ruff format --check fairlearn/reductions test/unit/reductions/moments/test_vacuous_utility_parity.py
14 files already formatted

$ git diff --check dd4b1ed2c13206041527e0dbb8f59de282af6e79
(no output)
```

The same directory at the merge base, run in a detached worktree:

```
$ python -m pytest test/unit/reductions -q -p no:randomly
3884 passed, 320 skipped, 888 deselected in 187.14s (0:03:07)
```

3890 - 3884 = exactly the 6 new cases; nothing pre-existing changed state.

### Revert proof

Keeping the new test module and restoring only the source back to the merge base:

```
$ git checkout dd4b1ed2c13206041527e0dbb8f59de282af6e79 -- fairlearn/reductions
$ python -m pytest test/unit/reductions/moments/test_vacuous_utility_parity.py -q -p no:randomly
6 failed in 1.78s
E       ZeroDivisionError: float division by zero
        fairlearn/reductions/_grid_search/_grid_generator.py:77: ZeroDivisionError
E       KeyError: '+'
```

Restoring the source: `6 passed in 1.49s`.

Per-file ablation, to show that all three touched source areas are load-bearing rather
than defensive padding. Each row reverts exactly one path to the merge base and leaves the
rest of the branch in place:

| Reverted to base | Result | Failure |
| --- | --- | --- |
| `fairlearn/reductions/_moments/utility_parity.py` | `4 failed, 2 passed in 1.10s` | `KeyError: '+'` |
| `fairlearn/reductions/_grid_search/_grid_generator.py` | `2 failed, 4 passed in 2.92s` | `ZeroDivisionError: float division by zero` |
| `fairlearn/reductions/_exponentiated_gradient/` | `2 failed, 4 passed in 0.48s` | `ValueError: cannot join with no overlapping index names` |

## Documentation

- [ ] no documentation changes needed
- [x] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

"user guide added or updated" is ticked only because the release note lives under
`docs/user_guide/` — the change here is one entry in
`docs/user_guide/installation_and_version_guide/v0.15.0.rst`, under **Bug fixes**. No
prose user-guide page was edited.

"API docs added or updated" is left unticked: no public signature, parameter or return
value changes, and the docstrings of the touched methods still describe them accurately.
If you would like the vacuous-constraint behaviour spelled out in the `UtilityParity`
class docstring, I will add it.

The changelog entry ends `by :user:`breken-ai`` and carries no `:pr:` role, because the PR
number does not exist until this PR is opened. Tell me the number and I will add it in the
same format as the surrounding entries.

## What was not verified

* **Only `test/unit/reductions` was run**, not the full `test/unit` suite.
* **One environment only**: Python 3.12.12 on macOS with the versions pinned above. No
  `requirements-min.txt` run, and no other Python version.
* **No coverage report.** `codecov` is an explicit CI gate per `code_style.rst`.
  `coverage.py` and `pytest-cov` are not installed in my virtualenv, so I did not produce
  a coverage report. Every added line is reached by the six new cases as far as the
  per-file ablation above shows, but that is an argument, not a coverage number.
* **No Sphinx docs build**, so the new release-note entry is unrendered — I checked its
  markup by eye against the surrounding entries only.
* **Numerical behaviour beyond "it fits and predicts"** is not asserted. The end-to-end
  tests check that `fit` succeeds and `predict` returns the right shape. They do not
  assert that the returned predictor is *identical* to the one you would get from fitting
  the base estimator with no reduction at all, which is what "returns the unconstrained
  best hypothesis" implies. That equivalence is worth a maintainer's opinion on whether it
  should be asserted.
* **Not tested on partially-vacuous data** — i.e. data where the conditioning event is
  absent for *some* sensitive groups but present for others. That path does not produce an
  empty index and so does not go through any of the new branches, but I did not construct
  a case to confirm it is unaffected.

## Screenshots

Not applicable — no visualization or website changes.
