### PR TITLE
FIX: reject non-2D features on fitted adversarial estimators

### DIFF
--- a/docs/user_guide/installation_and_version_guide/v0.15.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.15.0.rst
@@ -40,6 +40,15 @@ Bug fixes
   :user:`BALOGUN DAVID TAIWO <BALOGUN-DAVID>`.
 * Fixed :code:`fetch_diabetes_hospital` so that :code:`as_frame=False` returns numpy arrays instead of raising. The data is now always fetched as a pandas DataFrame internally and converted to numpy when needed. The skipped tests and the obsolete :code:`test_fetch_diabetes_hospital_as_ndarray_raises_value_error` test were removed: :pr:`1636` by :user:`Richard Ogundele <richardogundele>`.
 * :code:`BackendEngine` used to read :code:`X.shape[1]` without checking how many dimensions :code:`X` had, so passing data with more than two dimensions (for example an array of images) would silently build a predictor model with the wrong input size instead of failing. It now raises a :code:`ValueError` up front when :code:`X` is not two-dimensional: :pr:`1671` by :user:`Arnav <NotArnav03>`.
+* Extended the :code:`BackendEngine` two-dimensional check added in :pr:`1671` to the
+  public boundary of :class:`~fairlearn.adversarial.AdversarialFairnessClassifier` and
+  :class:`~fairlearn.adversarial.AdversarialFairnessRegressor`, so that :code:`fit`,
+  :code:`partial_fit`, and :code:`predict` reject features that are not two-dimensional
+  before any backend work happens. The check previously ran only when the backend
+  engine was constructed, on the first :code:`fit`, so on an already-fitted estimator a
+  three-dimensional :code:`X` whose second axis matched :code:`n_features_in_` reached
+  backend training or evaluation without raising. The :code:`ValueError` message now
+  also suggests reshaping the data: by :user:`breken-ai`.
 * Fixed :code:`FloatTransformer.transform` and
   :code:`FloatTransformer.inverse_transform` so that they raise
   :code:`NotFittedError` instead of :code:`AttributeError` when called before

--- a/fairlearn/adversarial/_adversarial_mitigation.py
+++ b/fairlearn/adversarial/_adversarial_mitigation.py
@@ -24,7 +24,7 @@ from sklearn.utils.validation import (
     validate_data,
 )
 
-from ._backend_engine import BackendEngine
+from ._backend_engine import BackendEngine, _check_2d
 from ._constants import (
     _CALLBACK_RETURNS_ERROR,
     _IMPORT_ERROR_MESSAGE,
@@ -547,6 +547,7 @@ class _AdversarialFairness(BaseEstimator):
         self : object
             Returns self.
         """
+        _check_2d(X)
         first_call = not hasattr(self, "classes_")
 
         if first_call and classes is not None:
@@ -577,6 +578,7 @@ class _AdversarialFairness(BaseEstimator):
             Two-dimensional array containing the model's (soft-)predictions
         """
         check_is_fitted(self)
+        _check_2d(X)
         X = validate_data(
             self,
             X,
@@ -671,6 +673,8 @@ class _AdversarialFairness(BaseEstimator):
                 raise ValueError(
                     "Unknown label type: Regression targets have been passed to AdversarialFairnessClassifier."
                 )
+
+        _check_2d(X)
 
         # Probe whether the estimator has been fitted so _validate_input
         # can decide whether to initialize the backend engine. `_is_setup`

--- a/fairlearn/adversarial/_backend_engine.py
+++ b/fairlearn/adversarial/_backend_engine.py
@@ -1,6 +1,7 @@
 # Copyright (c) Fairlearn contributors.
 # Licensed under the MIT License.
 
+import numpy as np
 from numpy import ndarray
 from sklearn.utils import shuffle
 
@@ -12,6 +13,15 @@ from ._constants import (
     _NOT_IMPLEMENTED,
     _X_NOT_2D,
 )
+
+
+def _check_2d(X):
+    """Validate matrix-shaped features without changing their representation."""
+    dimensions = getattr(X, "ndim", None)
+    if dimensions is None:
+        dimensions = np.asarray(X).ndim
+    if dimensions != 2:
+        raise ValueError(_X_NOT_2D.format(dimensions))
 
 
 class BackendEngine:
@@ -34,8 +44,7 @@ class BackendEngine:
         """
         self.base = base
 
-        if X.ndim != 2:
-            raise ValueError(_X_NOT_2D.format(X.ndim))
+        _check_2d(X)
         n_X_features = X.shape[1]
         n_Y_features = base._y_transform.n_features_out_
         n_A_features = base._sf_transform.n_features_out_

--- a/fairlearn/adversarial/_constants.py
+++ b/fairlearn/adversarial/_constants.py
@@ -41,4 +41,7 @@ _LIST_MODEL_UNSUPPORTED = (
     + "supported when the accompanying {}_loss is not a keyword."
 )
 _CALLBACK_RETURNS_ERROR = "Callback function returned a non-boolean value"
-_X_NOT_2D = "Expected 'X' to be a two-dimensional array, but got an array with {} dimension(s)."
+_X_NOT_2D = (
+    "Expected 'X' to be a two-dimensional array, but got an array with {} dimension(s). "
+    "Reshape your data to a two-dimensional array."
+)

--- a/test/unit/adversarial/test_adversarial_mitigation.py
+++ b/test/unit/adversarial/test_adversarial_mitigation.py
@@ -1,9 +1,10 @@
 # Copyright (c) Fairlearn contributors.
 # Licensed under the MIT License.
 
+import re
 import sys
 from typing import Literal
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import numpy as np
 import pandas as pd
@@ -14,6 +15,8 @@ from fairlearn.adversarial import (
     AdversarialFairnessRegressor,
 )
 from fairlearn.adversarial._adversarial_mitigation import _AdversarialFairness
+from fairlearn.adversarial._backend_engine import _check_2d
+from fairlearn.adversarial._constants import _X_NOT_2D
 from fairlearn.adversarial._preprocessor import FloatTransformer
 from test._sklearn_compat import parametrize_with_checks
 
@@ -32,6 +35,78 @@ from .helper import (
 )
 
 BackendType = Literal["torch", "tensorflow"]
+
+
+@pytest.mark.parametrize(
+    "X",
+    [[1, 2], np.array([1, 2]), np.zeros((1, 2, 3))],
+)
+def test_adversarial_non_2d_features_raise_shared_error_before_backend(X):
+    """The shared backend boundary rejects non-matrix features."""
+    ndim = np.asarray(X).ndim
+    with pytest.raises(ValueError, match=re.escape(_X_NOT_2D.format(ndim))):
+        _check_2d(X)
+
+
+def test_adversarial_check_2d_preserves_dataframe_identity_and_columns():
+    """The shared guard validates DataFrames without coercing their columns."""
+    X = pd.DataFrame([[1, 2]], columns=["first", "second"])
+    assert _check_2d(X) is None
+    assert X.columns.tolist() == ["first", "second"]
+
+
+def test_adversarial_check_2d_accepts_convertible_non_array_inputs():
+    """The guard avoids NumPy protocol dispatch when a shape is unavailable."""
+
+    class ConvertibleArray:
+        def __array__(self, dtype=None, copy=None):
+            return np.asarray([[1, 2]], dtype=dtype)
+
+        def __array_function__(self, func, types, args, kwargs):
+            raise TypeError(f"unsupported NumPy function: {func.__name__}")
+
+    assert _check_2d(ConvertibleArray()) is None
+
+
+@pytest.mark.parametrize("fake_backend_env", ["torch", "tensorflow"], indirect=True)
+@pytest.mark.parametrize("method", ["predict", "partial_fit"])
+@pytest.mark.parametrize(
+    "bad_X",
+    [
+        # 3-D with a trailing-feature axis matching ``n_features_in_``. This is the
+        # shape that reached the backend before the guard: ``allow_nd=True`` lets it
+        # past ``validate_data`` and ``X.shape[1] == n_features_in_`` satisfies the
+        # pre-existing feature-count check in ``partial_fit``.
+        np.zeros((Bin2d.shape[0], cols, 3)),
+        # 3-D with a mismatched second axis, and the two 1-D forms. These were already
+        # rejected before this change, by the feature-count check and by
+        # ``validate_data(ensure_2d=True)`` respectively; they are kept so the new
+        # guard is what raises, with one shared message, on every non-2D input.
+        np.zeros((1, 2, 3)),
+        [1, 2],
+        np.array([1, 2]),
+    ],
+)
+@pytest.mark.parametrize("skip_validation", [False, True])
+def test_fitted_adversarial_methods_reject_non_2d_before_backend(
+    fake_backend_env, method, bad_X, skip_validation
+):
+    """Fitted predict and partial-fit never invoke a backend for non-2D input."""
+    mitigator = get_instance(fake_mixin=True, fake_backend=fake_backend_env)
+    mitigator.fit(Bin2d, Bin1d, sensitive_features=Bin1d)
+    mitigator.skip_validation = skip_validation
+    backend_method = "evaluate" if method == "predict" else "train_step"
+    setattr(
+        mitigator.backendEngine_,
+        backend_method,
+        Mock(side_effect=AssertionError("backend called")),
+    )
+    with pytest.raises(ValueError, match=re.escape(_X_NOT_2D.format(np.asarray(bad_X).ndim))):
+        if method == "predict":
+            mitigator.predict(bad_X)
+        else:
+            mitigator.partial_fit(bad_X, Bin1d, sensitive_features=Bin1d)
+    getattr(mitigator.backendEngine_, backend_method).assert_not_called()
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
## Description

Extends the `BackendEngine` two-dimensional check added in #1671 from the backend
construction path to the public estimator boundary.

### Symptom

`BackendEngine.__init__` refuses non-two-dimensional `X` (#1671), but it only runs once,
when the backend engine is constructed on the first `fit`. After that the estimator is
fitted and the check never runs again. So on an **already-fitted**
`AdversarialFairnessClassifier` / `AdversarialFairnessRegressor`, a three-dimensional `X`
whose second axis happens to match `n_features_in_` slides all the way into the backend:
`predict` calls `backendEngine_.evaluate` on it, and `partial_fit` calls
`backendEngine_.train_step` on it. No error, and — depending on what the backend does with
the extra axis — either a wrong-shaped result or silent training on the wrong data.

The realistic way to hit this is exactly the case #1671 was written for: an array of
images, or any per-sample matrix, handed to a model that was fitted on tabular features of
a compatible width.

Copy-pasteable reproducer. It uses this repository's own fake-backend test helpers, so it
needs neither PyTorch nor TensorFlow installed. Save as `repro.py` in the repository root
and run `python repro.py`:

```python
import sys
from unittest.mock import Mock, patch

import numpy as np

sys.path.insert(0, ".")
from test.unit.adversarial.helper import (
    Bin1d,
    Bin2d,
    cols,
    get_backend_patches,
    get_instance,
)

with patch.dict(sys.modules, get_backend_patches("torch")):
    mitigator = get_instance(fake_mixin=True, fake_backend="torch")
    mitigator.fit(Bin2d, Bin1d, sensitive_features=Bin1d)
    print("n_features_in_ =", mitigator.n_features_in_)

    # 3-D, and X.shape[1] equals n_features_in_.
    X_bad = np.zeros((Bin2d.shape[0], cols, 3))
    print("X_bad.shape =", X_bad.shape)

    for method in ("predict", "partial_fit"):
        mitigator = get_instance(fake_mixin=True, fake_backend="torch")
        mitigator.fit(Bin2d, Bin1d, sensitive_features=Bin1d)
        name = "evaluate" if method == "predict" else "train_step"
        setattr(mitigator.backendEngine_, name, Mock(return_value=np.zeros((len(X_bad), 1))))
        try:
            if method == "predict":
                mitigator.predict(X_bad)
            else:
                mitigator.partial_fit(X_bad, Bin1d, sensitive_features=Bin1d)
            outcome = "NO ERROR"
        except Exception as exc:
            outcome = f"{type(exc).__name__}: {exc}"
        called = getattr(mitigator.backendEngine_, name).called
        print(f"{method:12s} -> {outcome} | backendEngine_.{name} called = {called}")
```

Against the merge base `dd4b1ed2c13206041527e0dbb8f59de282af6e79`, in a detached worktree
with `PYTHONPATH` pinned to it:

```
n_features_in_ = 5
X_bad.shape = (60, 5, 3)
predict      -> NO ERROR | backendEngine_.evaluate called = True
partial_fit  -> NO ERROR | backendEngine_.train_step called = True
```

With this branch applied:

```
n_features_in_ = 5
X_bad.shape = (60, 5, 3)
predict      -> ValueError: Expected 'X' to be a two-dimensional array, but got an array with 3 dimension(s). Reshape your data to a two-dimensional array. | backendEngine_.evaluate called = False
partial_fit  -> ValueError: Expected 'X' to be a two-dimensional array, but got an array with 3 dimension(s). Reshape your data to a two-dimensional array. | backendEngine_.train_step called = False
```

### What was already rejected at the merge base, and by what

The shape above is the *only* one that got through. I want to be explicit about that,
because it would be easy to overstate the size of this hole. Probed on a fitted estimator
at the merge base, calling `predict`, with the backend's `evaluate` replaced by a `Mock`:

| Input | Merge-base outcome | Backend called |
| --- | --- | --- |
| `[1, 2]` (1-D list) | `ValueError: Expected 2D array, got 1D array instead:` | no |
| `np.array([1, 2])` (1-D) | `ValueError: Expected 2D array, got 1D array instead:` | no |
| `np.zeros((1, 2, 3))` — 3-D, `shape[1] != n_features_in_` | `ValueError: X has 2 features, but _AdversarialFairness is expecting 5 features as input.` | no |
| `np.zeros((60, 5, 3))` — 3-D, `shape[1] == n_features_in_` | **no error** | **yes** |

Every row is identical with `skip_validation=False` and `skip_validation=True`;
`skip_validation` has no bearing on `predict`, because `_raw_predict` calls
`validate_data` unconditionally.

### Verified root cause

Two things combine, both at the merge base:

1. `fairlearn/adversarial/_backend_engine.py:37` — the #1671 check
   (`if X.ndim != 2: raise ValueError(_X_NOT_2D.format(X.ndim))`) lives in
   `BackendEngine.__init__`. `__init__` is reached only through
   `_AdversarialFairness.__setup`, which
   `fairlearn/adversarial/_adversarial_mitigation.py:688-689` calls only when
   `not is_fitted or reinitialize`, where `is_fitted = hasattr(self, "_is_setup")` at
   `:678`. On an already-fitted estimator the check simply does not run.
2. Both remaining validation paths pass N-D arrays through on purpose.
   `_raw_predict` (`:580-588`) calls `validate_data(..., allow_nd=True, reset=False)`, and
   `_validate_input` (`:644-653`, the `fit` / `partial_fit` path) calls
   `validate_data(..., allow_nd=True, ensure_2d=True)`. With `allow_nd=True` the only
   remaining shape assertion is scikit-learn's `n_features_in_ == X.shape[1]` check — which
   a `(n, n_features_in_, k)` array satisfies.

So the guard exists, it is just on the wrong side of the "already fitted" branch.

### What the change does

* Lifts the ndim check out of `BackendEngine.__init__` into a module-level `_check_2d(X)`
  in `fairlearn/adversarial/_backend_engine.py`, and calls it from `__init__` as before, so
  the #1671 behaviour is preserved exactly.
* Calls `_check_2d(X)` at the three public entry points in
  `_adversarial_mitigation.py`: `partial_fit`, `_raw_predict` (after `check_is_fitted`,
  before `validate_data`), and `_validate_input` (which `fit` and `partial_fit` share).
  The result is one message for every non-two-dimensional `X`, raised before any backend
  work happens, fitted or not.
* `_check_2d` reads `X.ndim` when the object has it and falls back to `np.asarray(X).ndim`
  otherwise. It does not coerce or replace `X`, so a `DataFrame` still arrives at
  `validate_data` as a `DataFrame` with its columns intact.

105 added lines, 5 removed, across 5 files.

### Behaviour change to disclose

`_X_NOT_2D` in `fairlearn/adversarial/_constants.py` gains a second sentence:
`"Reshape your data to a two-dimensional array."` This also changes the message text
raised on the pre-existing #1671 backend-construction path.

That sentence is not cosmetic — it is required. Placing `_check_2d` in `_raw_predict`
*before* `validate_data` means the new guard now raises on 1-D input where scikit-learn's
`validate_data` used to. scikit-learn's own estimator check `check_fit2d_predict1d`, which
this repository runs via `parametrize_with_checks` in
`test/unit/adversarial/test_adversarial_mitigation.py`, asserts
`raises(ValueError, match="Reshape your data")`. At the merge base that passed because
scikit-learn's message reads:

```
Expected 2D array, got 1D array instead:
array=[1. 2. 3. 4. 5.].
Reshape your data either using array.reshape(-1, 1) if your data has a single feature or array.reshape(1, -1) if it contains a single sample.
```

I measured what happens without the added sentence: reverting only `_constants.py` to the
merge base and re-running the directory gives

```
5 failed, 324 passed, 5 skipped, 6 xfailed, 6 xpassed in 8.16s
```

and all five failures are `check_fit2d_predict1d` (three under the torch parametrization,
two under tensorflow), each with
`AssertionError: The error message should contain one of the following patterns: Reshape your data`.

`code_style.rst` says of estimators that you "must ensure the estimator is fully
compatible with scikit-learn", and this repository already runs that check suite against
both adversarial estimators, so keeping it green is a requirement here. Folding
the sentence into the shared constant keeps the message identical on both paths rather
than splitting it into two spellings. The cost is that anyone matching the #1671 message
on its full exact text will break. Nothing in this repository does; I did not search
outside it. If you would rather not touch the #1671 message, the alternative is to move
`_check_2d` in `_raw_predict` to *after* `validate_data`, which keeps both messages as they
are but leaves 1-D input reported by scikit-learn and N-D input by fairlearn.

### On the Narwhals migration

`code_style.rst` recommends `narwhals` over `pandas` for new code. This change adds no
pandas at all — the only new logic is a NumPy `ndim` check.

## Tests

- [ ] no new tests required
- [x] new tests added
- [ ] existing tests adjusted

Four new tests in `test/unit/adversarial/test_adversarial_mitigation.py`, 37 cases in
total:

* `test_fitted_adversarial_methods_reject_non_2d_before_backend` — 32 cases, the
  important one. `{torch, tensorflow} x {predict, partial_fit} x 4 bad shapes x
  {skip_validation False, True}`, on a fitted estimator, with the relevant backend method
  replaced by a `Mock` that raises if it is called. Asserts both the message and
  `assert_not_called()`. The first of the four shapes is
  `np.zeros((Bin2d.shape[0], cols, 3))`, i.e. 3-D with `shape[1] == n_features_in_` — the
  one shape that actually reached the backend. The other three were already rejected at
  the merge base (see the table above) and are kept so that the new guard is what raises,
  with one message, on every non-2D input.
* `test_adversarial_non_2d_features_raise_shared_error_before_backend` — 3 cases on
  `_check_2d` directly.
* `test_adversarial_check_2d_preserves_dataframe_identity_and_columns` — asserts a
  `DataFrame` is neither coerced nor stripped of its column names.
* `test_adversarial_check_2d_accepts_convertible_non_array_inputs` — asserts the guard
  uses `__array__` rather than dispatching through `__array_function__`.

### Commands run and their output

Environment: Python 3.12.12, macOS, scikit-learn 1.9.0, pandas 3.0.5, numpy 2.5.3,
ruff 0.16.6.

```
$ python -m pytest test/unit/adversarial -q -p no:randomly
329 passed, 5 skipped, 6 xfailed, 6 xpassed in 8.48s

$ ruff check fairlearn/adversarial test/unit/adversarial docs
All checks passed!

$ ruff format --check fairlearn/adversarial test/unit/adversarial
11 files already formatted

$ git diff --check dd4b1ed2c13206041527e0dbb8f59de282af6e79
(no output)
```

The same directory at the merge base, in a detached worktree:

```
$ python -m pytest test/unit/adversarial -q -p no:randomly
292 passed, 5 skipped, 6 xfailed, 6 xpassed in 4.65s
```

329 - 292 = 37, exactly the new case count; no pre-existing case changed state.

### Revert proof

Restoring only `fairlearn/adversarial/_adversarial_mitigation.py` to the merge base — so
`_check_2d` is still defined and importable, and this is not an `ImportError` artefact:

```
$ git checkout dd4b1ed2c13206041527e0dbb8f59de282af6e79 -- fairlearn/adversarial/_adversarial_mitigation.py
$ python -m pytest test/unit/adversarial/test_adversarial_mitigation.py -q -p no:randomly \
    -k test_fitted_adversarial_methods_reject_non_2d_before_backend
32 failed, 292 deselected in 1.82s
```

Narrowed to the eight cases that use the reproducing shape
(`bad_X0 = np.zeros((60, 5, 3))`, `shape[1] == n_features_in_`):

```
$ python -m pytest test/unit/adversarial/test_adversarial_mitigation.py -q -p no:randomly \
    -k "test_fitted_adversarial_methods_reject_non_2d_before_backend and bad_X0"
8 failed, 316 deselected in 1.70s
   8 x  E   AssertionError: backend called
```

All eight fail on `assert_not_called()`, i.e. the mocked `backendEngine_.evaluate` /
`train_step` really was invoked without the fix — not merely on a message mismatch.
Restoring the file: `329 passed, 5 skipped, 6 xfailed, 6 xpassed`.

## Documentation

- [ ] no documentation changes needed
- [x] user guide added or updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

"user guide added or updated" is ticked only because the release note lives under
`docs/user_guide/` — the change is one entry in
`docs/user_guide/installation_and_version_guide/v0.15.0.rst`, placed directly after the
#1671 entry it extends. No prose user-guide page was edited.

"API docs added or updated" is left unticked: no signature or parameter changes, and the
`fit` / `partial_fit` / `predict` docstrings already say `X` is a two-dimensional array,
which is now enforced rather than assumed. If you would like the raised `ValueError`
documented in a `Raises` section, I will add it.

The changelog entry ends `by :user:`breken-ai`` with no `:pr:` role, because the PR number
does not exist until this PR is opened. Tell me the number and I will add it in the same
format as the surrounding entries.

## What was not verified

* **No real PyTorch or TensorFlow.** Neither is installed in my virtualenv. Every piece of
  evidence here — the tests, the reproducer, the revert proof — runs against this
  repository's fake-backend helpers. That is what makes "the backend was never called"
  assertable at all, but it means the new path has not been exercised against a real
  `torch.nn.Module` or Keras model.
* **No search for external consumers of the `_X_NOT_2D` text.** The constant is private
  and is referenced only from `_backend_engine.py` and the test module inside this
  repository. Code outside this repository matching on the message string was not searched.
* **Only `test/unit/adversarial` was run**, not the full `test/unit` suite.
* **One environment only**: Python 3.12.12 on macOS with the versions pinned above. No
  `requirements-min.txt` run, and no other Python version.
* **No coverage report.** `codecov` is an explicit CI gate per `code_style.rst`;
  `coverage.py` and `pytest-cov` are not installed in my virtualenv. The new `_check_2d`
  body is exercised by all 37 new cases, but that is an argument, not a coverage number.
* **No Sphinx docs build**, so the new release-note entry is unrendered — I checked its
  markup by eye against the surrounding entries only.
* **Not tested: sparse input.** `validate_data` is called with `accept_sparse=False` on
  both paths, so sparse matrices were already rejected; I did not construct a case to
  confirm `_check_2d` does not change that ordering.

## Screenshots

Not applicable — no visualization or website changes.
