### PR TITLE
ENH: report authoritative UCI feature names in dataset loaders

### DIFF
--- a/docs/user_guide/installation_and_version_guide/v0.15.0.rst
+++ b/docs/user_guide/installation_and_version_guide/v0.15.0.rst
@@ -61,6 +61,18 @@ Other improvements
   reductions constraints by removing the redundant per-event group-membership
   component while preserving the classifier-dependent Lagrangian term: :pr:`1714`
   by :user:`quinnarnold <quinnarnold>`.
+* **Behaviour change.** :func:`~fairlearn.datasets.fetch_bank_marketing` and
+  :func:`~fairlearn.datasets.fetch_credit_card` now report the authoritative UCI
+  column names (:code:`age`, :code:`job`, ... and :code:`LIMIT_BAL`, :code:`SEX`, ...)
+  instead of passing through the placeholder names carried by the underlying OpenML
+  records (:code:`V1` ... :code:`V16` and :code:`x1` ... :code:`x23`), so a sensitive
+  feature can be selected by its documented name. The names are applied consistently to
+  :code:`feature_names`, the :code:`data` and :code:`frame` DataFrame columns, and the
+  :code:`return_X_y=True` result; categorical metadata keys in non-frame Bunches are
+  remapped to match. Code that selects columns by the previous OpenML names will need
+  updating; positional access, OpenML data IDs, targets, arrays, and dtypes are
+  unchanged. The loaders now raise a :code:`ValueError` rather than relabelling if a
+  record's column count ever stops matching: by :user:`breken-ai`.
 * Preserved multi-column sensitive feature data in
   :class:`fairlearn.postprocessing.ThresholdOptimizer` data reformatting helpers:
   :pr:`1679` by :user:`BALOGUN-DAVID <BALOGUN-DAVID>`.

--- a/fairlearn/datasets/_fetch_bank_marketing.py
+++ b/fairlearn/datasets/_fetch_bank_marketing.py
@@ -7,6 +7,25 @@ from sklearn.datasets import fetch_openml
 
 from ._constants import _DOWNLOAD_DIRECTORY_NAME
 
+_BANK_FEATURE_NAMES = [
+    "age",
+    "job",
+    "marital",
+    "education",
+    "default",
+    "balance",
+    "housing",
+    "loan",
+    "contact",
+    "day",
+    "month",
+    "duration",
+    "campaign",
+    "pdays",
+    "previous",
+    "poutcome",
+]
+
 
 def fetch_bank_marketing(*, cache=True, data_home=None, as_frame=True, return_X_y=False):
     """Load the UCI bank marketing dataset (binary classification).
@@ -74,12 +93,23 @@ def fetch_bank_marketing(*, cache=True, data_home=None, as_frame=True, return_X_
             otherwise.
             If ``as_frame`` is True, ``target`` is a pandas object.
         feature_names : list of length 16
-            Array of ordered feature names used in the dataset.
+            The ordered UCI column names: ``age``, ``job``, ``marital``,
+            ``education``, ``default``, ``balance``, ``housing``, ``loan``,
+            ``contact``, ``day``, ``month``, ``duration``, ``campaign``,
+            ``pdays``, ``previous``, ``poutcome``. When ``as_frame`` is True the
+            same names are used for the ``data`` and ``frame`` columns, and for
+            the ``X`` returned by ``return_X_y=True``.
+
+            .. versionchanged:: 0.15.0
+                Previously these were whatever names the underlying OpenML
+                record carried, which are placeholders (``V1`` ... ``V16``)
+                rather than the UCI column names.
         DESCR : string
             Description of the UCI bank marketing dataset.
         categories : dict or None
             Maps each categorical feature name to a list of values, such that the
             value encoded as i is ith in the list. If ``as_frame`` is True, this is None.
+            The keys use the UCI names listed under ``feature_names``.
         frame : pandas DataFrame
             Only present when ``as_frame`` is True. DataFrame with ``data`` and ``target``.
 
@@ -94,7 +124,7 @@ def fetch_bank_marketing(*, cache=True, data_home=None, as_frame=True, return_X_
 
     # For data_home see
     # https://github.com/scikit-learn/scikit-learn/issues/27447
-    return fetch_openml(
+    result = fetch_openml(
         data_id=1461,
         data_home=str(data_home),
         cache=cache,
@@ -102,3 +132,35 @@ def fetch_bank_marketing(*, cache=True, data_home=None, as_frame=True, return_X_
         return_X_y=return_X_y,
         parser="auto",
     )
+    # The authoritative names are applied positionally, so refuse to relabel a record
+    # whose width does not match instead of silently mislabelling the columns.
+    if return_X_y:
+        X, y = result
+        original_feature_names = list(X.columns) if as_frame else []
+        observed_n_features = X.shape[1]
+    else:
+        original_feature_names = list(result.feature_names)
+        observed_n_features = len(original_feature_names)
+    if observed_n_features != len(_BANK_FEATURE_NAMES):
+        raise ValueError(
+            f"Expected the OpenML record with data_id=1461 backing the UCI bank marketing "
+            f"dataset to have {len(_BANK_FEATURE_NAMES)} features, but it has "
+            f"{observed_n_features}. The authoritative feature names are applied "
+            f"positionally and cannot be matched to this record."
+        )
+
+    if return_X_y:
+        if as_frame:
+            X = X.copy()
+            X.columns = _BANK_FEATURE_NAMES
+        return X, y
+    result.feature_names = _BANK_FEATURE_NAMES
+    if as_frame:
+        result.data.columns = _BANK_FEATURE_NAMES
+        result.frame.columns = _BANK_FEATURE_NAMES + [result.target.name]
+    elif isinstance(getattr(result, "categories", None), dict):
+        feature_name_map = dict(zip(original_feature_names, _BANK_FEATURE_NAMES, strict=True))
+        result.categories = {
+            feature_name_map.get(name, name): values for name, values in result.categories.items()
+        }
+    return result

--- a/fairlearn/datasets/_fetch_credit_card.py
+++ b/fairlearn/datasets/_fetch_credit_card.py
@@ -7,6 +7,24 @@ from sklearn.datasets import fetch_openml
 
 from ._constants import _DOWNLOAD_DIRECTORY_NAME
 
+_CREDIT_FEATURE_NAMES = (
+    [
+        "LIMIT_BAL",
+        "SEX",
+        "EDUCATION",
+        "MARRIAGE",
+        "AGE",
+        "PAY_0",
+        "PAY_2",
+        "PAY_3",
+        "PAY_4",
+        "PAY_5",
+        "PAY_6",
+    ]
+    + [f"BILL_AMT{i}" for i in range(1, 7)]
+    + [f"PAY_AMT{i}" for i in range(1, 7)]
+)
+
 
 def fetch_credit_card(*, cache=True, data_home=None, as_frame=True, return_X_y=False):
     """Load the 'Default of Credit Card clients' dataset (binary classification).
@@ -64,12 +82,23 @@ def fetch_credit_card(*, cache=True, data_home=None, as_frame=True, return_X_y=F
             Each value represents whether an applicant defaulted on credit loan.
             If ``as_frame`` is True, ``target`` is a Pandas Series.
         feature_names : List of Strings, Length 23
-            Array of ordered feature names used in the dataset.
+            The ordered UCI column names: ``LIMIT_BAL``, ``SEX``, ``EDUCATION``,
+            ``MARRIAGE``, ``AGE``, ``PAY_0``, ``PAY_2`` ... ``PAY_6``,
+            ``BILL_AMT1`` ... ``BILL_AMT6``, ``PAY_AMT1`` ... ``PAY_AMT6``.
+            When ``as_frame`` is True the same names are used for the ``data``
+            and ``frame`` columns, and for the ``X`` returned by
+            ``return_X_y=True``.
+
+            .. versionchanged:: 0.15.0
+                Previously these were whatever names the underlying OpenML
+                record carried, which are placeholders (``x1`` ... ``x23``)
+                rather than the UCI column names.
         DESCR : string
             Description of the UCI Default of Credit Card
         categories : dict or None
             Maps each categorical feature name to a list of values, such that the
             value encoded as i is ith in the list. If ``as_frame`` is True, this is None.
+            The keys use the UCI names listed under ``feature_names``.
         frame : pandas DataFrame
             Only present when ``as_frame`` is True. DataFrame with ``data`` and ``target``.
 
@@ -85,7 +114,7 @@ def fetch_credit_card(*, cache=True, data_home=None, as_frame=True, return_X_y=F
 
     # For data_home see
     # https://github.com/scikit-learn/scikit-learn/issues/27447
-    return fetch_openml(
+    result = fetch_openml(
         data_id=42477,
         data_home=str(data_home),
         cache=cache,
@@ -93,3 +122,35 @@ def fetch_credit_card(*, cache=True, data_home=None, as_frame=True, return_X_y=F
         return_X_y=return_X_y,
         parser="auto",
     )
+    # The authoritative names are applied positionally, so refuse to relabel a record
+    # whose width does not match instead of silently mislabelling the columns.
+    if return_X_y:
+        X, y = result
+        original_feature_names = list(X.columns) if as_frame else []
+        observed_n_features = X.shape[1]
+    else:
+        original_feature_names = list(result.feature_names)
+        observed_n_features = len(original_feature_names)
+    if observed_n_features != len(_CREDIT_FEATURE_NAMES):
+        raise ValueError(
+            f"Expected the OpenML record with data_id=42477 backing the UCI 'Default of Credit Card clients' "
+            f"dataset to have {len(_CREDIT_FEATURE_NAMES)} features, but it has "
+            f"{observed_n_features}. The authoritative feature names are applied "
+            f"positionally and cannot be matched to this record."
+        )
+
+    if return_X_y:
+        if as_frame:
+            X = X.copy()
+            X.columns = _CREDIT_FEATURE_NAMES
+        return X, y
+    result.feature_names = _CREDIT_FEATURE_NAMES
+    if as_frame:
+        result.data.columns = _CREDIT_FEATURE_NAMES
+        result.frame.columns = _CREDIT_FEATURE_NAMES + [result.target.name]
+    elif isinstance(getattr(result, "categories", None), dict):
+        feature_name_map = dict(zip(original_feature_names, _CREDIT_FEATURE_NAMES, strict=True))
+        result.categories = {
+            feature_name_map.get(name, name): values for name, values in result.categories.items()
+        }
+    return result

--- a/test/unit/datasets/test_datasets.py
+++ b/test/unit/datasets/test_datasets.py
@@ -1,9 +1,12 @@
 # Copyright (c) Fairlearn contributors.
 # Licensed under the MIT License.
 
+from unittest.mock import patch
+
 import numpy as np
 import pandas as pd
 import pytest
+from sklearn.utils import Bunch
 
 from fairlearn.datasets import (
     fetch_acs_income,
@@ -19,6 +22,241 @@ from test.utils import DATA_HOME
 
 
 class TestFairlearnDataset:
+    @pytest.mark.parametrize(
+        ("module", "loader", "data_id", "names"),
+        [
+            (
+                "fairlearn.datasets._fetch_bank_marketing",
+                fetch_bank_marketing,
+                1461,
+                [
+                    "age",
+                    "job",
+                    "marital",
+                    "education",
+                    "default",
+                    "balance",
+                    "housing",
+                    "loan",
+                    "contact",
+                    "day",
+                    "month",
+                    "duration",
+                    "campaign",
+                    "pdays",
+                    "previous",
+                    "poutcome",
+                ],
+            ),
+            (
+                "fairlearn.datasets._fetch_credit_card",
+                fetch_credit_card,
+                42477,
+                [
+                    "LIMIT_BAL",
+                    "SEX",
+                    "EDUCATION",
+                    "MARRIAGE",
+                    "AGE",
+                    "PAY_0",
+                    "PAY_2",
+                    "PAY_3",
+                    "PAY_4",
+                    "PAY_5",
+                    "PAY_6",
+                ]
+                + [f"BILL_AMT{i}" for i in range(1, 7)]
+                + [f"PAY_AMT{i}" for i in range(1, 7)],
+            ),
+        ],
+    )
+    def test_dataset_authoritative_feature_names_without_network(
+        self, module, loader, data_id, names
+    ):
+        data = pd.DataFrame(
+            np.zeros((2, len(names))), columns=[f"old{i}" for i in range(len(names))]
+        )
+        target = pd.Series(["no", "yes"], name="target")
+        bunch = Bunch(
+            data=data,
+            target=target,
+            frame=pd.concat([data, target], axis=1),
+            feature_names=list(data.columns),
+        )
+        with patch(f"{module}.fetch_openml", return_value=bunch) as mocked:
+            result = loader(as_frame=True)
+        assert result.feature_names == names
+        assert result.data.columns.tolist() == names
+        assert result.frame.columns.tolist() == names + ["target"]
+        assert result.target.tolist() == ["no", "yes"]
+        assert mocked.call_args.kwargs["data_id"] == data_id
+
+    @pytest.mark.parametrize(
+        ("module", "loader", "data_id", "names"),
+        [
+            (
+                "fairlearn.datasets._fetch_bank_marketing",
+                fetch_bank_marketing,
+                1461,
+                [
+                    "age",
+                    "job",
+                    "marital",
+                    "education",
+                    "default",
+                    "balance",
+                    "housing",
+                    "loan",
+                    "contact",
+                    "day",
+                    "month",
+                    "duration",
+                    "campaign",
+                    "pdays",
+                    "previous",
+                    "poutcome",
+                ],
+            ),
+            (
+                "fairlearn.datasets._fetch_credit_card",
+                fetch_credit_card,
+                42477,
+                [
+                    "LIMIT_BAL",
+                    "SEX",
+                    "EDUCATION",
+                    "MARRIAGE",
+                    "AGE",
+                    "PAY_0",
+                    "PAY_2",
+                    "PAY_3",
+                    "PAY_4",
+                    "PAY_5",
+                    "PAY_6",
+                ]
+                + [f"BILL_AMT{i}" for i in range(1, 7)]
+                + [f"PAY_AMT{i}" for i in range(1, 7)],
+            ),
+        ],
+    )
+    def test_dataset_feature_metadata_keeps_ndarray_and_return_xy_contract(
+        self, module, loader, data_id, names
+    ):
+        array = np.zeros((2, len(names)))
+        target = np.array([0, 1])
+        bunch = Bunch(
+            data=array, target=target, feature_names=[f"old{i}" for i in range(len(names))]
+        )
+        with patch(f"{module}.fetch_openml", return_value=bunch):
+            result = loader(as_frame=False)
+        assert result.feature_names == names
+        assert isinstance(result.data, np.ndarray)
+        assert result.target.tolist() == [0, 1]
+        frame = pd.DataFrame(array, columns=[f"old{i}" for i in range(len(names))])
+        with patch(f"{module}.fetch_openml", return_value=(frame, target)):
+            X, y = loader(as_frame=True, return_X_y=True)
+        assert X.columns.tolist() == names
+        assert y.tolist() == [0, 1]
+        with patch(f"{module}.fetch_openml", return_value=(array, target)):
+            X, y = loader(as_frame=False, return_X_y=True)
+        assert isinstance(X, np.ndarray)
+        assert y.tolist() == [0, 1]
+
+    @pytest.mark.parametrize(
+        ("module", "loader", "names"),
+        [
+            (
+                "fairlearn.datasets._fetch_bank_marketing",
+                fetch_bank_marketing,
+                [
+                    "age",
+                    "job",
+                    "marital",
+                    "education",
+                    "default",
+                    "balance",
+                    "housing",
+                    "loan",
+                    "contact",
+                    "day",
+                    "month",
+                    "duration",
+                    "campaign",
+                    "pdays",
+                    "previous",
+                    "poutcome",
+                ],
+            ),
+            (
+                "fairlearn.datasets._fetch_credit_card",
+                fetch_credit_card,
+                [
+                    "LIMIT_BAL",
+                    "SEX",
+                    "EDUCATION",
+                    "MARRIAGE",
+                    "AGE",
+                    "PAY_0",
+                    "PAY_2",
+                    "PAY_3",
+                    "PAY_4",
+                    "PAY_5",
+                    "PAY_6",
+                ]
+                + [f"BILL_AMT{i}" for i in range(1, 7)]
+                + [f"PAY_AMT{i}" for i in range(1, 7)],
+            ),
+        ],
+    )
+    def test_non_frame_categories_follow_renamed_feature_metadata(self, module, loader, names):
+        original_names = [f"V{i}" for i in range(len(names))]
+        categories = {"V0": ["low", "high"], "unrelated": ["keep"]}
+        bunch = Bunch(
+            data=np.zeros((2, len(names))),
+            target=np.array([0, 1]),
+            feature_names=original_names,
+            categories=categories,
+        )
+
+        with patch(f"{module}.fetch_openml", return_value=bunch):
+            result = loader(as_frame=False)
+
+        assert result.categories == {names[0]: ["low", "high"], "unrelated": ["keep"]}
+        assert result.feature_names == names
+
+    @pytest.mark.parametrize(
+        ("module", "loader", "data_id"),
+        [
+            ("fairlearn.datasets._fetch_bank_marketing", fetch_bank_marketing, 1461),
+            ("fairlearn.datasets._fetch_credit_card", fetch_credit_card, 42477),
+        ],
+    )
+    @pytest.mark.parametrize(
+        ("as_frame", "return_X_y"), [(True, False), (False, False), (True, True), (False, True)]
+    )
+    def test_dataset_loader_refuses_to_rename_a_record_of_unexpected_width(
+        self, module, loader, data_id, as_frame, return_X_y
+    ):
+        n_columns = 3
+        columns = [f"old{i}" for i in range(n_columns)]
+        frame = pd.DataFrame(np.zeros((2, n_columns)), columns=columns)
+        target = pd.Series([0, 1], name="target")
+        if return_X_y:
+            payload = (frame, target) if as_frame else (frame.to_numpy(), target.to_numpy())
+        else:
+            payload = Bunch(
+                data=frame if as_frame else frame.to_numpy(),
+                target=target,
+                frame=pd.concat([frame, target], axis=1),
+                feature_names=columns,
+            )
+        expected = rf"data_id={data_id} .* to have \d+ features, but it has {n_columns}\."
+        with (
+            patch(f"{module}.fetch_openml", return_value=payload),
+            pytest.raises(ValueError, match=expected),
+        ):
+            loader(as_frame=as_frame, return_X_y=return_X_y)
+
     @pytest.mark.openml
     @pytest.mark.parametrize("as_frame", [True, False])
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

### Related issue

Closes #1165.

That issue, open since January 2023, reports exactly this: both loaders return OpenML placeholder names instead of the real feature names. A June 2026 comment on it proposed moving `fetch_bank_marketing` to OpenML `data_id=44234`, which does carry real names, and noted two side effects of that swap: categoricals arrive as `str` rather than `category`, and the target labels change from `'1'`/`'2'` to `'no'`/`'yes'`.

This PR takes the other route for both loaders. It applies the authoritative UCI names to the existing records, so the data IDs, dtypes and targets stay exactly as they are today. For `fetch_credit_card` that is the same approach the comment proposed, since no OpenML version of that dataset carries real names.

### What this is

**This is a behaviour change, not a bug fix.** It changes public output that two dataset
loaders return today. Please read the trade-off section before the diff — the risky part
of this PR is not the code, it is whether you want the rename at all.

### Symptom

`fetch_bank_marketing` and `fetch_credit_card` load two well-known UCI datasets whose
columns have documented, meaningful names — `age`, `job`, `marital`, `education`, … and
`LIMIT_BAL`, `SEX`, `EDUCATION`, `MARRIAGE`, `AGE`, … But the loaders return the
placeholder names carried by the underlying OpenML records instead, so you cannot select
the sensitive feature by the name it is known by. Observed live against the real OpenML
records at the merge base `dd4b1ed2c13206041527e0dbb8f59de282af6e79`:

```
bank feature_names   : ['V1', 'V2', 'V3', 'V4', 'V5', 'V6', 'V7', 'V8', 'V9', 'V10', 'V11', 'V12', 'V13', 'V14', 'V15', 'V16']
credit feature_names : ['x1', 'x2', 'x3', 'x4', 'x5', 'x6', 'x7', 'x8', 'x9', 'x10', 'x11', 'x12', 'x13', 'x14', 'x15', 'x16', 'x17', 'x18', 'x19', 'x20', 'x21', 'x22', 'x23']
bank: data['age'] -> KeyError: 'age'
credit: data['SEX'] -> KeyError: 'SEX'
```

For a fairness library this bites harder than usual: the sensitive feature in the credit
card dataset is `SEX`, and in the bank marketing dataset it is `age` — and the only way to
reach either of them is to know that `SEX` is `x2` and `age` is `V1`, which nothing in
fairlearn tells you.

With this branch applied, against the same records:

```
bank feature_names   : ['age', 'job', 'marital', 'education', 'default', 'balance', 'housing', 'loan', 'contact', 'day', 'month', 'duration', 'campaign', 'pdays', 'previous', 'poutcome']
credit feature_names : ['LIMIT_BAL', 'SEX', 'EDUCATION', 'MARRIAGE', 'AGE', 'PAY_0', 'PAY_2', 'PAY_3', 'PAY_4', 'PAY_5', 'PAY_6', 'BILL_AMT1', 'BILL_AMT2', 'BILL_AMT3', 'BILL_AMT4', 'BILL_AMT5', 'BILL_AMT6', 'PAY_AMT1', 'PAY_AMT2', 'PAY_AMT3', 'PAY_AMT4', 'PAY_AMT5', 'PAY_AMT6']
bank: data['age'] -> OK
credit: data['SEX'] -> OK
```

### Verified root cause

Both loaders return `fetch_openml(...)` directly —
`fairlearn/datasets/_fetch_bank_marketing.py:97` and
`fairlearn/datasets/_fetch_credit_card.py:88` at the merge base — so whatever column names
the OpenML records for `data_id=1461` and `data_id=42477` happen to carry are what the
caller gets. Those two records use positional placeholders.

**There was no documented contract being violated.** I want to be straight about this
rather than dress the change up as a fix. Here are the two `feature_names` docstring
entries at the merge base, in full:

```
        feature_names : list of length 16
            Array of ordered feature names used in the dataset.
```

```
        feature_names : List of Strings, Length 23
            Array of ordered feature names used in the dataset.
```

Neither names a single UCI column, so nothing promised `age` or `LIMIT_BAL` and nothing
was broken. This PR *creates* that contract and documents it — which is why it is
classified `ENH:` and filed under **Other improvements** rather than **Bug fixes**.

### What the change does

* Adds `_BANK_FEATURE_NAMES` (16) and `_CREDIT_FEATURE_NAMES` (23), transcribed from the
  UCI documentation for *Bank Marketing* and *Default of Credit Card Clients*.
* Applies them consistently across all four return shapes: `feature_names`, the `data` and
  `frame` DataFrame columns when `as_frame=True`, and the `X` returned by
  `return_X_y=True`. For non-frame Bunches, the `categories` metadata keys are remapped to
  the new names via a `strict=True` zip, so a length mismatch raises rather than silently
  truncating.
* Before relabelling anything, computes the observed feature count for whichever return
  shape was requested and raises a `ValueError` naming the OpenML `data_id` if it does not
  match the authoritative name count.
* Rewrites both `feature_names` docstring entries to list the authoritative names, notes
  that `categories` keys use the same names, and adds a `.. versionchanged:: 0.15.0`
  directive recording that the previous names were the OpenML placeholders.

Unchanged: OpenML data IDs, targets, dtypes, row order, positional access, the numpy
arrays returned when `as_frame=False`, and the OpenML target column name appended to
`frame` (still `Class` for bank marketing — verified on the branch:
`b.frame.columns.tolist()[-3:]` is `['previous', 'poutcome', 'Class']`).

377 added lines, 4 removed, across 4 files; 238 of the added lines are the new tests.

### Trade-offs a reviewer should weigh

1. **The names are applied positionally. This is the one thing worth your eyes.** Nothing
   in the OpenML record ties `V1` to `age`; the mapping is "the first column is the first
   UCI column". I checked that the mapping is right *today* against the live records, but
   by eye on a handful of columns, not by a full column-by-column diff against the UCI
   CSVs. Bank row 0 on the branch reads:

   ```
   {'age': 58, 'job': 'management', 'marital': 'married', 'education': 'tertiary',
    'default': 'no', 'balance': 2143, 'housing': 'yes', 'loan': 'no',
    'contact': 'unknown', 'day': 5, 'month': 'may', 'duration': 261,
    'campaign': 1, 'pdays': -1, 'previous': 0, 'poutcome': 'unknown'}
   ```

   which matches the first record of UCI `bank-full.csv`. Credit row 0 reads
   `{'LIMIT_BAL': 20000, 'SEX': 2, 'EDUCATION': 2, 'MARRIAGE': 1, 'AGE': 24, 'PAY_0': 2}`,
   matching the first record of the UCI file. Domain checks on the branch: bank `age`
   ranges 18–95, credit `SEX` takes only `{1, 2}`, credit `AGE` ranges 21–79.

2. **The width guard catches a resize, not a reorder.** If OpenML ever republishes either
   record with the same number of columns in a different order, the loaders will
   confidently apply the wrong names and nothing here will notice. A guard that would
   catch that needs a value-level fingerprint of the record, which is a bigger and more
   brittle thing to maintain. I did not add one; I think it is your call whether the
   positional assumption is acceptable.

3. **Downstream breakage.** Code selecting columns by `V1`…`V16` or `x1`…`x23` will get a
   `KeyError`. Nothing inside this repository does — the only non-test references to these
   two loaders are `fairlearn/datasets/__init__.py` and `docs/api_reference/index.rst`, and
   no example notebook or user-guide page uses them. External notebooks and blog posts are
   a different matter, which is why this is flagged as a behaviour change in the release
   note and carries a `versionchanged` directive.

4. **On the Narwhals migration.** `code_style.rst` recommends `narwhals` over `pandas` for
   new code. This change adds `X.columns = ...`, `result.data.columns = ...` and
   `result.frame.columns = ...`. These operate on objects that `fetch_openml` hands back as
   pandas, and the `Bunch` contract these loaders document is a pandas contract, so
   converting to narwhals and back would change the returned types. I kept pandas for that
   reason; happy to be told otherwise.

## Tests

- [ ] no new tests required
- [x] new tests added
- [ ] existing tests adjusted

Four new tests in `test/unit/datasets/test_datasets.py`, 14 cases, all network-free
(`fetch_openml` is patched, so they run in the default CI job rather than only in the
OpenML job):

* `test_dataset_authoritative_feature_names_without_network` — 2 cases. `as_frame=True`:
  asserts `feature_names`, `data.columns`, `frame.columns` (names plus the target) and that
  the target is untouched, and that the `data_id` passed to `fetch_openml` is unchanged.
* `test_dataset_feature_metadata_keeps_ndarray_and_return_xy_contract` — 2 cases. Covers
  `as_frame=False` and both `return_X_y=True` shapes, asserting ndarrays stay ndarrays.
* `test_non_frame_categories_follow_renamed_feature_metadata` — 2 cases. Asserts the
  `categories` keys are remapped and unrelated keys are left alone.
* `test_dataset_loader_refuses_to_rename_a_record_of_unexpected_width` — 8 cases,
  2 loaders x 4 `as_frame` / `return_X_y` combinations. Feeds a 3-column record and asserts
  the `ValueError` text.

### Commands run and their output

Environment: Python 3.12.12, macOS, scikit-learn 1.9.0, pandas 3.0.5, numpy 2.5.3,
ruff 0.16.6.

```
$ python -m pytest test/unit/datasets -q -p no:randomly -m "not openml"
15 passed, 25 deselected in 1.03s

$ python -m pytest test/unit/datasets -q -p no:randomly
40 passed, 4 warnings in 6.08s

$ ruff check fairlearn/datasets test/unit/datasets docs
All checks passed!

$ ruff format --check fairlearn/datasets test/unit/datasets
10 files already formatted

$ git diff --check dd4b1ed2c13206041527e0dbb8f59de282af6e79
(no output)
```

The same directory at the merge base, in a detached worktree:

```
$ python -m pytest test/unit/datasets -q -p no:randomly -m "not openml"
1 passed, 25 deselected in 0.67s

$ python -m pytest test/unit/datasets -q -p no:randomly
26 passed, 4 warnings in 14.85s
```

40 - 26 = 14, exactly the new case count; no pre-existing case changed state.

### Revert proof

There is no defect to revert to — this is a behaviour change, so "the bug reappears" is not
the right frame. What can be shown is that every new test fails against the merge-base
loaders. Keeping the new tests and restoring only the source:

```
$ git checkout dd4b1ed2c13206041527e0dbb8f59de282af6e79 -- fairlearn/datasets
$ python -m pytest test/unit/datasets -q -p no:randomly -m "not openml"
14 failed, 1 passed, 25 deselected in 0.60s
```

All 14 new cases fail; the 1 that passes is the pre-existing network-free test. Restoring
the source: `15 passed, 25 deselected`.

The eight `test_dataset_loader_refuses_to_rename_a_record_of_unexpected_width` cases are
worth calling out separately: they exercise code that does not exist at the merge base at
all. At the merge base a 3-column record is passed through and relabelled with no
complaint; the guard is what makes the positional assumption fail loudly instead.

## Documentation

- [ ] no documentation changes needed
- [x] user guide added or updated
- [x] API docs added or updated
- [ ] example notebook added or updated

"API docs added or updated": both `feature_names` docstring entries now list the
authoritative names, both `categories` entries state that their keys use the same names,
and both carry a `.. versionchanged:: 0.15.0` directive.

"user guide added or updated" is ticked only because the release note lives under
`docs/user_guide/` — one entry in
`docs/user_guide/installation_and_version_guide/v0.15.0.rst`, under **Other improvements**,
opening with **Behaviour change.** No prose user-guide page was edited; none of them uses
these two loaders.

The changelog entry ends `by :user:`breken-ai`` with no `:pr:` role, because the PR number
does not exist until this PR is opened. Tell me the number and I will add it in the same
format as the surrounding entries.

## What was not verified

* **No cold OpenML download.** My `~/.fairlearn-data` was already populated, so the
  `openml`-marked tests and the live checks above read records that were already cached
  locally. I did not confirm that those cached records match what OpenML serves today.
* **Not a full column-by-column diff against the UCI source CSVs.** The positional mapping
  was spot-checked by eye on row 0 of each dataset plus a few range and domain checks, as
  described above.
* **The real-data CI job is non-blocking on PRs.** `.github/workflows/openml.yml:25` sets
  `continue-on-error: ${{ github.event_name == 'pull_request' }}`, so on a pull request the
  only tests that actually gate this change are the 14 mocked ones. A mocked test cannot
  detect a real-record mismatch. This is worth knowing when weighing trade-off 1.
* **Only `test/unit/datasets` was run**, not the full `test/unit` suite.
* **One environment only**: Python 3.12.12 on macOS with the versions pinned above. No
  `requirements-min.txt` run, and no other Python version.
* **No coverage report.** `codecov` is an explicit CI gate per `code_style.rst`;
  `coverage.py` and `pytest-cov` are not installed in my virtualenv.
* **No Sphinx docs build**, so the new `.. versionchanged::` directives and the release-note
  entry are unrendered — I checked their markup by eye against surrounding entries only.
* **The other dataset loaders were not touched or audited.** Only `fetch_bank_marketing`
  and `fetch_credit_card` are in scope here; I did not check whether any other loader has
  the same placeholder-name situation.

## Screenshots

Not applicable — no visualization or website changes.

